### PR TITLE
Added NS feature in win_dns_record module

### DIFF
--- a/changelogs/fragments/win_dns_ns_record.yml
+++ b/changelogs/fragments/win_dns_ns_record.yml
@@ -1,3 +1,2 @@
 minor_changes:
 - win_firewall_rule - Support NS record creation,modification and deletion
-

--- a/changelogs/fragments/win_dns_ns_record.yml
+++ b/changelogs/fragments/win_dns_ns_record.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- win_firewall_rule - Support NS record creation,modification and deletion
+- win_dns_record - Support NS record creation,modification and deletion

--- a/changelogs/fragments/win_dns_ns_record.yml
+++ b/changelogs/fragments/win_dns_ns_record.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- win_firewall_rule - Support NS record creation,modification and deletion
+

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -12,7 +12,7 @@ $spec = @{
         priority = @{ type = "int"}
         state = @{ type = "str"; choices = "absent", "present"; default = "present" }
         ttl = @{ type = "int"; default = "3600" }
-        type = @{ type = "str"; choices = "A","AAAA","CNAME","PTR","SRV"; required = $true }
+        type = @{ type = "str"; choices = "A","AAAA","CNAME","NS","PTR","SRV"; required = $true }
         value = @{ type = "list"; elements = "str"; default = @() ; aliases=@( 'values' )}
         weight = @{ type = "int"}
         zone = @{ type = "str"; required = $true }
@@ -59,7 +59,7 @@ if ($ttl -lt 1 -or $ttl -gt 31557600) {
 $ttl = New-TimeSpan -Seconds $ttl
 
 
-if (($type -eq 'CNAME' -or $type -eq 'PTR' -or $type -eq 'SRV') -and $null -ne $values -and $values.Count -gt 0 -and $zone[-1] -ne '.') {
+if (($type -eq 'CNAME' -or $type -eq 'NS' -or $type -eq 'PTR' -or $type -eq 'SRV') -and $null -ne $values -and $values.Count -gt 0 -and $zone[-1] -ne '.') {
     # CNAMEs and PTRs should be '.'-terminated, or record matching will fail
     $values = $values | ForEach-Object {
         if ($_ -Like "*.") { $_ } else { "$_." }
@@ -72,7 +72,7 @@ $record_argument_name = @{
     AAAA = "IPv6Address";
     CNAME = "HostNameAlias";
     # MX = "MailExchange";
-    # NS = "NameServer";
+    NS = "NameServer";
     PTR = "PtrDomainName";
     SRV = "DomainName";
     # TXT = "DescriptiveText"

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -52,13 +52,14 @@ options:
     description:
     - The type of DNS record to manage.
     - C(SRV) was added in the 1.0.0 release of this collection.
-    choices: [ A, AAAA, CNAME, PTR, SRV ]
+    choices: [ A, AAAA, CNAME, NS, PTR, SRV ]
     required: yes
     type: str
   value:
     description:
     - The value(s) to specify. Required when C(state=present).
     - When C(type=PTR) only the partial part of the IP should be given.
+    - Multiple values can be passed when C(type=NS)
     aliases: [ values ]
     type: list
     elements: str
@@ -151,7 +152,21 @@ EXAMPLES = r'''
     state: present
     type: "SRV"
     weight: 2
-    values: "amer.example.com"
+    value: "amer.example.com"
+    zone: "example.com"
+
+# Demonstrate creating a NS record with multiple values
+
+- name: Creating NS record
+  community.windows.win_dns_record:
+    name: "ansible.prog"
+    state: present
+    type: "NS"
+    values:
+      - 10.0.0.1
+      - 10.0.0.2
+      - 10.0.0.3
+      - 10.0.0.4
     zone: "example.com"
 '''
 

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -52,6 +52,7 @@ options:
     description:
     - The type of DNS record to manage.
     - C(SRV) was added in the 1.0.0 release of this collection.
+    - C(NS) was added in the 1.1.0 release of this collection.
     choices: [ A, AAAA, CNAME, NS, PTR, SRV ]
     required: yes
     type: str

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -142,7 +142,7 @@ EXAMPLES = r'''
       - 10.0.42.12  # this new value was added
     zone: "example.com"
 
-# Demonstate creating a SRV record
+# Demonstrate creating a SRV record
 
 - name: Creating a SRV record with port number and priority
   community.windows.win_dns_record:

--- a/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
@@ -185,7 +185,7 @@
       - cmd_result_actual.stdout == 'absent\r\n'
 
 - name: 'TYPE=NS - creation with multiple values (check mode)'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com , ansible-altmirror.example.com , ansiblull-mirror.example.com], type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com,ansible-altmirror.example.com,ansiblull-mirror.example.com], type: NS}
   register: cmd_result
   check_mode: yes
 
@@ -201,7 +201,7 @@
       - cmd_result_actual.stdout == 'absent\r\n'
 
 - name: 'TYPE=NS - creation with multiple values'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com , ansible-altmirror.example.com , ansiblull-mirror.example.com], type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com,ansible-altmirror.example.com,ansiblull-mirror.example.com], type: NS}
   register: cmd_result
 
 - name: 'TYPE=NS - creation get results'
@@ -216,7 +216,7 @@
       - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
 
 - name: 'TYPE=NS - creation with multiple values (idempotent)'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com , ansible-altmirror.example.com , ansiblull-mirror.example.com] , type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com,ansible-altmirror.example.com,ansiblull-mirror.example.com] , type: NS}
   register: cmd_result
 
 - name: 'TYPE=NS - creation get results (idempotent)'

--- a/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
@@ -216,7 +216,7 @@
       - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
 
 - name: 'TYPE=NS - creation with multiple values (idempotent)'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com] , type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com], type: NS}
   register: cmd_result
 
 - name: 'TYPE=NS - creation get results (idempotent)'

--- a/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
@@ -1,0 +1,277 @@
+- name: 'TYPE=NS - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-mirror.example.com, type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS- creation'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-mirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - creation (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-mirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+
+- name: 'TYPE=NS - update address (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - update address'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-altmirror.example.com.\r\n'
+
+- name: 'TYPE=NS - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-altmirror.example.com.\r\n'
+
+
+- name: 'TYPE=NS - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, ttl: 7200, type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=NS - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, ttl: 7200, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=NS - update TTL (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, ttl: 7200, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update TTL get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update TTL check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=NS - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=NS - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - creation with multiple values (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com , ansible-altmirror.example.com , ansiblull-mirror.example.com], type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - creation with multiple values'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com , ansible-altmirror.example.com , ansiblull-mirror.example.com], type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - creation with multiple values (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com , ansible-altmirror.example.com , ansiblull-mirror.example.com] , type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=NS - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
@@ -185,7 +185,7 @@
       - cmd_result_actual.stdout == 'absent\r\n'
 
 - name: 'TYPE=NS - creation with multiple values (check mode)'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com,ansible-altmirror.example.com,ansiblull-mirror.example.com], type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com], type: NS}
   register: cmd_result
   check_mode: yes
 
@@ -201,7 +201,7 @@
       - cmd_result_actual.stdout == 'absent\r\n'
 
 - name: 'TYPE=NS - creation with multiple values'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com,ansible-altmirror.example.com,ansiblull-mirror.example.com], type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com], type: NS}
   register: cmd_result
 
 - name: 'TYPE=NS - creation get results'
@@ -216,7 +216,7 @@
       - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
 
 - name: 'TYPE=NS - creation with multiple values (idempotent)'
-  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com,ansible-altmirror.example.com,ansiblull-mirror.example.com] , type: NS}
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com] , type: NS}
   register: cmd_result
 
 - name: 'TYPE=NS - creation get results (idempotent)'

--- a/tests/integration/targets/win_dns_record/tasks/tests.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests.yml
@@ -21,6 +21,7 @@
 
    - import_tasks: tests-A.yml
    - import_tasks: tests-AAAA.yml
+   - import_tasks: tests-NS.yml
    - import_tasks: tests-SRV.yml
    - import_tasks: tests-CNAME.yml
    - import_tasks: tests-PTR.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#123 
Added a new feature of NS DNS record to an existing win_dns_record module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
type: "NS"

It will create an NS resource record or will remove it.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
name: Creating a SRV record with port number and priority
community.windows.win_dns_record:
  name: "testing" 
  state: present
  type: "NS"
  values: 
     - 10.0.0.1
     - 10.0.0.2
     - 10.0.0.3
     - 10.0.0.4
  zone: "example.com"

```
