### PR TITLE
Add checks for globally installed packages

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -26,6 +26,7 @@ releases:
       - win_iis_website - Actually restart the site when ``state=restarted`` - https://github.com/ansible/ansible/issues/63828
       - win_partition - Fix invalid variable name causing a failure on checks - https://github.com/ansible/ansible/issues/62401
       - win_partition - don't resize partitions if size difference is < 1 MiB
+      - win_scoop - add checks for globally installed packages for better idempotency checks
       - win_timezone - Allow for _dstoff timezones
       - win_unzip - Fix support for paths with square brackets not being detected
         properly

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -26,7 +26,6 @@ releases:
       - win_iis_website - Actually restart the site when ``state=restarted`` - https://github.com/ansible/ansible/issues/63828
       - win_partition - Fix invalid variable name causing a failure on checks - https://github.com/ansible/ansible/issues/62401
       - win_partition - don't resize partitions if size difference is < 1 MiB
-      - win_scoop - add checks for globally installed packages for better idempotency checks
       - win_timezone - Allow for _dstoff timezones
       - win_unzip - Fix support for paths with square brackets not being detected
         properly

--- a/changelogs/fragments/win_scoop.yml
+++ b/changelogs/fragments/win_scoop.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_scoop - add checks for globally installed packages for better idempotency checks

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -236,10 +236,10 @@ if ($state -in @("absent")) {
 if ($state -in @("present")) {
   $missing_packages = foreach ($package in $name) {
     if (
-      ($installed_packages.Package -notcontains $package) -or 
-      ($installed_packages.Package -contains $package -and (
-          ($installed_packages.Where( { $_.Package -eq $package }).Global -contains $true -and -not $global) -or 
-          ($installed_packages.Where( { $_.Package -eq $package }).Global -notcontains $true -and $global)
+      ($installed_packages.Package -notcontains $package) -or
+      (($installed_packages.Package -contains $package) -and (
+          (($installed_packages.Where( { $_.Package -eq $package }).Global -contains $true) -and -not $global) -or
+          (($installed_packages.Where( { $_.Package -eq $package }).Global -notcontains $true) -and $global)
         )
       )
     ) {

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -225,7 +225,7 @@ function Uninstall-ScoopPackage {
 
 $scoop_path = Install-Scoop
 
-$installed_packages = Get-ScoopPackages -scoop_path $scoop_path
+$installed_packages = @(Get-ScoopPackages -scoop_path $scoop_path)
 
 if ($state -in @("absent")) {
   # Always attempt uninstall

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -238,8 +238,8 @@ if ($state -in @("present")) {
     if (
       ($installed_packages.Package -notcontains $package) -or
       (($installed_packages.Package -contains $package) -and (
-          (($installed_packages.Where( { $_.Package -eq $package }).Global -contains $true) -and -not $global) -or
-          (($installed_packages.Where( { $_.Package -eq $package }).Global -notcontains $true) -and $global)
+          ((($installed_packages | Where-Object { $_.Package -eq $package }).Global -contains $true) -and -not $global) -or
+          ((($installed_packages | Where-Object { $_.Package -eq $package }).Global -notcontains $true) -and $global)
         )
       )
     ) {

--- a/tests/integration/targets/win_scoop/tasks/tests.yml
+++ b/tests/integration/targets/win_scoop/tasks/tests.yml
@@ -26,10 +26,32 @@
     name: '{{ test_scoop_package1 }}'
   register: install_idempotent
 
-- name: assert install package locally (itempotent)
+- name: assert install package locally (idempotent)
   assert:
     that:
       - not install_idempotent is changed
+
+- name: install package globally
+  win_scoop:
+    name: '{{ test_scoop_package1 }}'
+    global: yes
+  register: install_globally
+
+- name: assert install package globally
+  assert:
+    that:
+      - install_globally is changed
+
+- name: install package globally
+  win_scoop:
+    name: '{{ test_scoop_package1 }}'
+    global: yes
+  register: install_globally_idempotent
+
+- name: assert install package globally (idempotent)
+  assert:
+    that:
+      - not install_globally_idempotent is changed
 
 - name: remove package
   win_scoop:
@@ -48,10 +70,34 @@
     state: absent
   register: remove_idempotent
 
-- name: assert remove package
+- name: assert remove package (idempotent)
   assert:
     that:
       - not remove_idempotent is changed
+
+- name: remove package globally
+  win_scoop:
+    name: '{{ test_scoop_package1 }}'
+    state: absent
+    global: yes
+  register: remove_globally
+
+- name: assert remove package
+  assert:
+    that:
+      - remove_globally is changed
+
+- name: remove package globally (idempotent)
+  win_scoop:
+    name: '{{ test_scoop_package1 }}'
+    state: absent
+    global: yes
+  register: remove_globally_idempotent
+
+- name: assert remove package globally (idempotent)
+  assert:
+    that:
+      - not remove_globally_idempotent is changed
 
 - name: install package before check mode test
   win_scoop:
@@ -85,7 +131,7 @@
     name: '{{ test_scoop_packages }}'
   register: install_multiple_idempotent
 
-- name: assert install multiple packages locally (itempotent)
+- name: assert install multiple packages locally (idempotent)
   assert:
     that:
       - not install_multiple_idempotent is changed


### PR DESCRIPTION
##### SUMMARY
The main fix here is to check if packages are installed globally, as well as the architecture of the installed package.

Scoop allows packages to be installed locally and globally simultaneously, but not different architectures installed locally or different architectures installed globally e.g. you can have dotnet-sdk 32bit locally, and dotnet-sdk 64bit globally.

Also a couple of minor fixes around spelling.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scoop

##### ADDITIONAL INFORMATION
