### PR TITLE
Changed method for installing dependencies to rather use update than …

### DIFF
--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -79,15 +79,17 @@ Function Install-PrereqModule {
                         $install_params.SkipPublisherCheck = $true
                     }
 
-                    Install-Module @install_params > $null
+                    $moduleInstalled = Get-InstalledModule -Name $install_params.Name -MinimumVersion $install_params.MinimumVersion -ErrorAction Ignore
 
-                    if ( $Name -eq 'PowerShellGet' ) {
-                        # An order has to be reverted due to dependency
-                        Remove-Module -Name PowerShellGet, PackageManagement -Force
-                        Import-Module -Name PowerShellGet, PackageManagement -Force
+                    if($null -ne $moduleInstalled) {
+                        Install-Module @install_params > $null
+                    }
+                    else {
+                        Update-Module @install_params > null
                     }
 
                     $result.changed = $true
+
                 }
                 catch [ System.Exception ] {
                     $ErrorMessage = "Problems adding a prerequisite module $Name $($_.Exception.Message)"

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -85,7 +85,7 @@ Function Install-PrereqModule {
                         Install-Module @install_params > $null
                     }
                     else {
-                        Update-Module @install_params > null
+                        Update-Module @install_params > $null
                     }
 
                     $result.changed = $true


### PR DESCRIPTION
_From @ChrisRo89 on Oct 22, 2019 21:06_

Changed method to avoid errors, because Remove doesn't work.

Changed #63780 in a different way, without using AllowClobber; which is better.

##### ISSUE TYPE
- Bugfix Pull Request


_Copied from original issue: ansible/ansible#63820_