### PR TITLE
Add porting guide entries from Ansible-base porting guide

### DIFF
--- a/changelogs/fragments/porting-guide.yml
+++ b/changelogs/fragments/porting-guide.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - win_pester - no longer runs all ``*.ps1`` file in the directory specified due to it executing potentially unknown scripts. It will follow the default behaviour of only running tests for files that are like ``*.tests.ps1`` which is built into Pester itself.


### PR DESCRIPTION
##### SUMMARY
This adds entries from the Ansible-base porting guide that do not belong there (because they belong to this collection). This data has already been moved to the ansible changelog (https://github.com/ansible-community/ansible-build-data/blob/main/2.10/changelog.yaml), but it would be better if it appears in the changelog of the collection it applies to.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
