### PR TITLE
New Feature enable all FW rules in a group in win_firewall_rule module

### DIFF
--- a/changelogs/fragments/win_firewall_rule_group_state.yml
+++ b/changelogs/fragments/win_firewall_rule_group_state.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- win_firewall_rule - Support editing rules that have a duplicated name
+- win_firewall_rule - Support editing rules by the group it belongs to

--- a/plugins/modules/win_firewall_rule.py
+++ b/plugins/modules/win_firewall_rule.py
@@ -16,7 +16,6 @@ options:
     description:
       - Whether this firewall rule is enabled or disabled.
       - Defaults to C(true) when creating a new rule.
-      - If provided with a group only then it will enabled or disabled all the rules in a group.
     type: bool
     aliases: [ enable ]
   state:
@@ -28,10 +27,12 @@ options:
   name:
     description:
       - The rule's display name.
+      - This is required unless I(group) is specified.
     type: str
   group:
     description:
       - The group name for the rule.
+      - If I(name) is not specified then the module will set the firewall options for all the rules in this group.
     type: str
   direction:
     description:
@@ -110,6 +111,9 @@ options:
       - See U(https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
         for a list of ICMP types and the codes that apply to them.
     type: list
+notes:
+- Multiple firewall rules can share the same I(name), if there are multiple matches then the module will set the user
+  defined options for each matching rule.
 seealso:
 - module: community.windows.win_firewall
 author:

--- a/plugins/modules/win_firewall_rule.py
+++ b/plugins/modules/win_firewall_rule.py
@@ -5,14 +5,9 @@
 # Copyright: (c) 2017, Artem Zinenko <zinenkoartem@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 DOCUMENTATION = r'''
 ---
 module: win_firewall_rule
-version_added: "2.0"
 short_description: Windows firewall automation
 description:
   - Allows you to create/remove/update firewall rules.
@@ -37,7 +32,6 @@ options:
   group:
     description:
       - The group name for the rule.
-    version_added: '2.9'
     type: str
   direction:
     description:
@@ -105,8 +99,19 @@ options:
       - Defaults to C(domain,private,public) when creating a new rule.
     type: list
     aliases: [ profile ]
+  icmp_type_code:
+    description:
+      - The ICMP types and codes for the rule.
+      - This is only valid when I(protocol) is C(icmpv4) or C(icmpv6).
+      - Each entry follows the format C(type:code) where C(type) is the type
+        number and C(code) is the code number for that type or C(*) for all
+        codes.
+      - Set the value to just C(*) to apply the rule for all ICMP type codes.
+      - See U(https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
+        for a list of ICMP types and the codes that apply to them.
+    type: list
 seealso:
-- module: win_firewall
+- module: community.windows.win_firewall
 author:
   - Artem Zinenko (@ar7z1)
   - Timothy Vandenbrande (@TimothyVandenbrande)
@@ -114,7 +119,7 @@ author:
 
 EXAMPLES = r'''
 - name: Firewall rule to allow SMTP on TCP port 25
-  win_firewall_rule:
+  community.windows.win_firewall_rule:
     name: SMTP
     localport: 25
     action: allow
@@ -124,7 +129,7 @@ EXAMPLES = r'''
     enabled: yes
 
 - name: Firewall rule to allow RDP on TCP port 3389
-  win_firewall_rule:
+  community.windows.win_firewall_rule:
     name: Remote Desktop
     localport: 3389
     action: allow
@@ -135,7 +140,7 @@ EXAMPLES = r'''
     enabled: yes
 
 - name: Firewall rule to be created for application group
-  win_firewall_rule:
+  community.windows.win_firewall_rule:
     name: SMTP
     group: application
     localport: 25
@@ -151,7 +156,7 @@ EXAMPLES = r'''
     enabled: yes
 
 - name: Firewall rule to allow port range
-  win_firewall_rule:
+  community.windows.win_firewall_rule:
     name: Sample port range
     localport: 5000-5010
     action: allow
@@ -160,8 +165,8 @@ EXAMPLES = r'''
     state: present
     enabled: yes
 
-- name: Firewall rule to allow ICMP v4 (ping)
-  win_firewall_rule:
+- name: Firewall rule to allow ICMP v4 echo (ping)
+  community.windows.win_firewall_rule:
     name: ICMP Allow incoming V4 echo request
     enabled: yes
     state: present
@@ -169,4 +174,17 @@ EXAMPLES = r'''
     action: allow
     direction: in
     protocol: icmpv4
+    icmp_type_code:
+    - '8:*'
+
+- name: Firewall rule to alloc ICMP v4 on all type codes
+  community.windows.win_firewall_rule:
+    name: ICMP Allow incoming V4 echo request
+    enabled: yes
+    state: present
+    profiles: private
+    action: allow
+    direction: in
+    protocol: icmpv4
+    icmp_type_code: '*'
 '''

--- a/plugins/modules/win_firewall_rule.py
+++ b/plugins/modules/win_firewall_rule.py
@@ -5,9 +5,14 @@
 # Copyright: (c) 2017, Artem Zinenko <zinenkoartem@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = r'''
 ---
 module: win_firewall_rule
+version_added: "2.0"
 short_description: Windows firewall automation
 description:
   - Allows you to create/remove/update firewall rules.
@@ -16,6 +21,7 @@ options:
     description:
       - Whether this firewall rule is enabled or disabled.
       - Defaults to C(true) when creating a new rule.
+      - If provided with a group only then it will enabled or disabled all the rules in a group.
     type: bool
     aliases: [ enable ]
   state:
@@ -28,10 +34,10 @@ options:
     description:
       - The rule's display name.
     type: str
-    required: yes
   group:
     description:
       - The group name for the rule.
+    version_added: '2.9'
     type: str
   direction:
     description:
@@ -99,19 +105,8 @@ options:
       - Defaults to C(domain,private,public) when creating a new rule.
     type: list
     aliases: [ profile ]
-  icmp_type_code:
-    description:
-      - The ICMP types and codes for the rule.
-      - This is only valid when I(protocol) is C(icmpv4) or C(icmpv6).
-      - Each entry follows the format C(type:code) where C(type) is the type
-        number and C(code) is the code number for that type or C(*) for all
-        codes.
-      - Set the value to just C(*) to apply the rule for all ICMP type codes.
-      - See U(https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
-        for a list of ICMP types and the codes that apply to them.
-    type: list
 seealso:
-- module: community.windows.win_firewall
+- module: win_firewall
 author:
   - Artem Zinenko (@ar7z1)
   - Timothy Vandenbrande (@TimothyVandenbrande)
@@ -119,7 +114,7 @@ author:
 
 EXAMPLES = r'''
 - name: Firewall rule to allow SMTP on TCP port 25
-  community.windows.win_firewall_rule:
+  win_firewall_rule:
     name: SMTP
     localport: 25
     action: allow
@@ -129,7 +124,7 @@ EXAMPLES = r'''
     enabled: yes
 
 - name: Firewall rule to allow RDP on TCP port 3389
-  community.windows.win_firewall_rule:
+  win_firewall_rule:
     name: Remote Desktop
     localport: 3389
     action: allow
@@ -140,7 +135,7 @@ EXAMPLES = r'''
     enabled: yes
 
 - name: Firewall rule to be created for application group
-  community.windows.win_firewall_rule:
+  win_firewall_rule:
     name: SMTP
     group: application
     localport: 25
@@ -150,8 +145,13 @@ EXAMPLES = r'''
     state: present
     enabled: yes
 
+- name: Enable all the Firewall rules in application group
+  win_firewall_rule:
+    group: application
+    enabled: yes
+
 - name: Firewall rule to allow port range
-  community.windows.win_firewall_rule:
+  win_firewall_rule:
     name: Sample port range
     localport: 5000-5010
     action: allow
@@ -160,8 +160,8 @@ EXAMPLES = r'''
     state: present
     enabled: yes
 
-- name: Firewall rule to allow ICMP v4 echo (ping)
-  community.windows.win_firewall_rule:
+- name: Firewall rule to allow ICMP v4 (ping)
+  win_firewall_rule:
     name: ICMP Allow incoming V4 echo request
     enabled: yes
     state: present
@@ -169,17 +169,4 @@ EXAMPLES = r'''
     action: allow
     direction: in
     protocol: icmpv4
-    icmp_type_code:
-    - '8:*'
-
-- name: Firewall rule to alloc ICMP v4 on all type codes
-  community.windows.win_firewall_rule:
-    name: ICMP Allow incoming V4 echo request
-    enabled: yes
-    state: present
-    profiles: private
-    action: allow
-    direction: in
-    protocol: icmpv4
-    icmp_type_code: '*'
 '''

--- a/tests/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/tests/integration/targets/win_firewall_rule/tasks/main.yml
@@ -72,6 +72,84 @@
 - name: Add firewall rule
   win_firewall_rule:
     name: http
+    enabled: no
+    state: present
+    group: application
+    localport: 80
+    action: allow
+    direction: in
+    protocol: tcp
+  register: add_firewall_rule
+
+- name: Check that creating new firewall rule succeeds with a change
+  assert:
+    that:
+    - add_firewall_rule.changed == true
+
+- name: Enable all the rules in application group
+  win_firewall_rule:
+    group: application
+    enabled: yes 
+  register: change_firewall_rule
+
+- name: Check if the rules are enabled in application group
+  assert:
+    that:
+    - change_firewall_rule.changed == true 
+
+- name: Enable all the rules in application group (again)
+  win_firewall_rule:
+    group: application
+    enabled: yes 
+  register: change_firewall_rule
+
+- name: Check if the rules are enabled without a change
+  assert:
+    that:
+    - change_firewall_rule.changed == false
+
+- name: Disable all the rules in application group
+  win_firewall_rule:
+    group: application
+    enabled: no
+  register: change_firewall_rule
+
+- name: Check if the rules are disabled
+  assert:
+    that:
+    - change_firewall_rule.changed == true 
+
+- name: Disable all the rules in application group (again)
+  win_firewall_rule:
+    group: application
+    enabled: no 
+  register: change_firewall_rule
+
+- name: Check if the rules are disabled without a change
+  assert:
+    that:
+    - change_firewall_rule.changed == false
+
+- name: Remove firewall rule
+  win_firewall_rule:
+    name: http
+    enabled: no
+    state: absent
+    localport: 80
+    action: allow
+    group: application
+    direction: in
+    protocol: tcp
+  register: remove_firewall_rule
+
+- name: Check that removing existing firewall rule succeeds with a change
+  assert:
+    that:
+    - remove_firewall_rule.changed == true
+
+- name: Add firewall rule
+  win_firewall_rule:
+    name: http
     enabled: yes
     state: present
     localport: 80
@@ -101,7 +179,7 @@
     enabled: no
 
 - name: Get the actual values from the changed firewall rule
-  ansible.windows.win_shell: '(New-Object -ComObject HNetCfg.FwPolicy2).Rules | Where-Object { $_.Name -eq "http" } | Foreach-Object { $_.LocalPorts; $_.Enabled; $_.Action; $_.Direction; $_.Protocol }'
+  win_shell: '(New-Object -ComObject HNetCfg.FwPolicy2).Rules | Where-Object { $_.Name -eq "http" } | Foreach-Object { $_.LocalPorts; $_.Enabled; $_.Action; $_.Direction; $_.Protocol }'
   register: firewall_rule_actual
 
 - name: Ensure that disabling the rule did not change the previous values
@@ -333,7 +411,7 @@
   register: add_firewall_rule_with_edge_traversal
 
 # Setup action creates ansible_distribution_version variable
-- ansible.windows.setup:
+- setup:
 
 - name: Check that creating firewall rule with enge traversal option 'deferapp' succeeds with a change
   assert:
@@ -472,3 +550,19 @@
   assert:
     that:
     - add_firewall_rule_with_icmptypecode.changed == true
+
+- name: Remove rule with icmptypecode
+  win_firewall_rule:
+    name: icmptest
+    enabled: yes
+    state: absent
+    action: allow
+    direction: in
+    protocol: icmpv4
+    icmp_type_code: '8:*'
+  register: remove_firewall_rule_with_icmptypecode
+
+- name: Check that removing same firewall rule with expanded vars identified
+  assert:
+    that:
+    - remove_firewall_rule_with_icmptypecode.changed == true

--- a/tests/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/tests/integration/targets/win_firewall_rule/tasks/main.yml
@@ -179,7 +179,7 @@
     enabled: no
 
 - name: Get the actual values from the changed firewall rule
-  win_shell: '(New-Object -ComObject HNetCfg.FwPolicy2).Rules | Where-Object { $_.Name -eq "http" } | Foreach-Object { $_.LocalPorts; $_.Enabled; $_.Action; $_.Direction; $_.Protocol }'
+  ansible.windows.win_shell: '(New-Object -ComObject HNetCfg.FwPolicy2).Rules | Where-Object { $_.Name -eq "http" } | Foreach-Object { $_.LocalPorts; $_.Enabled; $_.Action; $_.Direction; $_.Protocol }'
   register: firewall_rule_actual
 
 - name: Ensure that disabling the rule did not change the previous values
@@ -411,7 +411,7 @@
   register: add_firewall_rule_with_edge_traversal
 
 # Setup action creates ansible_distribution_version variable
-- setup:
+- ansible.windows.setup:
 
 - name: Check that creating firewall rule with enge traversal option 'deferapp' succeeds with a change
   assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a new feature that allows the user to enable or disable all the firewall rules in a particular group.

Fixes https://github.com/ansible-collections/community.windows/issues/13

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When a user inputs only the group and enabled parameter than it will enable all the rules in a group.  
Removed `name` from the required parameter.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Enable all the Firewall rules in the application group
  win_firewall_rule:
    group: application
    enabled: yes
```
