### PR TITLE
Add Extra Information for IIS parameters.

### DIFF
--- a/plugins/modules/win_iis_website.py
+++ b/plugins/modules/win_iis_website.py
@@ -58,6 +58,11 @@ options:
   parameters:
     description:
       - Custom site Parameters from string where properties are separated by a pipe and property name/values by colon Ex. "foo:1|bar:2"
+      - IIS Custom Parameters:
+          - logfile.directory - Physical Path to store Logs (ex: D:\IIS-LOGs\)
+          - logfile.period - Log File Rollover Schedule accepting these values: Hourly | Dialy | Weekly | Montly. How frequently the log file should be rolled-over.
+          - logfile.LogFormat - Log File format, by default IIS uses w3C
+          - logFile.truncateSize -  the size at which the log file contents will be truncated expressed in bytes (20971520 bytes = 20 megabytes)
     type: str
 seealso:
 - module: win_iis_virtualdirectory
@@ -89,6 +94,23 @@ EXAMPLES = r'''
   win_iis_website:
     name: "Default Web Site"
     state: absent
+
+# Create a WebSite with custom Logging configuration (Logs Location, Format and Rolling Over).
+
+- name: Creating WebSite with Custom Log location, Format 3WC and rolling over every hour.
+      win_iis_website:
+       name: "MyCustom_Web_Shop_Site"
+       state: started
+       port: 80
+       ip: '*'
+       hostname: '*'
+       physical_path: D:\wwwroot\websites\my-shop-site
+       parameters: logfile.directory:D:\IIS-LOGS\websites\my-shop-site|logfile.period:Hourly|logFile.logFormat:W3C
+       application_pool: my-shop-site
+      register: dsc_state_is
+    - debug: var=dsc_state_is
+
+
 
 # Some commandline examples:
 

--- a/plugins/modules/win_iis_website.py
+++ b/plugins/modules/win_iis_website.py
@@ -58,11 +58,12 @@ options:
   parameters:
     description:
       - Custom site Parameters from string where properties are separated by a pipe and property name/values by colon Ex. "foo:1|bar:2"
-      - IIS Custom Parameters:
-          - logfile.directory - Physical Path to store Logs (ex: D:\IIS-LOGs\)
-          - logfile.period - Log File Rollover Schedule accepting these values: Hourly | Dialy | Weekly | Montly. How frequently the log file should be rolled-over.
-          - logfile.LogFormat - Log File format, by default IIS uses w3C
-          - logFile.truncateSize -  the size at which the log file contents will be truncated expressed in bytes (20971520 bytes = 20 megabytes)
+      - Some custom parameters that you can use are listed below, this isn't a definitive list but some common parameters.
+      - C(logfile.directory) - Physical path to store Logs, e.g. C(D:\IIS-LOGs\).
+      - C(logfile.period) - Log file rollover scheduled accepting these values, how frequently the log file should be rolled-over,
+        e.g. C(Hourly, Daily, Weekly, Monthly).
+      - C(logfile.LogFormat) - Log file format, by default IIS uses C(W3C).
+      - C(logfile.truncateSize) - The size at which the log file contents will be trunsted, expressed in bytes.
     type: str
 seealso:
 - module: win_iis_virtualdirectory
@@ -98,19 +99,15 @@ EXAMPLES = r'''
 # Create a WebSite with custom Logging configuration (Logs Location, Format and Rolling Over).
 
 - name: Creating WebSite with Custom Log location, Format 3WC and rolling over every hour.
-      win_iis_website:
-       name: "MyCustom_Web_Shop_Site"
-       state: started
-       port: 80
-       ip: '*'
-       hostname: '*'
-       physical_path: D:\wwwroot\websites\my-shop-site
-       parameters: logfile.directory:D:\IIS-LOGS\websites\my-shop-site|logfile.period:Hourly|logFile.logFormat:W3C
-       application_pool: my-shop-site
-      register: dsc_state_is
-    - debug: var=dsc_state_is
-
-
+  community.windows.win_iis_website:
+    name: MyCustom_Web_Shop_Site
+    state: started
+    port: 80
+    ip: '*'
+    hostname: '*'
+    physical_path: D:\wwwroot\websites\my-shop-site
+    parameters: logfile.directory:D:\IIS-LOGS\websites\my-shop-site|logfile.period:Hourly|logFile.logFormat:W3C
+    application_pool: my-shop-site
 
 # Some commandline examples:
 


### PR DESCRIPTION
_From @jorgeemir29 on Dec 30, 2019 12:50_

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When configuring a website with custom site parameters, for people who are not familiar with PowerShell or IIS, it would be great to add in the documentation some examples to show them how to use these parameters.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_iis_website.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This additional information will help people when trying to create custom IIS websites.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```


_Copied from original issue: ansible/ansible#66130_