### PR TITLE
win_scoop_bucket does not install scoop if missing

### DIFF
--- a/plugins/modules/win_scoop_bucket.py
+++ b/plugins/modules/win_scoop_bucket.py
@@ -11,7 +11,6 @@ version_added: 1.0.0
 short_description: Manage Scoop buckets
 description:
 - Manage Scoop buckets
-- If Scoop is missing from the system, the module will install it.
 requirements:
 - git
 options:


### PR DESCRIPTION
##### SUMMARY
Update the docs for `win_scoop_bucket` to reflect that it doesn't install scoop, if missing from the system

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_scoop_bucket 

##### ADDITIONAL INFORMATION

