### PR TITLE
Fix up builtin module references

### DIFF
--- a/plugins/modules/psexec.py
+++ b/plugins/modules/psexec.py
@@ -195,7 +195,7 @@ notes:
 - For more information on this module and the various host requirements, see
   U(https://github.com/jborean93/pypsexec).
 seealso:
-- module: raw
+- module: ansible.builtin.raw
 - module: ansible.windows.win_command
 - module: community.windows.win_psexec
 - module: ansible.windows.win_shell

--- a/plugins/modules/win_lineinfile.py
+++ b/plugins/modules/win_lineinfile.py
@@ -95,8 +95,8 @@ options:
     choices: [ unix, windows ]
     default: windows
 seealso:
-- module: assemble
-- module: lineinfile
+- module: ansible.builtin.assemble
+- module: ansible.builtin.lineinfile
 author:
 - Brian Lloyd (@brianlloyd)
 '''

--- a/plugins/modules/win_psexec.py
+++ b/plugins/modules/win_psexec.py
@@ -101,7 +101,7 @@ notes:
   U(https://technet.microsoft.com/en-us/sysinternals/bb897553.aspx)
 seealso:
 - module: community.windows.psexec
-- module: raw
+- module: ansible.builtin.raw
 - module: ansible.windows.win_command
 - module: ansible.windows.win_shell
 author:

--- a/plugins/modules/win_robocopy.py
+++ b/plugins/modules/win_robocopy.py
@@ -42,8 +42,8 @@ options:
       - If set, C(purge) and C(recurse) will be ignored.
     type: str
 notes:
-- This is not a complete port of the M(synchronize) module. Unlike the M(synchronize) module this only performs the sync/copy on the remote machine,
-  not from the Ansible controller to the remote machine.
+- This is not a complete port of the M(ansible.posix.synchronize) module. Unlike the M(ansible.posix.synchronize)
+  module this only performs the sync/copy on the remote machine, not from the Ansible controller to the remote machine.
 - This module does not currently support all Robocopy flags.
 seealso:
 - module: ansible.posix.synchronize

--- a/plugins/modules/win_unzip.py
+++ b/plugins/modules/win_unzip.py
@@ -12,7 +12,7 @@ description:
 - Unzips compressed files and archives.
 - Supports .zip files natively.
 - Supports other formats supported by the Powershell Community Extensions (PSCX) module (basically everything 7zip supports).
-- For non-Windows targets, use the M(unarchive) module instead.
+- For non-Windows targets, use the M(ansible.builtin.unarchive) module instead.
 requirements:
 - PSCX
 options:
@@ -52,7 +52,7 @@ notes:
   has the ability to recursively unzip files within the src zip file provided and also functionality for many other compression types. If the destination
   directory does not exist, it will be created before unzipping the file.  Specifying rm parameter will force removal of the src file after extraction.
 seealso:
-- module: unarchive
+- module: ansible.builtin.unarchive
 author:
 - Phil Schwartz (@schwartzmx)
 '''

--- a/plugins/modules/win_wait_for_process.py
+++ b/plugins/modules/win_wait_for_process.py
@@ -76,7 +76,7 @@ options:
     type: int
     default: 300
 seealso:
-- module: wait_for
+- module: ansible.builtin.wait_for
 - module: ansible.windows.win_wait_for
 author:
 - Charles Crossan (@crossan007)

--- a/plugins/modules/win_wakeonlan.py
+++ b/plugins/modules/win_wakeonlan.py
@@ -10,7 +10,7 @@ module: win_wakeonlan
 short_description: Send a magic Wake-on-LAN (WoL) broadcast packet
 description:
 - The C(win_wakeonlan) module sends magic Wake-on-LAN (WoL) broadcast packets.
-- For non-Windows targets, use the M(wakeonlan) module instead.
+- For non-Windows targets, use the M(community.general.wakeonlan) module instead.
 options:
   mac:
     description:

--- a/plugins/modules/win_xml.py
+++ b/plugins/modules/win_xml.py
@@ -11,7 +11,7 @@ short_description: Manages XML file content on Windows hosts
 description:
     - Manages XML nodes, attributes and text, using xpath to select which xml nodes need to be managed.
     - XML fragments, formatted as strings, are used to specify the desired state of a part or parts of XML files on remote Windows servers.
-    - For non-Windows targets, use the M(xml) module instead.
+    - For non-Windows targets, use the M(community.general.xml) module instead.
 options:
     attribute:
         description:


### PR DESCRIPTION
##### SUMMARY
Any references to builtin modules should contain the `ansible.builtin` prefix.

https://github.com/ansible-collections/overview/issues/45#issuecomment-648405709

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
many