### PR TITLE
Stop using EAP Ignore

### DIFF
--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -162,7 +162,7 @@ Function Add-DefinedParameter {
     )
 
     ForEach ($ParameterName in $ParametersNames) {
-        $ParameterVariable = Get-Variable -Name $ParameterName -ErrorAction Ignore
+        $ParameterVariable = Get-Variable -Name $ParameterName -ErrorAction SilentlyContinue
         if ( $ParameterVariable.Value -and $Hashtable.Keys -notcontains $ParameterName ){
                 $Hashtable.Add($ParameterName,$ParameterVariable.Value)
         }
@@ -381,7 +381,7 @@ if ( ($state -eq "latest") -and
 }
 
 if ( $repo -and (-not $url) ) {
-    $RepositoryExists = Get-PSRepository -Name $repo -ErrorAction Ignore
+    $RepositoryExists = Get-PSRepository -Name $repo -ErrorAction SilentlyContinue
     if ( $null -eq $RepositoryExists) {
         $ErrorMessage = "The repository $repo doesn't exist."
         Fail-Json $result $ErrorMessage

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -27,6 +27,18 @@ $result = @{changed = $false
             nuget_changed = $false
             repository_changed = $false}
 
+
+# Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+$security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
+if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+    $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
+}
+if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+    $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
+}
+[System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
+
+
 Function Install-NugetProvider {
     Param(
         [Bool]$CheckMode

--- a/plugins/modules/win_psrepository.ps1
+++ b/plugins/modules/win_psrepository.ps1
@@ -26,6 +26,16 @@ $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $fals
 
 $result = @{"changed" = $false}
 
+# Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+$security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
+if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+    $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
+}
+if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+    $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
+}
+[System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
+
 if (-not (Import-Module -Name PowerShellGet -MinimumVersion 1.6.0 -PassThru -ErrorAction SilentlyContinue)) {
     Fail-Json -obj $result -Message "PowerShellGet version 1.6.0+ is required."
 }

--- a/plugins/modules/win_psrepository.ps1
+++ b/plugins/modules/win_psrepository.ps1
@@ -34,7 +34,7 @@ $repository_params = @{
     Name = $name
 }
 
-$Repo = Get-PSRepository @repository_params -ErrorAction Ignore
+$Repo = Get-PSRepository @repository_params -ErrorAction SilentlyContinue
 
 if ($installation_policy) {
     $repository_params.InstallationPolicy = $installation_policy

--- a/plugins/modules/win_psscript.ps1
+++ b/plugins/modules/win_psscript.ps1
@@ -50,6 +50,17 @@ $spec = @{
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 $state = $module.Params.state
+
+# Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+$security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
+if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+    $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
+}
+if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+    $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
+}
+[System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
+
 function Get-SplattableParameters {
     [CmdletBinding(DefaultParameterSetName='All')]
     [OutputType([hashtable])]

--- a/tests/integration/targets/win_psrepository/tasks/get_repo_info.yml
+++ b/tests/integration/targets/win_psrepository/tasks/get_repo_info.yml
@@ -5,7 +5,7 @@
 ---
 - name: Retrieve Repository Manually
   ansible.windows.win_shell: |
-    $repo = Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction Ignore
+    $repo = Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction SilentlyContinue
     @{
         repo = $repo
         exists = $repo -as [bool]

--- a/tests/integration/targets/win_psrepository/tasks/main.yml
+++ b/tests/integration/targets/win_psrepository/tasks/main.yml
@@ -5,7 +5,7 @@
 
 ---
 - name: unregister the repository
-  ansible.windows.win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction Ignore
+  ansible.windows.win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction SilentlyContinue
 
 - block:
   - name: run all tests
@@ -15,4 +15,4 @@
     include_tasks: update_and_force.yml
   always:
   - name: ensure test repo is unregistered
-    ansible.windows.win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction Ignore
+    ansible.windows.win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction SilentlyContinue

--- a/tests/integration/targets/win_psrepository/tasks/tests.yml
+++ b/tests/integration/targets/win_psrepository/tasks/tests.yml
@@ -14,7 +14,7 @@
   register: adding_repository_check
 
 - name: get result of adding repository defaults - check mode
-  ansible.windows.win_shell: (Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction ignore | Measure-Object).Count
+  ansible.windows.win_shell: (Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction SilentlyContinue | Measure-Object).Count
   changed_when: false
   register: result_adding_repository_check
 
@@ -161,7 +161,7 @@
   register: removing_repository_check
 
 - name: get result of remove repository - check mode
-  ansible.windows.win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction Ignore | Measure-Object).Count'
+  ansible.windows.win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction SilentlyContinue | Measure-Object).Count'
   changed_when: false
   register: result_removing_repository_check
 
@@ -178,7 +178,7 @@
   register: removing_repository
 
 - name: get result of remove repository
-  ansible.windows.win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction Ignore | Measure-Object).Count'
+  ansible.windows.win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction SilentlyContinue | Measure-Object).Count'
   changed_when: false
   register: result_removing_repository
 


### PR DESCRIPTION
##### SUMMARY
Using `-ErrorAction Ignore` can have problems in advanced functions whereas `-ErrorAction SilentlyContinue` does work. This isn't usually a problem if the function succeeds but if there is a failure and it writes to the error stream (say the repo doesn't exist)  then it applies the ErrorAction and Ignore isn't supported for `$ErrorActionPreference`.

While this has been fixed in PowerShell 7 we need to ensure our code works with v3+ https://github.com/PowerShell/PowerShell/issues/1759.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule
win_psrepository

##### ADDITIONAL INFORMATION
To test this out manually in PowerShell run the following script

```powershell
Function Test-Function {
    [CmdletBinding()]
    param ([Switch]$Error)

    if ($Error) {
        Write-Error -Message "error message"
    }
}

Test-Function

Test-Function -Error

Test-Function -ErrorAction Ignore

Test-Function -Error -ErrorAction Ignore
```

On PowerShell < 7 we get

```powershell
PS C:\Users\vagrant-domain> Test-Function
PS C:\Users\vagrant-domain>
PS C:\Users\vagrant-domain> Test-Function -Error
Test-Function : error message
At line:1 char:1
+ Test-Function -Error
+ ~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Test-Function

PS C:\Users\vagrant-domain>
PS C:\Users\vagrant-domain> Test-Function -ErrorAction Ignore
PS C:\Users\vagrant-domain>
PS C:\Users\vagrant-domain> Test-Function -Error -ErrorAction Ignore
Write-Error : The value Ignore is not supported for an ActionPreference variable. The provided value should be used
only as a value for a preference parameter, and has been replaced by the default value. For more information, see the
Help topic, "about_Preference_Variables."
At line:6 char:9
+         Write-Error -Message "error message"
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], NotSupportedException
    + FullyQualifiedErrorId : System.NotSupportedException,Microsoft.PowerShell.Commands.WriteErrorCommand
```

On PowerShell 7+ we get

```
PS C:\Users\vagrant-domain> Test-Function
PS C:\Users\vagrant-domain>
PS C:\Users\vagrant-domain> Test-Function -Error
Test-Function: error message
PS C:\Users\vagrant-domain>
PS C:\Users\vagrant-domain> Test-Function -ErrorAction Ignore
PS C:\Users\vagrant-domain>
PS C:\Users\vagrant-domain> Test-Function -Error -ErrorAction Ignore
PS C:\Users\vagrant-domain>
```

Where this is relevant is because we were using code like `Get-PSRepository -Name repo -ErrorAction Ignore` where that repo may or may not have existed. If it did not exist then we wanted to ignore the error and continue on but due to this PowerShell bug it failed with this error.