### PR TITLE
Fix psrepository tests

### DIFF
--- a/tests/integration/targets/win_psrepository/defaults/main.yml
+++ b/tests/integration/targets/win_psrepository/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 repository_name: My Get
-repository_source_location:               https://www.myget.org/F/powershellgetdemo/api/v2
+repository_source_location:               https://www.nuget.org/api/v2
 repository_publish_location:              '{{ repository_source_location }}/fake/publish'
 repository_script_source_location:        '{{ repository_source_location }}/fake/script'
 repository_script_publish_location:       '{{ repository_source_location }}/fake/script/publish'

--- a/tests/integration/targets/win_psrepository_info/aliases
+++ b/tests/integration/targets/win_psrepository_info/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group3
+needs/httptester

--- a/tests/integration/targets/win_psrepository_info/defaults/main.yml
+++ b/tests/integration/targets/win_psrepository_info/defaults/main.yml
@@ -4,7 +4,7 @@ suffix: "{{ '(check mode)' if run_check_mode else '' }}"
 default_repository_name: PSGallery
 
 second_repository_name: PowerShellGetDemo
-second_repository_source_location: https://www.myget.org/F/powershellgetdemo/api/v2
+second_repository_source_location: https://www.nuget.org/api/v2
 
 third_repository_name: OtherRepo
-third_repository_source_location: http://httpbin.org/get
+third_repository_source_location: http://{{ httpbin_host }}/get

--- a/tests/integration/targets/win_psrepository_info/meta/main.yml
+++ b/tests/integration/targets/win_psrepository_info/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
+  - setup_http_tests
   - setup_win_psget


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
A public repository used in the tests seems to have been deleted:
https://app.shippable.com/github/ansible-collections/community.windows/runs/74/16/tests
https://app.shippable.com/github/ansible-collections/community.windows/runs/74/20/tests

Local testing using nuget.org seems like it'll work well enough for these tests as a psrepository, even if it doesn't actually contain PowerShell modules.

Also replaced a use of httpbin.org with the httptester.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
