### PR TITLE
Mark test as unstable

### DIFF
--- a/tests/integration/targets/win_psrepository/aliases
+++ b/tests/integration/targets/win_psrepository/aliases
@@ -1,2 +1,3 @@
 shippable/windows/group2
 needs/httptester
+unstable


### PR DESCRIPTION
##### SUMMARY
I'm not sure why but this test has the httptester component not come up correctly. Marking the test as unstable until we find a proper solution.

https://app.shippable.com/github/ansible-collections/community.windows/runs/147/20/tests

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psrepository_info