### PR TITLE
Add Windows firewall profile manager module

### DIFF
--- a/plugins/modules/win_firewall_profile.ps1
+++ b/plugins/modules/win_firewall_profile.ps1
@@ -9,7 +9,7 @@
 # Specs and init
 $spec = @{
     options = @{
-        profiles = @{ type = "list"; choices = "Domain", "Private", "Public"; default = @( "Domain", "Private", "Public" ); aliases = @( "profile" ) }
+        profiles = @{ type = "list"; elements = "str"; choices = "Domain", "Private", "Public"; default = @( "Domain", "Private", "Public" ); aliases = @( "profile" ) }
         enabled = @{ type = "str"; choices = "True", "False", "NotConfigured" }
         default_inbound_action = @{ type = "str"; choices = "NotConfigured", "Allow", "Block"; aliases = @( "inbound" ) }
         default_outbound_action = @{ type = "str"; choices = "NotConfigured", "Allow", "Block"; aliases = @( "outbound" ) }

--- a/plugins/modules/win_firewall_profile.ps1
+++ b/plugins/modules/win_firewall_profile.ps1
@@ -1,0 +1,118 @@
+#!powershell
+
+# Copyright : (c) 2019, Simon Lecoq <simon.lecoq@live.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#Requires -Module Ansible.ModuleUtils.CamelConversion
+
+# Specs and init
+$spec = @{
+    options = @{
+        profiles = @{ type = "list"; choices = "Domain", "Private", "Public"; default = @( "Domain", "Private", "Public" ); aliases = @( "profile" ) }
+        enabled = @{ type = "str"; choices = "True", "False", "NotConfigured" }
+        default_inbound_action = @{ type = "str"; choices = "NotConfigured", "Allow", "Block"; aliases = @( "inbound" ) }
+        default_outbound_action = @{ type = "str"; choices = "NotConfigured", "Allow", "Block"; aliases = @( "outbound" ) }
+        log_file_name = @{ type = "path"; aliases = @( "log_file" ) }
+        log_max_size_kilobytes = @{ type = "int"; aliases = @( "log_max_size" ) }
+        log_allowed = @{ type = "str"; choices = "True", "False", "NotConfigured" }
+        log_blocked = @{ type = "str"; choices = "True", "False", "NotConfigured" }
+        log_ignored = @{ type = "str"; choices = "True", "False", "NotConfigured" }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module.Diff.before = @{}
+$module.Diff.after = @{}
+$check_mode = $module.CheckMode
+$supported_options_list = @("Enabled", "DefaultInBoundAction", "DefaultOutBoundAction", "LogFileName", "LogMaxSizeKilobytes", "LogAllowed", "LogBlocked", "LogIgnored")
+
+# Check that required cmdlets are available
+try {
+    Get-Command Get-NetFirewallProfile | Out-Null
+    Get-Command Set-NetFirewallProfile | Out-Null
+}
+catch {
+    $module.FailJson("This Powershell version does not support the following required cmdlets : Get-NetfirewallProfile and Set-NetFirewallProfile.")
+}
+
+# Params init
+$profiles = $module.Params.profiles
+$enabled = $module.Params.enabled
+$default_inbound_action = $module.Params.default_inbound_action
+$default_outbound_action = $module.Params.default_outbound_action
+$log_file_name = $module.Params.log_file_name
+$log_max_size_kilobytes = $module.Params.log_max_size_kilobytes
+$log_allowed = $module.Params.log_allowed
+$log_blocked = $module.Params.log_blocked
+$log_ignored = $module.Params.log_ignored
+
+# Process
+foreach ($profile in $profiles) {
+
+    # Get settings for current profile
+    $current_state = @{}
+    $current_state_object = (Get-NetFirewallProfile -Name $profile | Select-Object -Property $supported_options_list)
+    $current_state_object.psobject.properties | ForEach-Object { $current_state[$_.Name] = $_.value.toString() }
+    $current_state = Convert-DictToSnakeCase($current_state)
+    $current_state.log_max_size_kilobytes = [int]$current_state.log_max_size_kilobytes
+    $module.Result.$profile = $current_state
+    $module.Result.$profile.changed = $false
+    $module.Diff.before.$profile = $module.Result.$profile
+
+    # Apply editions
+    if (($null -ne $enabled) -and ($enabled -ne $current_state.enabled)) {
+        Set-NetFirewallProfile -Name $profile -Enabled $enabled -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.enabled = $enabled
+    }
+
+    if (($null -ne $default_inbound_action) -and ($default_inbound_action -ne $current_state.default_inbound_action)) {
+        Set-NetFirewallProfile -Name $profile -DefaultInboundAction $default_inbound_action -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.default_inbound_action = $default_inbound_action
+    }
+
+    if (($null -ne $default_outbound_action) -and ($default_outbound_action -ne $current_state.default_outbound_action)) {
+        Set-NetFirewallProfile -Name $profile -DefaultOutboundAction $default_outbound_action -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.default_outbound_action = $default_outbound_action
+    }
+
+    if (($null -ne $log_file_name) -and ($log_file_name -ne $current_state.log_file_name)) {
+        Set-NetFirewallProfile -Name $profile -LogFileName $log_file_name -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.log_file_name = $log_file_name
+    }
+
+    if (($null -ne $log_max_size_kilobytes) -and ($log_max_size_kilobytes -ne $current_state.log_max_size_kilobytes)) {
+        Set-NetFirewallProfile -Name $profile -LogMaxSizeKilobytes $log_max_size_kilobytes -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.log_max_size_kilobytes = $log_max_size_kilobytes
+    }
+
+    if (($null -ne $log_allowed) -and ($log_allowed -ne $current_state.log_allowed)) {
+        Set-NetFirewallProfile -Name $profile -LogAllowed $log_allowed -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.log_allowed = $log_allowed
+    }
+
+    if (($null -ne $log_blocked) -and ($log_blocked -ne $current_state.log_blocked)) {
+        Set-NetFirewallProfile -Name $profile -LogBlocked $log_blocked -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.log_blocked = $log_blocked
+    }
+
+    if (($null -ne $log_ignored) -and ($log_ignored -ne $current_state.log_ignored)) {
+        Set-NetFirewallProfile -Name $profile -LogIgnored $log_ignored -WhatIf:$check_mode
+        $module.Result.$profile.changed = $true
+        $module.Result.$profile.log_ignored = $log_ignored
+    }
+
+    # Update results
+    $module.Result.changed = $module.Result.changed -or $module.Result.$profile.changed
+    $module.Diff.after.$profile = $module.Result.$profile
+
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_firewall_profile.py
+++ b/plugins/modules/win_firewall_profile.py
@@ -16,7 +16,7 @@ module: win_firewall_profile
 version_added: "2.10"
 short_description: Windows firewall profile default action automation
 description:
-  - Allows you to update settings for Windows firewall profiles default action.
+  - Allows you to update settings for Windows firewall profiles default actions.
 options:
   profiles:
     description:

--- a/plugins/modules/win_firewall_profile.py
+++ b/plugins/modules/win_firewall_profile.py
@@ -22,7 +22,7 @@ options:
     description:
       - The profiles which need to be configured.
     type: list
-    choices: [ Domain, Private, Public ]
+    elements: [ Domain, Private, Public ]
     default: [ Domain, Private, Public ]
     aliases:
       - profile

--- a/plugins/modules/win_firewall_profile.py
+++ b/plugins/modules/win_firewall_profile.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Simon Lecoq <simon.lecoq@live.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: win_firewall_profile
+version_added: "2.10"
+short_description: Windows firewall profile default action automation
+description:
+  - Allows you to update settings for Windows firewall profiles default action.
+options:
+  profiles:
+    description:
+      - The profiles which need to be configured.
+    type: list
+    choices: [ Domain, Private, Public ]
+    default: [ Domain, Private, Public ]
+    aliases:
+      - profile
+  enabled:
+    description:
+      - Enabled or disable given profiles.
+    type: str
+    choices: [ True, False, NotConfigured ]
+  default_inbound_action:
+    description:
+      - Default inbound action for given profiles.
+    type: str
+    choices: [ Allow, Block, NotConfigured ]
+    aliases:
+      - inbound
+  default_outbound_action:
+    description:
+      - Default outbound action for given profiles.
+    type: str
+    choices: [ Allow, Block, NotConfigured ]
+    aliases:
+      - outbound
+  log_file_name:
+    description:
+      - Specifies the path and filename of the file to which Windows writes log entries.
+    type: path
+    aliases:
+      - log_file
+  log_max_size_kilobytes:
+    description:
+      - Specifies the maximum file size of the log, in kilobytes (the acceptable values for this parameter are 1 through 32767).
+    type: int
+    aliases:
+      - log_max_size
+  log_allowed:
+    description:
+      - Specifies how to log the allowed packets.
+    type: str
+    choices: [ True, False, NotConfigured ]
+  log_blocked:
+    description:
+      - Specifies how to log the dropped packets.
+    type: str
+    choices: [ True, False, NotConfigured ]
+  log_ignored:
+    description:
+      - Specifies how to log the ignored packets.
+    type: str
+    choices: [ True, False, NotConfigured ]
+seealso:
+  - module: win_firewall_rule
+  - module: win_firewall
+author:
+  - Simon Lecoq (@lowlighter)
+'''
+
+EXAMPLES = r'''
+- name: Block inbound and outbound connections by default for Domain, Private and Public profiles
+  win_firewall_profile:
+    inbound: Block
+    outbound: Block
+    profiles:
+      - Domain
+      - Private
+      - Public
+
+- name: Reset inbound and outbound default action to Group policy for all profiles
+  win_firewall_profile:
+    inbound: NotConfigured
+    outbound: NotConfigured
+
+- name: Configure logs for all profiles (log blocked and ignored packets and set custom path for log)
+  win_firewall_profile:
+    log_file_name: "C:/path/to/firewall.log"
+    log_allowed: False
+    log_blocked: True
+    log_ignored: True
+    log_max_size: 2048
+
+- name: Retrieve current profile configuration for Private and Public profiles
+  win_firewall_profile:
+  profiles:
+    - Private
+    - Public
+  register: win_firewall_profiles_current_settings
+
+- name: Enable all profiles
+  win_firewall_profile:
+    enabled: True
+'''
+
+RETURN = r'''
+changed:
+  description: Tell if one of given profile settings has changed.
+  returned: always
+  type: bool
+
+profile:
+  description: Contains current profile settings.
+  returned: For each given profile
+  type: complex
+  contains:
+    changed:
+      description: Profile has changed.
+      type: bool
+    enabled:
+      description: Enabled status.
+      type: str
+    default_inbound_action:
+      description: Default inbound action.
+      type: str
+    default_outbound_action:
+      description: Default outbound action.
+      type: str
+    log_file_name:
+      description: Path and filename of the file to which Windows writes log entries.
+      type: str
+    log_max_size_kilobytes:
+      description: Maximum file size of the log, in kilobytes.
+      type: int
+    log_allowed:
+      description: Specifies how the allowed packets are logged.
+      type: str
+    log_blocked:
+      description: Specifies how the dropped packets are logged.
+      type: str
+    log_ignored:
+      description: Specifies how the ignored packets are logged.
+      type: str
+'''

--- a/plugins/modules/win_firewall_profile.py
+++ b/plugins/modules/win_firewall_profile.py
@@ -22,8 +22,7 @@ options:
     description:
       - The profiles which need to be configured.
     type: list
-    elements: str
-    choices: [ Domain, Private, Public ]
+    elements: [ Domain, Private, Public ]
     default: [ Domain, Private, Public ]
     aliases:
       - profile

--- a/plugins/modules/win_firewall_profile.py
+++ b/plugins/modules/win_firewall_profile.py
@@ -22,7 +22,8 @@ options:
     description:
       - The profiles which need to be configured.
     type: list
-    elements: [ Domain, Private, Public ]
+    elements: str
+    choices: [ Domain, Private, Public ]
     default: [ Domain, Private, Public ]
     aliases:
       - profile

--- a/tests/integration/targets/win_firewall_profile/aliases
+++ b/tests/integration/targets/win_firewall_profile/aliases
@@ -1,0 +1,3 @@
+shippable/windows/group4
+skip/windows/2008
+skip/windows/2008-R2

--- a/tests/integration/targets/win_firewall_profile/tasks/main.yml
+++ b/tests/integration/targets/win_firewall_profile/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Backup current firewall configuration
+  win_firewall_profile:
+  register: win_firewall_profile_backup
+
 - name: Reset potentially leftovers profiles configuration
   win_firewall_profile:
     enabled: False
@@ -124,3 +128,16 @@
     - win_firewall_profile_again.Public.log_allowed == 'True'
     - win_firewall_profile_again.Public.log_blocked == 'True'
     - win_firewall_profile_again.Public.log_ignored == 'True'
+
+- name: Restore previous firewall configuration
+  win_firewall_profile:
+    enabled: "{{ item.value.enabled }}"
+    inbound: "{{ item.value.default_inbound_action }}"
+    outbound: "{{ item.value.default_outbound_action }}"
+    log_file: "{{ item.value.log_file_name }}"
+    log_max_size: "{{ item.value.log_max_size_kilobytes }}"
+    log_allowed: "{{ item.value.log_allowed }}"
+    log_blocked: "{{ item.value.log_blocked }}"
+    log_ignored: "{{ item.value.log_ignored }}"
+    profile: "{{ item.key }}"
+  loop: "{{ { 'Public': win_firewall_profile_backup.Public, 'Private': win_firewall_profile_backup.Private, 'Domain': win_firewall_profile_backup.Domain } | dict2items }}"

--- a/tests/integration/targets/win_firewall_profile/tasks/main.yml
+++ b/tests/integration/targets/win_firewall_profile/tasks/main.yml
@@ -1,0 +1,126 @@
+- name: Reset potentially leftovers profiles configuration
+  win_firewall_profile:
+    enabled: False
+    inbound: NotConfigured
+    outbound: NotConfigured
+    log_file_name: "C:\\Windows\\system32\\logfiles\\firewall\\pfirewall.log"
+    log_max_size_kilobytes: 4096
+    log_allowed: NotConfigured
+    log_blocked: NotConfigured
+    log_ignored: NotConfigured
+
+- name: Update profile (check mode)
+  win_firewall_profile:
+    enabled: True
+    inbound: Block
+    outbound: Block
+    log_file: "C:\\myfirewall.log"
+    log_max_size: 8192
+    log_allowed: True
+    log_blocked: True
+    log_ignored: True
+    profile: Public
+  register: win_firewall_profile_check
+  check_mode: yes
+
+- name: Register effects of update profile (check mode)
+  win_firewall_profile:
+    profile: Public
+  register: win_firewall_profile_check_effects
+
+- name: Assert result of update profile (check mode)
+  assert:
+    that: 
+    - win_firewall_profile_check is changed
+    - win_firewall_profile_check.Public.changed
+    - win_firewall_profile_check.Private is not defined
+    - win_firewall_profile_check.Domain is not defined
+    - win_firewall_profile_check.Public.enabled == 'True'
+    - win_firewall_profile_check.Public.default_inbound_action == 'Block'
+    - win_firewall_profile_check.Public.default_outbound_action == 'Block'
+    - win_firewall_profile_check.Public.log_file_name == 'C:\myfirewall.log'
+    - win_firewall_profile_check.Public.log_max_size_kilobytes == 8192
+    - win_firewall_profile_check.Public.log_allowed == 'True'
+    - win_firewall_profile_check.Public.log_blocked == 'True'
+    - win_firewall_profile_check.Public.log_ignored == 'True'
+    - not win_firewall_profile_check_effects is changed
+    - not win_firewall_profile_check_effects.Public.changed
+    - win_firewall_profile_check_effects.Public.enabled == 'False'
+    - win_firewall_profile_check_effects.Public.default_inbound_action == 'NotConfigured'
+    - win_firewall_profile_check_effects.Public.default_outbound_action == 'NotConfigured'
+    - win_firewall_profile_check_effects.Public.log_file_name == "C:\\Windows\\system32\\logfiles\\firewall\\pfirewall.log"
+    - win_firewall_profile_check_effects.Public.log_max_size_kilobytes == 4096
+    - win_firewall_profile_check_effects.Public.log_allowed == 'NotConfigured'
+    - win_firewall_profile_check_effects.Public.log_blocked == 'NotConfigured'
+    - win_firewall_profile_check_effects.Public.log_ignored == 'NotConfigured'
+
+- name: Update profile
+  win_firewall_profile:
+    enabled: True
+    inbound: Block
+    outbound: Block
+    log_file: "C:\\myfirewall.log"
+    log_max_size: 8192
+    log_allowed: True
+    log_blocked: True
+    log_ignored: True
+    profile: Public
+  register: win_firewall_profile
+
+- name: Register effects of update profile
+  win_firewall_profile:
+    profile: Public
+  register: win_firewall_profile_effects
+
+- name: Assert result of update profile
+  assert:
+    that: 
+    - win_firewall_profile is changed
+    - win_firewall_profile.Public.changed
+    - win_firewall_profile.Private is not defined
+    - win_firewall_profile.Domain is not defined
+    - win_firewall_profile.Public.enabled == 'True'
+    - win_firewall_profile.Public.default_inbound_action == 'Block'
+    - win_firewall_profile.Public.default_outbound_action == 'Block'
+    - win_firewall_profile.Public.log_file_name == 'C:\myfirewall.log'
+    - win_firewall_profile.Public.log_max_size_kilobytes == 8192
+    - win_firewall_profile.Public.log_allowed == 'True'
+    - win_firewall_profile.Public.log_blocked == 'True'
+    - win_firewall_profile.Public.log_ignored == 'True'
+    - not win_firewall_profile_effects is changed
+    - not win_firewall_profile_effects.Public.changed
+    - win_firewall_profile_effects.Public.enabled == 'True'
+    - win_firewall_profile_effects.Public.default_inbound_action == 'Block'
+    - win_firewall_profile_effects.Public.default_outbound_action == 'Block'
+    - win_firewall_profile_effects.Public.log_file_name == 'C:\myfirewall.log'
+    - win_firewall_profile_effects.Public.log_max_size_kilobytes == 8192
+    - win_firewall_profile_effects.Public.log_allowed == 'True'
+    - win_firewall_profile_effects.Public.log_blocked == 'True'
+    - win_firewall_profile_effects.Public.log_ignored == 'True'
+
+- name: Update profile (idempotent)
+  win_firewall_profile:
+    enabled: True
+    inbound: Block
+    outbound: Block
+    log_file: "C:\\myfirewall.log"
+    log_max_size: 8192
+    log_allowed: True
+    log_blocked: True
+    log_ignored: True
+    profile: Public
+  register: win_firewall_profile_again
+
+- name: Assert result of update profile (idempotent)
+  assert:
+    that: 
+    - not win_firewall_profile_again is changed
+    - not win_firewall_profile_again.Public.changed
+    - win_firewall_profile_again.Public.enabled == 'True'
+    - win_firewall_profile_again.Public.default_inbound_action == 'Block'
+    - win_firewall_profile_again.Public.default_outbound_action == 'Block'
+    - win_firewall_profile_again.Public.log_file_name == 'C:\myfirewall.log'
+    - win_firewall_profile_again.Public.log_max_size_kilobytes == 8192
+    - win_firewall_profile_again.Public.log_allowed == 'True'
+    - win_firewall_profile_again.Public.log_blocked == 'True'
+    - win_firewall_profile_again.Public.log_ignored == 'True'


### PR DESCRIPTION
_From @lowlighter on Nov 12, 2019 16:41_

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, modules `win_firewall` and `win_firewall_rule` allows to manage Windows firewall through Ansible. However, it is not yet possible to set a default action for inbound/outbound connections (special rules which are triggered when no other rules for a given profile matched*) and to configure the logging of allowed/blocked/ignored packets.

\**As Windows firewall rules aren't really ordered, rules likes *block all unwanted connections* cannot be applied by creating rules with `win_firewall_rule`*

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`win_firewall_profile`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Current behavior :
```yaml
- name: Block unwanted inbound connections for Domain and Private profiles
  win_shell: Set-NetFirewallProfile -name Public,Domain,Private -DefaultInBoundAction Block -DefaultOutboundAction Block -LogFileName C:\path\to\logs\firewall.log -LogAllowed False -LogIgnored False -LogBlocked True -LogMaxSizeKilobytes 8192
```
Proposed behavior : 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Block unwanted inbound and outbound connections for Public, Domain and Private profiles and configure logging
  win_firewall_profile:
    inbound: Block
    outbound: Block
    log_file: 'C:\path\to\logs\firewall.log'
    log_allowed: False
    log_ignored: False
    log_blocked: True
    log_max_size: 8192 
    profiles:
      - Public
      - Domain
      - Private

- name: Retrieve current configuration of Public profile
  win_firewall_profile:
    profile: Public
  register: win_firewall_profile_public
```

_Copied from original issue: ansible/ansible#64743_