### PR TITLE
Fix win_xml error: The property hostName cannot be found on this obje…

### DIFF
--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -227,10 +227,10 @@ if ($type -eq "element") {
                     $changed = $true
                 }
             } else { # assume NodeType is Element
+                if (!$node.HasAttribute($attribute)) { # add attribute to Element if missing
+                    $node.SetAttributeNode($attribute, $xmlorig.get_DocumentElement().get_NamespaceURI())
+                }
                 if ($node.$attribute -ne $fragment) {
-                    if (!$node.HasAttribute($attribute)) { # add attribute to Element if missing
-                        $node.SetAttributeNode($attribute, $xmlorig.get_DocumentElement().get_NamespaceURI())
-                    }
                     #set the attribute into the element
                     $node.SetAttribute($attribute, $fragment)
                     $changed = $true


### PR DESCRIPTION
_From @Sephtex on Dec 26, 2019 15:46_

…ct. Verify that the property exists.

##### SUMMARY
Fix: Attribute is added in the if testing for its existence.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_xml

##### ADDITIONAL INFORMATION
Original Ansible error:
```
The property 'hostName' cannot be found on this object. Verify that the property exists.
At line:230 char:21
+                 if ($node.$attribute -ne $fragment) {
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : PropertyNotFoundStrict

ScriptStackTrace:
at <ScriptBlock>, <No file>: line 230

fatal: [HOSTNAME]: FAILED! => changed=false
  msg: 'Unhandled exception while executing module: The property ''hostName'' cannot be found on this object. Verify that the property exists.'
```
Module execution task
```
- name: "win_xml | add hostName key-value for initializationPage in web.config"
  win_xml:
    path: "{{ applications_path }}\\{{ site.name }}\\web.config"
    xpath: /configuration/system.webServer/applicationInitialization/add
    type: attribute
    attribute: hostName
    fragment: "{{ site.binding.fqdn }}"
```
After making this small change, the error disappeared and the expected attribute was added to the xml-file.

After a few tests, changing win_xml.attribute to another value, added the attibute inside of the xml file.


_Copied from original issue: ansible/ansible#66081_