### PR TITLE
win_pagefile does nothing when override is false

### DIFF
--- a/plugins/modules/win_pagefile.ps1
+++ b/plugins/modules/win_pagefile.ps1
@@ -130,11 +130,11 @@ if ($state -eq "absent") {
         $result.changed = $true
     }else
     {
-        $CurPageFileSystemManaged = (Get-CimInstance -ClassName win32_Pagefile -Property 'System' -Filter "name='$($fullPath.Replace('\','\\'))'").System
         if ((-not $check_mode) -and
-            -not ($systemManaged -or $CurPageFileSystemManaged) -and
-            (   ($curPagefile.InitialSize -ne $initialSize) -or
-                ($curPagefile.maximumSize -ne $maximumSize)))
+            -not ($systemManaged) -and
+            -not ( ($curPagefile.InitialSize -eq 0) -and ($curPagefile.maximumSize -eq 0) ) -and
+            ( ($curPagefile.InitialSize -ne $initialSize) -or ($curPagefile.maximumSize -ne $maximumSize) )
+           )
         {
             $curPagefile.InitialSize = $initialSize
             $curPagefile.MaximumSize = $maximumSize

--- a/tests/integration/targets/win_pagefile/tasks/main.yml
+++ b/tests/integration/targets/win_pagefile/tasks/main.yml
@@ -5,6 +5,12 @@
     state: query
   register: original_pagefile_settings
 
+# Remove all original pagefiles
+- name: Remove all original pagefiles
+  win_pagefile:
+    remove_all: true
+  register: remove_all_pagefiles
+
 # Test 1: Set c pagefile with inital and maximum size
 - name: Set C pagefile as 1024-2048MB
   win_pagefile:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
win_pagefile does nothing when override is false
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/68652

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_pagefile

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The powershell command used gave unexpected results (always True) causing the module to never apply changes as it thought the page file was system managed.

See full info here: https://github.com/ansible/ansible/issues/68652
<!--- Paste verbatim command output below, e.g. before and after your change -->

