### PR TITLE
Add new module win_psscript for installing scripts from PSRepositories

### DIFF
--- a/plugins/modules/win_psscript.ps1
+++ b/plugins/modules/win_psscript.ps1
@@ -146,7 +146,8 @@ if ($state -eq 'absent') {
             if (-not $module.CheckMode) {
                 $existing.Values | Uninstall-Script -Force -ErrorAction Stop
             }
-        } catch {
+        }
+        catch {
             $module.FailJson("Error uninstalling scripts.", $_)
         }
     }
@@ -154,7 +155,8 @@ if ($state -eq 'absent') {
 else { # state is 'present' or 'latest'
     try {
         $remote = Find-Script @pFind -ErrorAction Stop
-    } catch {
+    }
+    catch {
         $module.FailJson("Error searching for scripts.", $_)
     }
 
@@ -175,7 +177,8 @@ else { # state is 'present' or 'latest'
         if ($toInstall -and -not $module.CheckMode) {
             $toInstall | Install-Script -Scope:$pInstall.scope -Force -ErrorAction Stop
         }
-    } catch {
+    }
+    catch {
         $module.FailJson("Error installing scripts.", $_)
     }
 }

--- a/plugins/modules/win_psscript.ps1
+++ b/plugins/modules/win_psscript.ps1
@@ -1,0 +1,179 @@
+#!powershell
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#Requires -Module @{ ModuleName = 'PowerShellGet' ; ModuleVersion = '1.6.0' }
+
+$spec = @{
+    supports_check_mode = $true
+    options = @{
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        repository = @{ type = 'str' }
+        scope = @{
+            type = 'str'
+            choices = @('all_users', 'current_user')
+            default = 'all_users'
+        }
+        state = @{
+            type = 'str'
+            choices = @('present', 'absent', 'latest')
+            default = 'present'
+        }
+        required_version = @{ type = 'str' }
+        minimum_version = @{ type = 'str' }
+        maximum_version = @{ type = 'str' }
+        source_username = @{ type = 'str' }
+        source_password = @{
+            type = 'str'
+            no_log = $true
+        }
+        allow_prerelease = @{
+            type = 'bool'
+            default = $false
+        }
+    }
+
+    mutually_exclusive = @(
+       @('required_version', 'minimum_version'),
+       @('required_version', 'maximum_version')
+   )
+
+   required_together = @(
+       ,@('source_username', 'source_password')
+   )
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$state = $module.Params.state
+function Get-SplattableParameters {
+    [CmdletBinding(DefaultParameterSetName='All')]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory=$true)]
+        [Ansible.Basic.AnsibleModule]
+        $Module ,
+
+        [Parameter(ParameterSetName='ForCommand')]
+        [Alias('For')]
+        [String]
+        $ForCommand ,
+
+        [Parameter(ParameterSetName='WithCommand', ValueFromPipeline=$true)]
+        [Alias('Command')]
+        [System.Management.Automation.CommandInfo]
+        $WithCommand
+    )
+
+    Process {
+        $ret = @{}
+
+        $cmd = switch ($PSCmdlet.ParameterSetName) {
+            'WithCommand' { $WithCommand }
+            'ForCommand' { Get-Command -Name $ForCommand }
+        }
+
+        if ($cmd) {
+            $commons = [System.Management.Automation.Cmdlet]::CommonParameters + [System.Management.Automation.Cmdlet]::CommonOptionalParameters
+            $validParams = $cmd.Parameters.GetEnumerator() | ForEach-Object -Process {
+                if ($commons -notcontains $_.Key) {
+                    $_.Key
+                }
+            }
+        }
+
+        switch -Wildcard ($Module.Params.Keys) {
+            '*' {
+                $value = $Module.Params[$_]
+                if ($null -eq $value) {
+                    continue
+                }
+
+                $key = $_.Replace('_', '')
+                if ($validParams -and $validParams -notcontains $key) {
+                    continue
+                }
+            }
+
+            'scope' { $value = $value.Replace('_', '') }
+            'source_username' { continue } # handled in password block
+            'source_password' {
+                $key = 'Credential'
+                $secure = ConvertTo-SecureString -String $value -AsPlainText -Force
+                $value = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Module.Params.source_username,$secure
+            }
+            '*_version' {
+                if ($Module.Params.state -eq 'latest') {
+                    $Module.FailJson("version options can't be used with 'state': 'latest'")
+                }
+            }
+            'repository' {
+                if ($Module.Params.state -eq 'absent') {
+                    $Module.FailJson("'repository' is not valid with 'state': 'absent'")
+                }
+            }
+
+            '*' { $ret[$key] = $value }
+        }
+
+        $ret
+    }
+}
+
+$pGet,$pUninstall,$pFind,$pInstall = Get-Command -Name @(
+     'Get-InstalledScript'
+    ,'Uninstall-Script'
+    ,'Find-Script'
+    ,'Install-Script'
+) | Get-SplattableParameters -Module $module
+
+$existing = Get-InstalledScript @pGet -ErrorAction SilentlyContinue
+$existing = if ($existing) {
+    $existing | Group-Object -Property Name -AsHashTable -AsString
+}
+else {
+    @{}
+}
+
+if ($state -eq 'absent') {
+    if ($existing.Count) {
+        try {
+            $module.Result.changed = $true
+            $existing.Values | Uninstall-Script -Force -WhatIf:$module.CheckMode -ErrorAction Stop
+        } catch {
+            $module.FailJson("Error uninstalling scripts.", $_)
+        }
+    }
+}
+else { # state is 'present' or 'latest'
+    try {
+        $remote = Find-Script @pFind -ErrorAction Stop
+    } catch {
+        $module.FailJson("Error searching for scripts.", $_)
+    }
+
+    try {
+        $toInstall = $remote | Where-Object -FilterScript {
+            $install = -not $existing.ContainsKey($_.Name) -or (
+                $state -eq 'latest' -and
+                ($_.Version -as [version]) -gt ($existing[$_.Name].Version -as [version])
+            )
+            $module.Result.changed = $module.Result.changed -or $install
+            $install
+        }
+
+        if (($toInstall | Group-Object -Property Name -NoElement | Where-Object -Property Count -gt 1)) {
+            $module.FailJson("Multiple scripts found. Please choose a specific repository.")
+        }
+
+        $toInstall | Install-Script -Scope:$pInstall.scope -Force -WhatIf:$module.CheckMode -ErrorAction Stop
+    } catch {
+        $module.FailJson("Error installing scripts.", $_)
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_psscript.py
+++ b/plugins/modules/win_psscript.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_psscript
+version_added: '2.10'
+short_description: Install and manage PowerShell scripts from a PSRepository
+description:
+  - Add or remove PowerShell scripts from registered PSRepositories.
+options:
+  name:
+    description:
+      - The name of the script you want to install or remove.
+    type: str
+    required: True
+  repository:
+    description:
+      - The registered name of the repository you want to install from.
+      - Cannot be used when I(state=absent).
+      - If ommitted, all repositories will be searched.
+      - To register a repository, use M(win_psrepository).
+    type: str
+  scope:
+    description:
+      - Determines whether the script is installed for only the C(current_user) or for C(all_users).
+    type: str
+    choices:
+      - current_user
+      - all_users
+    default: all_users
+  state:
+    description:
+      - The desired state of the script. C(absent) removes the script.
+      - C(latest) will ensure the most recent version available is installed.
+      - C(present) only installs if the script is missing.
+    type: str
+    choices:
+      - present
+      - absent
+      - latest
+    default: present
+  required_version:
+    description:
+      - The exact version of the script to install.
+      - Cannot be used with I(minimum_version) or I(maximum_version).
+      - Cannot be used when I(state=latest).
+    type: str
+  minimum_version:
+    description:
+      - The minimum version of the script to install.
+      - Cannot be used when I(state=latest).
+    type: str
+  maximum_version:
+    description:
+      - The maximum version of the script to install.
+      - Cannot be used when I(state=latest).
+    type: str
+  allow_prerelease:
+    description:
+      - If C(yes) installs scripts flagged as prereleases.
+    type: bool
+    default: no
+  source_username:
+    description:
+      - The username portion of the credential required to access the repository.
+      - Must be used together with I(source_password).
+    type: str
+  source_password:
+    description:
+      - The password portion of the credential required to access the repository.
+      - Must be used together with I(source_username).
+    type: str
+requirements:
+  - C(PowerShellGet) module v1.6.0+
+seealso:
+  - module: win_psrepository
+  - module: win_psrepository_info
+  - module: win_psmodule
+notes:
+  - Unlike PowerShell modules, scripts do not support side-by-side installations of multiple versions. Installing a new version will replace the existing one.
+author:
+  - Brian Scholer (@briantist)
+'''
+
+EXAMPLES = r'''
+- name: Install a script from PSGallery
+  win_psscript:
+    name: Invoke-NeatStuff
+    repository: PSGallery
+
+- name: Find and install the latest version of a script from any repository
+  win_psscript:
+    name: Start-Utility
+    state: latest
+
+- name: Remove a script that isn't needed
+  win_psscript:
+    name: Defrag-Partition
+    state: absent
+
+- name: Install a specific version of a script for the current user
+  win_psscript:
+    name: CleanOldFiles
+    scope: current_user
+    required_version: 3.10.2
+
+- name: Install a script below a certain version
+  win_psscript:
+    name: New-FeatureEnable
+    maximum_version: 2.99.99
+
+- name: Ensure a minimum version of a script is present
+  win_psscript:
+    name: OldStandby
+    minimum_version: 3.0.0
+
+- name: Install any available version that fits a specific range
+  win_psscript:
+    name: FinickyScript
+    minimum_version: 2.5.1
+    maximum_version: 2.6.19
+'''
+
+RETURN = r'''
+'''

--- a/plugins/modules/win_psscript.py
+++ b/plugins/modules/win_psscript.py
@@ -93,12 +93,12 @@ author:
 EXAMPLES = r'''
 - name: Install a script from PSGallery
   win_psscript:
-    name: Invoke-NeatStuff
+    name: Test-RPC
     repository: PSGallery
 
 - name: Find and install the latest version of a script from any repository
   win_psscript:
-    name: Start-Utility
+    name: Get-WindowsAutoPilotInfo
     state: latest
 
 - name: Remove a script that isn't needed

--- a/plugins/modules/win_psscript.py
+++ b/plugins/modules/win_psscript.py
@@ -11,7 +11,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: win_psscript
-version_added: '2.10'
 short_description: Install and manage PowerShell scripts from a PSRepository
 description:
   - Add or remove PowerShell scripts from registered PSRepositories.

--- a/tests/integration/targets/win_psscript/aliases
+++ b/tests/integration/targets/win_psscript/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group6

--- a/tests/integration/targets/win_psscript/aliases
+++ b/tests/integration/targets/win_psscript/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group6
+shippable/windows/group2

--- a/tests/integration/targets/win_psscript/defaults/main.yml
+++ b/tests/integration/targets/win_psscript/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+repos:
+  - name: Repo1
+    path: '{{ remote_tmp_dir }}\Repo1'
+    policy: trusted
+    scripts:
+      - Test-One
+      - Test-Multi
+
+  - name: Repo2
+    path: '{{ remote_tmp_dir }}\Repo2'
+    policy: untrusted
+    scripts:
+      - Test-Two
+      - Test-Multi
+
+versions:
+  - 1.0.0
+  - 1.0.9
+  - 1.0.10
+  - 10.0.0
+  - 10.0.9
+  - 10.0.10
+
+earliest_version: 1.0.0
+latest_version: 10.0.10

--- a/tests/integration/targets/win_psscript/handlers/main.yml
+++ b/tests/integration/targets/win_psscript/handlers/main.yml
@@ -4,19 +4,19 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: Clear Repositories
-  win_shell: |
+  ansible.windows.win_shell: |
     Get-PSRepository | Unregister-PSRepository
 
 - name: Add PSGallery
-  win_shell: |
+  ansible.windows.win_shell: |
     Register-PSRepository -Default
 
 - name: Clear Installed Scripts
-  win_shell: |
+  ansible.windows.win_shell: |
     Get-InstalledScript | Uninstall-Script -Force
 
 - name: Remove Directories
-  win_file:
+  ansible.windows.win_file:
     path: '{{ item.path }}'
     state: absent
   loop: "{{ repos }}"

--- a/tests/integration/targets/win_psscript/handlers/main.yml
+++ b/tests/integration/targets/win_psscript/handlers/main.yml
@@ -1,0 +1,22 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Clear Repositories
+  win_shell: |
+    Get-PSRepository | Unregister-PSRepository
+
+- name: Add PSGallery
+  win_shell: |
+    Register-PSRepository -Default
+
+- name: Clear Installed Scripts
+  win_shell: |
+    Get-InstalledScript | Uninstall-Script -Force
+
+- name: Remove Directories
+  win_file:
+    path: '{{ item.path }}'
+    state: absent
+  loop: "{{ repos }}"

--- a/tests/integration/targets/win_psscript/meta/main.yml
+++ b/tests/integration/targets/win_psscript/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - setup_remote_tmp_dir
+  - setup_win_psget

--- a/tests/integration/targets/win_psscript/tasks/main.yml
+++ b/tests/integration/targets/win_psscript/tasks/main.yml
@@ -1,0 +1,18 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- block:
+    - name: Setup local repositories
+      import_tasks: setup_repos.yml
+      tags:
+        - always
+        - setup
+
+    - name: Run Tests
+      import_tasks: tests.yml
+
+  always:
+    - meta: flush_handlers
+      tags: always

--- a/tests/integration/targets/win_psscript/tasks/main.yml
+++ b/tests/integration/targets/win_psscript/tasks/main.yml
@@ -3,16 +3,11 @@
 # Copyright: (c) 2020, Brian Scholer <@briantist>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- block:
-    - name: Setup local repositories
-      import_tasks: setup_repos.yml
-      tags:
-        - always
-        - setup
+- name: Setup local repositories
+  import_tasks: setup_repos.yml
+  tags:
+    - always
+    - setup
 
-    - name: Run Tests
-      import_tasks: tests.yml
-
-  always:
-    - meta: flush_handlers
-      tags: always
+- name: Run Tests
+  import_tasks: tests.yml

--- a/tests/integration/targets/win_psscript/tasks/script_info.yml
+++ b/tests/integration/targets/win_psscript/tasks/script_info.yml
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: Get installed scripts
-  win_shell: |
+  ansible.windows.win_shell: |
     $pMachine = "$env:ProgramFiles\WindowsPowerShell\Scripts"
     # 2012/2012R2 test environments seem to have blank values for some environment vars
     $userStub = 'Documents\WindowsPowerShell\Scripts'

--- a/tests/integration/targets/win_psscript/tasks/script_info.yml
+++ b/tests/integration/targets/win_psscript/tasks/script_info.yml
@@ -1,0 +1,81 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Get installed scripts
+  win_shell: |
+    $pMachine = "$env:ProgramFiles\WindowsPowerShell\Scripts"
+    # 2012/2012R2 test environments seem to have blank values for some environment vars
+    $userStub = 'Documents\WindowsPowerShell\Scripts'
+    $userBase = if ($Home) {
+        $Home
+    }
+    elseif ($env:UserProfile) {
+        $env:UserProfile
+    }
+    elseif ($env:HomeDrive -and $env:HomePath) {
+        "${env:HomeDrive}${env:HomePath}\$userStub"
+    }
+    elseif ($env:UserName) {
+        $root = if ($env:SystemDrive) {
+            $env:SystemDrive
+        }
+        elseif ($emv:HomeDrive) {
+            $env:HomeDrive
+        }
+        else {
+            'C:'
+        }
+        "${root}\Users\${env:UserName}"
+    }
+    $pUser = "${userBase}\${userStub}"
+
+    $scripts = Get-InstalledScript |
+        Select-Object Name,Version,InstalledLocation,Repository,@{
+            Name = 'current_user'
+            Expression = { $_.InstalledLocation -eq $pUser }
+        },
+        @{
+            Name = 'all_users'
+            Expression = { $_.InstalledLocation -eq $pMachine }
+        },
+        @{
+            # this is for troubleshooting tests
+            # 2012/2012R2 test environments seem to have blank values for some environment vars
+            Name = 'paths_to_compare'
+            Expression = {
+                @{
+                    pUser = $pUser
+                    pMachine = $pMachine
+                    home = $Home
+                    homedrive = $env:HOMEDRIVE
+                    homepath = $env:HOMEPATH
+                    providerhome = (Get-PSProvider -PSProvider FileSystem).Home
+                    userprofile = $env:UserProfile
+                    username = $env:UserName
+                }
+            }
+        }
+
+    if (-not $scripts) {
+        $scripts = @()
+    }
+
+    ConvertTo-Json -Depth 5 -InputObject ([object[]]$scripts)
+  register: _raw_info
+
+- name: Set script info var
+  set_fact:
+    "{{ script_info_var | default('scripts') }}": "{{
+      dict(
+        _raw_info.stdout
+        | from_json
+        | map(attribute='Name')
+        | list
+        | zip(
+          _raw_info.stdout
+          | from_json
+        )
+      )
+    }}"

--- a/tests/integration/targets/win_psscript/tasks/setup_repos.yml
+++ b/tests/integration/targets/win_psscript/tasks/setup_repos.yml
@@ -4,12 +4,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: Unregister all repositories
-  win_shell: |
+  ansible.windows.win_shell: |
     Get-PSRepository | Unregister-PSRepository
   notify: Add PSGallery
 
 - name: Create repo folders
-  win_file:
+  ansible.windows.win_file:
     path: '{{ item.path }}'
     state: directory
   loop: "{{ repos }}"
@@ -24,7 +24,7 @@
   loop: "{{ repos }}"
 
 - name: Create and Publish Scripts
-  win_shell: |
+  ansible.windows.win_shell: |
     $tmp = '{{ remote_tmp_dir }}'
 
     # it looks like Tls12 is not added during the nuget bootstrapping process

--- a/tests/integration/targets/win_psscript/tasks/setup_repos.yml
+++ b/tests/integration/targets/win_psscript/tasks/setup_repos.yml
@@ -1,0 +1,58 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Unregister all repositories
+  win_shell: |
+    Get-PSRepository | Unregister-PSRepository
+  notify: Add PSGallery
+
+- name: Create repo folders
+  win_file:
+    path: '{{ item.path }}'
+    state: directory
+  loop: "{{ repos }}"
+  notify: Remove Directories
+
+- name: Register repos
+  win_psrepository:
+    name: '{{ item.name }}'
+    source: '{{ item.path }}'
+    installation_policy: '{{ item.policy }}'
+  notify: Clear Repositories
+  loop: "{{ repos }}"
+
+- name: Create and Publish Scripts
+  win_shell: |
+    $tmp = '{{ remote_tmp_dir }}'
+
+    # it looks like Tls12 is not added during the nuget bootstrapping process
+    # hitting connection closed errors during some tests. May be related to this:
+    # https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/
+    [System.Net.ServicePointManager]::SecurityProtocol = `
+        [System.Net.ServicePointManager]::SecurityProtocol -bor
+        [System.Net.SecurityProtocolType]::SystemDefault -bor
+        [System.Net.SecurityProtocolType]::Tls11 -bor
+        [System.Net.SecurityProtocolType]::Tls12
+
+    {% for version in versions %}
+    {% for repo in repos %}
+    {% for script in repo.scripts %}
+
+      $script = '{{ script }}'
+      $repo = '{{ repo.name }}'
+      $ver = '{{ version }}'
+      $file = "${script}.ps1"
+      $out = $tmp | Join-Path -ChildPath $file
+
+    try {
+      New-ScriptFileInfo -Description $script -Version $ver -Path $out -Force
+      Publish-Script -Path $out -Repository $repo -Force
+    } finally {
+      Remove-Item -LiteralPath $out -Force -ErrorAction SilentlyContinue
+    }
+
+    {% endfor %}
+    {% endfor %}
+    {% endfor %}

--- a/tests/integration/targets/win_psscript/tasks/tests.yml
+++ b/tests/integration/targets/win_psscript/tasks/tests.yml
@@ -1,0 +1,555 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Basic Tests Script 1
+  tags:
+    - basic1
+  vars:
+    script: Test-One
+    scope: all_users
+    expected:
+      repo: Repo1
+      version: "{{ latest_version }}"
+  block:
+    - name: Install a script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - scripts | length == 0
+          - script not in scripts
+
+    - name: Install a script
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was installed
+      assert:
+        that:
+          - scripts | length == 1
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+          - scripts[script][scope]
+
+    - name: Install script again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: Basic Tests Script 2
+  tags:
+    - basic2
+  vars:
+    script: Test-Two
+    scope: current_user
+    expected:
+      repo: Repo2
+      version: "{{ latest_version }}"
+  block:
+    - name: Install a script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - scripts | length == 1
+          - script not in scripts
+
+    - name: Install a script
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was installed
+      assert:
+        that:
+          - scripts | length == 2
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+          - scripts[script][scope]
+
+    - name: Install script again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: Removal Tests Script 1
+  tags:
+    - remove1
+  vars:
+    script: Test-One
+    state: absent
+  block:
+    - name: Remove Script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was not removed (check mode)
+      assert:
+        that:
+          - scripts | length == 2
+          - script in scripts
+
+    - name: Remove Script
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was removed
+      assert:
+        that:
+          - scripts | length == 1
+          - script not in scripts
+
+    - name: Remove Script Again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: Removal Tests Script 2
+  tags:
+    - remove2
+  vars:
+    script: Test-Two
+    state: absent
+  block:
+    - name: Remove Script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was not removed (check mode)
+      assert:
+        that:
+          - scripts | length == 1
+          - script in scripts
+
+    - name: Remove Script
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was removed
+      assert:
+        that:
+          - scripts | length == 0
+          - script not in scripts
+
+    - name: Remove Script Again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: Tests for Script in Multiple Repos
+  tags:
+    - multi
+  vars:
+    script: Test-Multi
+    scope: all_users
+    expected:
+      repo: Repo2
+      version: "{{ latest_version }}"
+  block:
+    - name: Install a script from multiple repos
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+      register: result
+      failed_when: result.msg is not search('Multiple scripts found')
+
+    - name: Install a script from multiple repos by chosing one (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        repository: "{{ expected.repo }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - scripts | length == 0
+          - script not in scripts
+
+    - name: Install a script from multiple repos by chosing one
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        repository: "{{ expected.repo }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was installed
+      assert:
+        that:
+          - scripts | length == 1
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+          - scripts[script][scope]
+
+    - name: Install script again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        repository: "{{ expected.repo }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: Exact Version Tests
+  tags:
+    - exact
+  vars:
+    script: Test-Two
+    scope: current_user
+    expected:
+      repo: Repo2
+      version: "{{ earliest_version }}"
+  block:
+    - name: Install a script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        required_version: "{{ expected.version }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - script not in scripts
+
+    - name: Install a script
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        required_version: "{{ expected.version }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was installed
+      assert:
+        that:
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+          - scripts[script][scope]
+
+    - name: Install script again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        required_version: "{{ expected.version }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: Minimum / Maximum Version Tests
+  tags:
+    - minmax
+    - present
+  vars:
+    script: Test-Two
+    scope: current_user
+    minver: 1.0.1
+    maxver: 2.0.0
+    expected:
+      repo: Repo2
+      version: "1.0.10"
+  block:
+    - name: Install a script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        minimum_version: "{{ minver }}"
+        maximum_version: "{{ maxver }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - script not in scripts or scripts[script].Version is version(expected.version, '<')
+
+    - name: Install a script
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        minimum_version: "{{ minver }}"
+        maximum_version: "{{ maxver }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was installed
+      assert:
+        that:
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+          - scripts[script][scope]
+
+    - name: Install script again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        scope: "{{ scope }}"
+        minimum_version: "{{ minver }}"
+        maximum_version: "{{ maxver }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+- name: State Present Tests
+  tags:
+    - present
+  vars:
+    script: Test-Two
+    state: present
+    scope: all_users   # implied
+    curver: 1.0.10
+    expected:
+      repo: Repo2
+      version: "{{ curver }}"
+  block:
+    - name: Install present script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+
+    - name: Install present script
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is not changed
+      assert:
+        that: result is not changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was not installed
+      assert:
+        that:
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+
+- name: State Latest Tests
+  tags:
+    - latest
+  vars:
+    script: Test-Two
+    state: latest
+    scope: all_users   # implied
+    expected:
+      repo: Repo2
+      version: "10.0.10"
+  block:
+    - name: Install latest script (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is changed (check mode)
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure nothing was installed (check mode)
+      assert:
+        that:
+          - script not in scripts or scripts[script].Version is version(expected.version, '<')
+
+    - name: Install latest script
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      notify: Clear Installed Scripts
+
+    - name: Assert task is changed
+      assert:
+        that: result is changed
+
+    - import_tasks: script_info.yml
+
+    - name: Ensure script was installed
+      assert:
+        that:
+          - script in scripts
+          - scripts[script].Version is version(expected.version, '==')
+          - scripts[script].Repository == expected.repo
+          - scripts[script][scope]
+
+    - name: Install latest script again (check mode)
+      win_psscript:
+        name: "{{ script }}"
+        state: "{{ state }}"
+      register: result
+      check_mode: True
+
+    - name: Assert task is not changed (check mode)
+      assert:
+        that: result is not changed


### PR DESCRIPTION
_From @briantist on Feb 23, 2020 03:34_

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding new module `win_psscript` as a counterpart to `win_psmodule`.

Most common options and scenarios accounted for, including mix/max/required versions, add/remove and update to latest.

Includes tests.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_psscript

##### ADDITIONAL INFORMATION

##### RELATED PRs:
- #67499
- #67594
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


_Copied from original issue: ansible/ansible#67674_