### PR TITLE
win_domain_computer - add offline domain join support

### DIFF
--- a/changelogs/fragments/93-win_domain_computer-offline-domain-join.yml
+++ b/changelogs/fragments/93-win_domain_computer-offline-domain-join.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - win_domain_computer - add support for offline domain join
-  - win_domain_computer - sam account name with missing ``$``` will have it added automatically
+  - win_domain_computer - ``sam_account_name`` with missing ``$`` will have it added automatically

--- a/changelogs/fragments/93-win_domain_computer-offline-domain-join.yml
+++ b/changelogs/fragments/93-win_domain_computer-offline-domain-join.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - win_domain_computer - add support for offline domain join
-  - win_domain_computer - ``sam_account_name`` with missing ``$`` will have it added automatically
+  - win_domain_computer - add support for offline domain join (https://github.com/ansible-collections/community.windows/pull/93)
+  - win_domain_computer - ``sam_account_name`` with missing ``$`` will have it added automatically (https://github.com/ansible-collections/community.windows/pull/93)

--- a/changelogs/fragments/93-win_domain_computer-offline-domain-join.yml
+++ b/changelogs/fragments/93-win_domain_computer-offline-domain-join.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - win_domain_computer - add support for offline domain join
+  - win_domain_computer - sam account name with missing ``$``` will have it added automatically

--- a/plugins/modules/win_domain_computer.ps1
+++ b/plugins/modules/win_domain_computer.ps1
@@ -206,6 +206,10 @@ Function Invoke-OfflineDomainJoin {
       $result.odj_blob_path = $BlobPath.FullName
     }
 
+    if (-not $BlobPath.Directory.Exists) {
+      Fail-Json -obj $result -message "BLOB path directory '$($BlobPath.Directory.FullName)' doesn't exist."
+    }
+
     if ($PSCmdlet.ShouldProcess($argstring)) {
       try {
         $djoin_result = Run-Command -command $invocation
@@ -224,7 +228,7 @@ Function Invoke-OfflineDomainJoin {
         }
       }
       finally {
-        if ($output) {
+        if ($output -and $BlobPath.Exists) {
           $BlobPath.Delete()
         }
       }

--- a/plugins/modules/win_domain_computer.py
+++ b/plugins/modules/win_domain_computer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2020, Brian Scholer (@briantist)
 # Copyright: (c) 2017, AMTEGA - Xunta de Galicia
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -88,6 +89,28 @@ options:
     type: str
     choices: [ absent, present ]
     default: present
+  offline_domain_join:
+    description:
+      - Provisions a computer in the directory and provides a BLOB file that can be used on the target computer/image to join it to the domain while offline.
+      - If the computer already exists, no BLOB will be created/returned, and the module will operate as it would have without offline domain join.
+    type: bool
+  odj_return_blob:
+    description:
+      - Returns the BLOB in the module output. Note that the BLOB should be treated as a secret, as it contains the machine password.
+      - The module should be called with C(no_log) when using this option.
+      - The BLOB file contains a terminating null character which will not be included. See Notes.
+  odj_blob_path:
+    description:
+      - The path to the file where the BLOB will be saved.
+      - Required when I(offline_domain_join=True) and I(odj_return_blob=False).
+      - If using I(odj_return_blob=True) this can be omitted, and a temporary file will be used and then destroyed.
+      - If I(odj_return_blob=True) and this is specified, it will be used and file will remain.
+notes:
+  - "For more information on Offline Domain Join
+    see U(https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd392267(v=ws.10))"
+  - When using the ODJ BLOB to join a computer to the domain, it must be written out to a file.
+  - The file must be UTF-16 encoded (in PowerShell this encoding is called C(Unicode)), and it must end in a null character. See examples.
+  - The C(djoin.exe) part of the offline domain join process will not use I(domain_server), I(domain_username), or I(domain_password).
 seealso:
 - module: win_domain
 - module: win_domain_controller
@@ -96,11 +119,12 @@ seealso:
 - module: win_domain_user
 author:
 - Daniel Sánchez Fábregas (@Daniel-Sanchez-Fabregas)
+- Brian Scholer (@briantist)
 '''
 
 EXAMPLES = r'''
   - name: Add linux computer to Active Directory OU using a windows machine
-    win_domain_computer:
+    community.windows.win_domain_computer:
       name: one_linux_server
       sam_account_name: linux_server$
       dns_hostname: one_linux_server.my_org.local
@@ -111,11 +135,64 @@ EXAMPLES = r'''
     delegate_to: my_windows_bridge.my_org.local
 
   - name: Remove linux computer from Active Directory using a windows machine
-    win_domain_computer:
+    community.windows.win_domain_computer:
       name: one_linux_server
       state: absent
     delegate_to: my_windows_bridge.my_org.local
+
+  - name: Provision a computer for offline domain join
+    community.windows.win_domain_computer:
+      name: newhost
+      dns_hostname: newhost.ansible.local
+      ou: 'OU=A great\, big organizational unit name,DC=ansible,DC=local'
+      state: present
+      offline_domain_join: yes
+      odj_return_blob: yes
+    register: computer_status
+    delegate_to: windc.ansible.local
+
+  - name: Join a workgroup computer to the domain
+    vars:
+      target_blob_file: 'C:\ODJ\blob.txt'
+    ansible.windows.win_shell: |
+      # add terminating null character to BLOB
+      $blob = "{{ computer_status.odj_blob }}`0"
+      $blob | Set-Content -LiteralPath '{{ target_blob_file }}' -Encoding Unicode -Force
+      & djoin.exe --% /RequestODJ /LoadFile "{{ target_blob_file }}" /LocalOS /WindowsPath "%SystemRoot%"
+
+  - name: Restart to complete domain join
+    ansible.windows.win_restart:
 '''
 
 RETURN = r'''
+odj_blob:
+  description: The offline domain join BLOB. This is an empty string when in check mode or when odj_return_blob is False.
+  returned: when offline_domain_join is True and the computer didn't exist
+  type: str
+  sample: <a long base64 string>
+djoin:
+  description: Information about the invocation of djoin.exe.
+  returned: when offline_domain_join is True and the computer didn't exist
+  type: dict
+  contains:
+    invocation:
+      description: The full command line used to call djoin.exe
+      type: str
+      returned: always
+      sample: djoin.exe /PROVISION /MACHINE compname /MACHINEOU OU=Hosts,DC=ansible,DC=local /DOMAIN ansible.local /SAVEFILE blobfile.txt
+    rc:
+      description: The return code from djoin.exe
+      type: int
+      returned: when not check mode
+      sample: 87
+    stdout:
+      description: The stdout from djoin.exe
+      type: str
+      returned: when not check mode
+      sample: Computer provisioning completed successfully.
+    stderr:
+      description: The stderr from djoin.exe
+      type: str
+      returned: when not check mode
+      sample: Invalid input parameter combination.
 '''

--- a/plugins/modules/win_domain_computer.py
+++ b/plugins/modules/win_domain_computer.py
@@ -32,7 +32,8 @@ options:
         operating systems compatibility.
       - The LDAP display name (ldapDisplayName) for this property is sAMAccountName.
       - If ommitted the value is the same as C(name).
-      - Note that all computer SAMAccountNames need to end with a $.
+      - Note that all computer SAMAccountNames need to end with a C($).
+      - If C($) is omitted, it will be added to the end.
     type: str
   enabled:
     description:
@@ -47,6 +48,7 @@ options:
     description:
       - Specifies the X.500 path of the Organizational Unit (OU) or container
         where the new object is created. Required when I(state=present).
+      - Special characters must be escaped, see U(https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ldap/distinguished-names)
     type: str
   description:
     description:
@@ -99,7 +101,7 @@ author:
 EXAMPLES = r'''
   - name: Add linux computer to Active Directory OU using a windows machine
     win_domain_computer:
-      name: one_linux_server.my_org.local
+      name: one_linux_server
       sam_account_name: linux_server$
       dns_hostname: one_linux_server.my_org.local
       ou: "OU=servers,DC=my_org,DC=local"
@@ -110,7 +112,7 @@ EXAMPLES = r'''
 
   - name: Remove linux computer from Active Directory using a windows machine
     win_domain_computer:
-      name: one_linux_server.my_org.local
+      name: one_linux_server
       state: absent
     delegate_to: my_windows_bridge.my_org.local
 '''

--- a/plugins/modules/win_domain_computer.py
+++ b/plugins/modules/win_domain_computer.py
@@ -107,6 +107,7 @@ options:
     description:
       - The path to the file where the BLOB will be saved. If omitted, a temporary file will be used.
       - If I(offline_domain_join=output) the file will be deleted after its contents are returned.
+      - The parent directory for the BLOB file must exist; intermediate directories will not be created.
 notes:
   - "For more information on Offline Domain Join
     see L(the step-by-step guide,https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd392267%28v=ws.10%29)."

--- a/tests/integration/targets/win_domain_computer/tasks/main.yml
+++ b/tests/integration/targets/win_domain_computer/tasks/main.yml
@@ -124,8 +124,7 @@
                 description: "{{ test_computer_description }}"
                 enabled: yes
                 state: present
-                offline_domain_join: yes
-                odj_return_blob: yes
+                offline_domain_join: output
               register: odj_result
               check_mode: yes
 
@@ -135,6 +134,7 @@
                   - odj_result is changed
                   - odj_result.odj_blob is defined
                   - odj_result.odj_blob == ''
+                  - odj_result.odj_blob_path is not defined
                   - odj_result.djoin is defined
                   - odj_result.djoin.invocation is defined
 
@@ -147,8 +147,7 @@
                 description: "{{ test_computer_description }}"
                 enabled: yes
                 state: present
-                offline_domain_join: yes
-                odj_return_blob: yes
+                offline_domain_join: output
               register: odj_result
 
             - name: assert odj
@@ -157,6 +156,7 @@
                   - odj_result is changed
                   - odj_result.odj_blob is defined
                   - odj_result.odj_blob != ''
+                  - odj_result.odj_blob_path is not defined
                   - odj_result.djoin is defined
                   - odj_result.djoin.invocation is defined
                   - odj_result.djoin.rc is defined
@@ -173,8 +173,7 @@
                 description: "{{ test_computer_description }}"
                 enabled: yes
                 state: present
-                offline_domain_join: yes
-                odj_return_blob: yes
+                offline_domain_join: output
               register: odj_result
 
             - name: assert odj
@@ -182,6 +181,7 @@
                 that:
                   - odj_result is not changed
                   - odj_result.odj_blob is not defined
+                  - odj_result.odj_blob_path is not defined
                   - odj_result.djoin is not defined
 
           always:
@@ -205,8 +205,7 @@
                 description: "{{ test_computer_description }}"
                 enabled: yes
                 state: present
-                offline_domain_join: yes
-                odj_return_blob: yes
+                offline_domain_join: output
                 odj_blob_path: "{{ blob_path }}"
               register: odj_result
               check_mode: yes
@@ -217,6 +216,7 @@
                   - odj_result is changed
                   - odj_result.odj_blob is defined
                   - odj_result.odj_blob == ''
+                  - odj_result.odj_blob_path is not defined
                   - odj_result.djoin is defined
                   - odj_result.djoin.invocation is defined
 
@@ -229,8 +229,7 @@
                 description: "{{ test_computer_description }}"
                 enabled: yes
                 state: present
-                offline_domain_join: yes
-                odj_return_blob: yes
+                offline_domain_join: output
                 odj_blob_path: "{{ blob_path }}"
               register: odj_result
 
@@ -240,22 +239,13 @@
                   - odj_result is changed
                   - odj_result.odj_blob is defined
                   - odj_result.odj_blob != ''
+                  - odj_result.odj_blob_path is not defined
                   - odj_result.djoin is defined
                   - odj_result.djoin.invocation is defined
                   - odj_result.djoin.rc is defined
                   - odj_result.djoin.rc == 0
                   - odj_result.djoin.stdout is defined
                   - odj_result.djoin.stderr is defined
-
-            - name: Test ODJ file
-              ansible.windows.win_shell: |
-                $file = '{{ blob_path }}'
-                $expected_content = '{{ odj_result.odj_blob }}'
-                $content = (Get-Content -LiteralPath $file -Raw -Encoding Unicode -ErrorAction Stop).TrimEnd("`0")
-
-                if ($expected_content.Length -ne $content.Length -or $expected_content -cne $content) {
-                  throw "BLOB file and returned contents don't match"
-                }
 
             - name: Create computer with offline domain join and blob file with return (idempotence)
               win_domain_computer:
@@ -266,8 +256,7 @@
                 description: "{{ test_computer_description }}"
                 enabled: yes
                 state: present
-                offline_domain_join: yes
-                odj_return_blob: yes
+                offline_domain_join: output
                 odj_blob_path: "{{ blob_path }}"
               register: odj_result
 
@@ -276,6 +265,7 @@
                 that:
                   - odj_result is not changed
                   - odj_result.odj_blob is not defined
+                  - odj_result.odj_blob_path is not defined
                   - odj_result.djoin is not defined
 
           always:
@@ -288,3 +278,201 @@
             - name: ensure the blob file is deleted
               win_shell: |
                 Remove-Item -LiteralPath '{{ blob_path }}' -Force -ErrorAction SilentlyContinue
+                exit 0
+
+        - name: Specified file return
+          vars:
+            blob_path: 'C:\Windows\Temp\blob.txt'
+          block:
+            - name: Create computer with offline domain join and blob file return with specified path (check mode)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: path
+                odj_blob_path: "{{ blob_path }}"
+              register: odj_result
+              check_mode: yes
+
+            - name: assert odj (check mode)
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob == ''
+                  - odj_result.odj_blob_path is defined
+                  - odj_result.odj_blob_path == blob_path
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+
+            - name: Create computer with offline domain join and blob file return with specified path
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: path
+                odj_blob_path: "{{ blob_path }}"
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob == ''
+                  - odj_result.odj_blob_path is defined
+                  - odj_result.odj_blob_path == blob_path
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+                  - odj_result.djoin.rc is defined
+                  - odj_result.djoin.rc == 0
+                  - odj_result.djoin.stdout is defined
+                  - odj_result.djoin.stderr is defined
+
+            - name: Test ODJ File
+              ansible.windows.win_shell: |
+                $ErrorActionPreference = 'Stop'
+                $file = '{{ odj_result.odj_blob_path }}'
+                $content = Get-Content -LiteralPath $file -Raw -Encoding Unicode
+                $trimmed = $content.TrimEnd("`0")
+                if ($content.Length -eq $trimmed.Length) { throw 'No terminating null found' }
+                # try a base64 decode to validate it is the kind of data we expect
+                $bytes = [Convert]::FromBase64String($trimmed)
+
+            - name: Create computer with offline domain join and blob file return with specified path (idempotence)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: path
+                odj_blob_path: "{{ blob_path }}"
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is not changed
+                  - odj_result.odj_blob is not defined
+                  - odj_result.odj_blob_path is not defined
+                  - odj_result.djoin is not defined
+
+          always:
+            - name: ensure the test computer is deleted after the test
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                state: absent
+
+            - name: ensure the blob file is deleted
+              win_shell: |
+                Remove-Item -LiteralPath '{{ blob_path }}' -Force -ErrorAction SilentlyContinue
+                exit 0
+
+        - name: Random file return
+          block:
+            - name: Create computer with offline domain join and random blob file return (check mode)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: path
+              register: odj_result
+              check_mode: yes
+
+            - name: assert odj (check mode)
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob == ''
+                  - odj_result.odj_blob_path is defined
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+
+            - name: Create computer with offline domain join and random blob file return
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: path
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob == ''
+                  - odj_result.odj_blob_path is defined
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+                  - odj_result.djoin.rc is defined
+                  - odj_result.djoin.rc == 0
+                  - odj_result.djoin.stdout is defined
+                  - odj_result.djoin.stderr is defined
+
+            - name: This file needs to be deleted later
+              set_fact:
+                returned_file: "{{ odj_result.odj_blob_path }}"
+
+            - name: Test ODJ File
+              ansible.windows.win_shell: |
+                $ErrorActionPreference = 'Stop'
+                $file = '{{ odj_result.odj_blob_path }}'
+                $content = Get-Content -LiteralPath $file -Raw -Encoding Unicode
+                $trimmed = $content.TrimEnd("`0")
+                if ($content.Length -eq $trimmed.Length) { throw 'No terminating null found' }
+                # try a base64 decode to validate it is the kind of data we expect
+                $bytes = [Convert]::FromBase64String($trimmed)
+
+            - name: Create computer with offline domain join and random blob file return (idempotence)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: path
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is not changed
+                  - odj_result.odj_blob is not defined
+                  - odj_result.odj_blob_path is not defined
+                  - odj_result.djoin is not defined
+
+          always:
+            - name: ensure the test computer is deleted after the test
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                state: absent
+
+            - name: ensure the blob file is deleted
+              win_shell: |
+                Remove-Item -LiteralPath '{{ returned_file }}' -Force -ErrorAction SilentlyContinue
+                exit 0

--- a/tests/integration/targets/win_domain_computer/tasks/main.yml
+++ b/tests/integration/targets/win_domain_computer/tasks/main.yml
@@ -25,16 +25,21 @@
     test_win_domain_computer_ou_path: "{{ test_ad_computer_ou }}"
     test_win_domain_computer_name: "test_computer"
     test_win_domain_domain_name: "{{ test_domain_name }}"
+    test_win_domain_computer_dns_hostname: "{{ test_win_domain_computer_name }}.{{ test_domain_name }}"
+    test_win_domain_computer_description: "{{ test_computer_description | default('description') }}"
   tasks:
 
     - name: ensure the computer is deleted before the test
       win_domain_computer:
         name: '{{ test_win_domain_computer_name }}'
         state: absent
+      tags: always
 
     # --------------------------------------------------------------------------
 
     - name: Test computer with long name and distinct sam_account_name
+      tags:
+        - long_name
       vars:
         test_win_domain_computer_long_name: '{{ test_win_domain_computer_name }}_with_long_name'
         test_win_domain_computer_sam_account_name: '{{ test_win_domain_computer_name }}$'
@@ -93,11 +98,193 @@
             that:
             - create_distinct_sam_account_name_idempotence is not changed
 
+      always:
         - name: ensure the test computer is deleted after the test
           win_domain_computer:
             name: '{{ test_win_domain_computer_long_name }}'
             sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
             state: absent
-            ignore_protection: True
 
         # ----------------------------------------------------------------------
+
+    - name: Test offline domain join
+      tags:
+        - djoin
+      vars:
+        test_win_domain_computer_sam_account_name: '{{ test_win_domain_computer_name }}$'
+      block:
+        - name: No file with blob return
+          block:
+            - name: Create computer with offline domain join and blob return (check mode)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: yes
+                odj_return_blob: yes
+              register: odj_result
+              check_mode: yes
+
+            - name: assert odj (check mode)
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob == ''
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+
+            - name: Create computer with offline domain join and blob return
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: yes
+                odj_return_blob: yes
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob != ''
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+                  - odj_result.djoin.rc is defined
+                  - odj_result.djoin.rc == 0
+                  - odj_result.djoin.stdout is defined
+                  - odj_result.djoin.stderr is defined
+
+            - name: Create computer with offline domain join and blob return (idempotence)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: yes
+                odj_return_blob: yes
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is not changed
+                  - odj_result.odj_blob is not defined
+                  - odj_result.djoin is not defined
+
+          always:
+            - name: ensure the test computer is deleted after the test
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                state: absent
+
+
+        - name: File and blob return
+          vars:
+            blob_path: 'C:\Windows\Temp\blob.txt'
+          block:
+            - name: Create computer with offline domain join and blob file with return (check mode)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: yes
+                odj_return_blob: yes
+                odj_blob_path: "{{ blob_path }}"
+              register: odj_result
+              check_mode: yes
+
+            - name: assert odj (check mode)
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob == ''
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+
+            - name: Create computer with offline domain join and blob file with return
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: yes
+                odj_return_blob: yes
+                odj_blob_path: "{{ blob_path }}"
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is changed
+                  - odj_result.odj_blob is defined
+                  - odj_result.odj_blob != ''
+                  - odj_result.djoin is defined
+                  - odj_result.djoin.invocation is defined
+                  - odj_result.djoin.rc is defined
+                  - odj_result.djoin.rc == 0
+                  - odj_result.djoin.stdout is defined
+                  - odj_result.djoin.stderr is defined
+
+            - name: Test ODJ file
+              ansible.windows.win_shell: |
+                $file = '{{ blob_path }}'
+                $expected_content = '{{ odj_result.odj_blob }}'
+                $content = (Get-Content -LiteralPath $file -Raw -Encoding Unicode -ErrorAction Stop).TrimEnd("`0")
+
+                if ($expected_content.Length -ne $content.Length -or $expected_content -cne $content) {
+                  throw "BLOB file and returned contents don't match"
+                }
+
+            - name: Create computer with offline domain join and blob file with return (idempotence)
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                ou: "{{ test_win_domain_computer_ou_path }}"
+                description: "{{ test_computer_description }}"
+                enabled: yes
+                state: present
+                offline_domain_join: yes
+                odj_return_blob: yes
+                odj_blob_path: "{{ blob_path }}"
+              register: odj_result
+
+            - name: assert odj
+              assert:
+                that:
+                  - odj_result is not changed
+                  - odj_result.odj_blob is not defined
+                  - odj_result.djoin is not defined
+
+          always:
+            - name: ensure the test computer is deleted after the test
+              win_domain_computer:
+                name: '{{ test_win_domain_computer_name }}'
+                sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+                state: absent
+
+            - name: ensure the blob file is deleted
+              win_shell: |
+                Remove-Item -LiteralPath '{{ blob_path }}' -Force -ErrorAction SilentlyContinue

--- a/tests/integration/targets/win_domain_computer/tasks/main.yml
+++ b/tests/integration/targets/win_domain_computer/tasks/main.yml
@@ -2,15 +2,29 @@
 # these are here if someone wants to run the module tests locally on their own
 # domain.
 # Requirements:
-#   LDAP Base path set in defaults/main.yml like DC=ansible,DC=local
-#   Custom OU path set in defaults/main.yml like OU=ou1,DC=ansible,DC=local
+#   Set the names in vars: on the command line, or set the following:
+#   test_domain_name:       The DNS name of the domain like ansible.local
+#   test_ad_domain_dn:      The DN of the domain like DC=ansible,DC=local
+#   test_ad_computer_ou:    The DN of the OU where computers will be created like OU=ou1,DC=ansible,DC=local
+#
+# This is not a traditional role, and can't be used with ansible-test. This is a playbook. To run ensure:
+#   - your collections are set up and Ansible knows where to find them ($ANSIBLE_COLLECTIONS_PATHS for example)
+#   - your inventory contains a host where this can run, like a domain controller
+#   - connection keywords/options/vars are set properly to connect to the host
+#   - the variable win_domain_computer_testing_host contains the name of the host or the group that contains it
+#
+# then call this file with ansible-playbook and any extra vars or other params you need
 ---
 - name: run win_domain_users test
-  hosts: win_domain_computer_testing_host
+  hosts: "{{ win_domain_computer_testing_host }}"
+  gather_facts: no
+  collections:
+    - community.windows
   vars:
-    test_win_domain_computer_ldap_base: "{{ test_ad_ou }}"
-    test_win_domain_computer_ou_path: "{{ test_ad_group_ou }}"
-    test_win_domain_computer_name: "test_computer.{{ test_domain_name }}"
+    test_win_domain_computer_ldap_base: "{{ test_ad_domain_dn }}"
+    test_win_domain_computer_ou_path: "{{ test_ad_computer_ou }}"
+    test_win_domain_computer_name: "test_computer"
+    test_win_domain_domain_name: "{{ test_domain_name }}"
   tasks:
 
     - name: ensure the computer is deleted before the test
@@ -24,33 +38,51 @@
       vars:
         test_win_domain_computer_long_name: '{{ test_win_domain_computer_name }}_with_long_name'
         test_win_domain_computer_sam_account_name: '{{ test_win_domain_computer_name }}$'
+        test_win_domain_computer_dns_hostname: "{{ test_win_domain_computer_long_name }}.{{ test_domain_name }}"
       block:
 
         # ----------------------------------------------------------------------
-        - name: create computer with long name and distinct sam_account_name
+        - name: create computer with long name and distinct sam_account_name (check mode)
           win_domain_computer:
             name: '{{ test_win_domain_computer_long_name }}'
+            dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
             sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+            ou: "{{ test_win_domain_computer_ou_path }}"
             enabled: yes
             state: present
           register: create_distinct_sam_account_name
           check_mode: yes
 
-        - name: get actual computer with long name and distinct sam_account_name
-          ansible.windows.win_command: powershell.exe "Import-Module ActiveDirectory; Get-ADComputer -Identity '{{ test_win_domain_computer_sam_account_name }}'"
-          register: create_distinct_sam_account_name_check
-          ignore_errors: True
-
-        - name: assert create computer with long name and distinct sam_account_name
+        - name: assert create computer with long name and distinct sam_account_name (check mode)
           assert:
             that:
-            - create_distinct_sam_account_name is changed
-            - create_distinct_sam_account_name_check.rc == 1
+              - create_distinct_sam_account_name is changed
+
+        - name: create computer with long name and distinct sam_account_name
+          win_domain_computer:
+            name: '{{ test_win_domain_computer_long_name }}'
+            dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
+            sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+            ou: "{{ test_win_domain_computer_ou_path }}"
+            enabled: yes
+            state: present
+          register: create_distinct_sam_account_name
+
+        - name: get actual computer with long name and distinct sam_account_name
+          ansible.windows.win_shell: |
+            Import-Module ActiveDirectory
+            $c = Get-ADComputer -Identity '{{ test_win_domain_computer_sam_account_name }}' -ErrorAction Stop
+            if ($c.Name -ne '{{ test_win_domain_computer_long_name }}') {
+              throw 'Wrong computer name in relation to sAMAccountName'
+            }
+          register: create_distinct_sam_account_name_check
 
         - name: (Idempotence) create computer with long name and distinct sam_account_name
           win_domain_computer:
             name: '{{ test_win_domain_computer_long_name }}'
+            dns_hostname: '{{ test_win_domain_computer_dns_hostname }}'
             sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'
+            ou: "{{ test_win_domain_computer_ou_path }}"
             enabled: yes
             state: present
           register: create_distinct_sam_account_name_idempotence
@@ -61,7 +93,7 @@
             that:
             - create_distinct_sam_account_name_idempotence is not changed
 
-        - name: ensure the test group is deleted after the test
+        - name: ensure the test computer is deleted after the test
           win_domain_computer:
             name: '{{ test_win_domain_computer_long_name }}'
             sam_account_name: '{{ test_win_domain_computer_sam_account_name }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Looking to add support for offline domain join, similar to the `ADComputer` DSC resource.

Offline Domain Join is usually done with `djoin.exe` and lets you pre-create a computer and get back an opaque BLOB, which you can use on a target machine or machine image to join the machine to the domain, without having to contact a domain controller.

[A bug I recently found in the DSC resource](https://github.com/dsccommunity/ActiveDirectoryDsc/issues/608) led me to look at adding the support directly to Ansible instead of continuing to use the DSC resource.

Main changes:
- Add support for doing an offline domain join provision
- Added tests for ODJ
- Optionally return the BLOB from the module

Other changes:
- Leaving off the `$` from `sam_account_name` is no longer an error; it will be added for you
- fixed up tests which were completely broken and unusable, updated their comments to better inform how they could be used locally (they don't run in CI)
- fixed up some syntax and PowerShell calls
- touched up documentation, added examples and notes

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_computer

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
