### PR TITLE
Change Username assignment variable

### DIFF
--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -16,11 +16,9 @@ Function Test-Credential {
         $Domain = $null # force $Domain to be null, to prevent undefined behaviour, as a domain name is already included in the username
     } elseif (($Username.ToCharArray()) -contains [char]'\') {
         # Pre Win2k Account Name
-        $Username = ($Username -split '\')[0]
-        $Domain = ($Username -split '\')[1]
-    } else {
-        # No domain provided, so maybe local user, or domain specified separately.
-    }
+        $Domain = ($Username -split '\\')[0]
+        $Username = ($Username -split '\\', 2)[-1]
+    } # If no domain provided, so maybe local user, or domain specified separately.
 
     try {
         $handle = [Ansible.AccessToken.TokenUtil]::LogonUser($Username, $Domain, $Password, "Network", "Default")


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Username was overriding variable and Domain is first in array as
DOMAIN\USERNAME it's the standard

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin win_domain_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Using username with format `domain\user` get logon failure
