### PR TITLE
New feature support inbound,outbound connection in win_firewall module.

### DIFF
--- a/changelogs/fragments/win_firewall_action.yml
+++ b/changelogs/fragments/win_firewall_action.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_firewall - Support inbound, outbound connection in windows firewall.

--- a/changelogs/fragments/win_firewall_action.yml
+++ b/changelogs/fragments/win_firewall_action.yml
@@ -1,3 +1,2 @@
 minor_changes:
-- win_firewall - Support inbound, outbound connection in windows firewall.
-- win_firewall - By default inbound connections are block and outbound connections are allow.
+- win_firewall - Support defining the default inbound and outbound action of traffic in Windows firewall

--- a/changelogs/fragments/win_firewall_action.yml
+++ b/changelogs/fragments/win_firewall_action.yml
@@ -1,2 +1,3 @@
 minor_changes:
 - win_firewall - Support inbound, outbound connection in windows firewall.
+- win_firewall - By default inbound connections are block and outbound connections are allow.

--- a/changelogs/fragments/win_firewall_action.yml
+++ b/changelogs/fragments/win_firewall_action.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- win_firewall - Support defining the default inbound and outbound action of traffic in Windows firewall
+- win_firewall - Support defining the default inbound and outbound action of traffic in Windows firewall.

--- a/plugins/modules/win_firewall.ps1
+++ b/plugins/modules/win_firewall.ps1
@@ -13,8 +13,8 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 
 $profiles = Get-AnsibleParam -obj $params -name "profiles" -type "list" -default @("Domain", "Private", "Public")
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -failifempty $true -validateset 'disabled','enabled'
-$inbound_action = Get-AnsibleParam -obj $params -name "inbound_action" -type "str" -validateset 'allow','block', 'not_configured'
-$outbound_action = Get-AnsibleParam -obj $params -name "outbound_action" -type "str" -validateset 'allow','block', 'not_configured'
+$inbound_action = Get-AnsibleParam -obj $params -name "inbound_action" -type "str" -validateset 'allow','block','not_configured'
+$outbound_action = Get-AnsibleParam -obj $params -name "outbound_action" -type "str" -validateset 'allow','block','not_configured'
 
 $result = @{
     changed = $false
@@ -59,7 +59,6 @@ Try {
                 $inbound_action = (Get-Culture).TextInfo.ToTitleCase(($inbound_action.ToLower() -replace "_", " ")) -replace " ", ""
                 if ($inbound_action -ne $current_inboundaction) {
                   Set-NetFirewallProfile -name $profile -DefaultInboundAction $inbound_action -WhatIf:$check_mode
-                  $result.inbound_action = $inbound_action
                   $result.changed = $true
                 }
             }
@@ -67,9 +66,8 @@ Try {
                 $outbound_action = (Get-Culture).TextInfo.ToTitleCase(($outbound_action.ToLower() -replace "_", " ")) -replace " ", ""
                 if ($null -ne $outbound_action -and $outbound_action -ne $current_outboundaction) {
                   Set-NetFirewallProfile -name $profile -DefaultOutboundAction $outbound_action -WhatIf:$check_mode
-                  $result.outbound_action = $outbound_action
                   $result.changed = $true
-                }  
+                }
             }
         } else {
 

--- a/plugins/modules/win_firewall.ps1
+++ b/plugins/modules/win_firewall.ps1
@@ -56,15 +56,15 @@ Try {
                 $result.$profile.enabled = $true
             }
             if($null -ne $inbound_action) {
-                $inbound_action = (Get-Culture).TextInfo.ToTitleCase(($inbound_action.ToLower() -replace "_", " ")) -replace " ", ""
+                $inbound_action = [Globalization.CultureInfo]::InvariantCulture.TextInfo.ToTitleCase($inbound_action.ToLower()) -replace '_', ''
                 if ($inbound_action -ne $current_inboundaction) {
                   Set-NetFirewallProfile -name $profile -DefaultInboundAction $inbound_action -WhatIf:$check_mode
                   $result.changed = $true
                 }
             }
             if($null -ne $outbound_action) {
-                $outbound_action = (Get-Culture).TextInfo.ToTitleCase(($outbound_action.ToLower() -replace "_", " ")) -replace " ", ""
-                if ($null -ne $outbound_action -and $outbound_action -ne $current_outboundaction) {
+                $outbound_action = [Globalization.CultureInfo]::InvariantCulture.TextInfo.ToTitleCase($outbound_action.ToLower()) -replace '_', ''
+                if ($outbound_action -ne $current_outboundaction) {
                   Set-NetFirewallProfile -name $profile -DefaultOutboundAction $outbound_action -WhatIf:$check_mode
                   $result.changed = $true
                 }

--- a/plugins/modules/win_firewall.py
+++ b/plugins/modules/win_firewall.py
@@ -26,16 +26,18 @@ options:
     choices: [ disabled, enabled ]
   inbound_action:
     description:
-    - Allow or block inbound network traffic in the profile.
-    - NotConfigured is valid when configuring a GPO.
+    - Set to C(allow) or C(block) inbound network traffic in the profile.
+    - C(not_configured) is valid when configuring a GPO.
     type: str
     choices: [ allow, block, not_configured ]
+    version_added: 1.1.0
   outbound_action:
     description:
-    - Allow or block inbound network traffic in the profile.
-    - NotConfigured is valid when configuring a GPO.
+    - Set to C(allow) or C(block) inbound network traffic in the profile.
+    - C(not_configured) is valid when configuring a GPO.
     type: str
     choices: [ allow, block, not_configured ]
+    version_added: 1.1.0
 seealso:
 - module: community.windows.win_firewall_rule
 author:
@@ -58,6 +60,7 @@ EXAMPLES = r'''
     profiles:
     - Domain
   tags: disable_firewall
+
 - name: Enable firewall for Domain profile and block outbound connections
   community.windows.win_firewall:
     profiles: Domain

--- a/plugins/modules/win_firewall.py
+++ b/plugins/modules/win_firewall.py
@@ -24,13 +24,13 @@ options:
     - Set state of firewall for given profile.
     type: str
     choices: [ disabled, enabled ]
-  inbound:
+  inbound_action:
     description:
     - Allow or block inbound connection in the profile.
     type: str
     choices: [ allow, block ]
     default: "block"
-  outbound:
+  outbound_action:
     description:
     - Allow or block outbound connection in the profile.
     type: str
@@ -62,7 +62,7 @@ EXAMPLES = r'''
   win_firewall:
     profiles: Domain
     state: enabled
-    outbound: block
+    outbound_action: block
   tags: block_connection
 '''
 
@@ -82,12 +82,12 @@ state:
     returned: always
     type: list
     sample: enabled
-inbound:
+inbound_action:
     description: Desired state of inbound connection
     returned: always
     type: str
     sample: block
-outbound:
+outbound_action:
     description: Desired state of outbound connection
     returned: always
     type: str

--- a/plugins/modules/win_firewall.py
+++ b/plugins/modules/win_firewall.py
@@ -26,16 +26,16 @@ options:
     choices: [ disabled, enabled ]
   inbound_action:
     description:
-    - Allow or block inbound connection in the profile.
+    - Allow or block inbound network traffic in the profile.
+    - NotConfigured is valid when configuring a GPO.
     type: str
-    choices: [ allow, block ]
-    default: "block"
+    choices: [ allow, block, not_configured ]
   outbound_action:
     description:
-    - Allow or block outbound connection in the profile.
+    - Allow or block inbound network traffic in the profile.
+    - NotConfigured is valid when configuring a GPO.
     type: str
-    choices: [ allow, block ]
-    default: "allow"
+    choices: [ allow, block, not_configured ]
 seealso:
 - module: community.windows.win_firewall_rule
 author:
@@ -59,7 +59,7 @@ EXAMPLES = r'''
     - Domain
   tags: disable_firewall
 - name: Enable firewall for Domain profile and block outbound connections
-  win_firewall:
+  community.windows.win_firewall:
     profiles: Domain
     state: enabled
     outbound_action: block
@@ -82,14 +82,4 @@ state:
     returned: always
     type: list
     sample: enabled
-inbound_action:
-    description: Desired state of inbound connection
-    returned: always
-    type: str
-    sample: block
-outbound_action:
-    description: Desired state of outbound connection
-    returned: always
-    type: str
-    sample: allow
 '''

--- a/plugins/modules/win_firewall.py
+++ b/plugins/modules/win_firewall.py
@@ -24,6 +24,18 @@ options:
     - Set state of firewall for given profile.
     type: str
     choices: [ disabled, enabled ]
+  inbound:
+    description:
+    - Allow or block inbound connection in the profile.
+    type: str
+    choices: [ allow, block ]
+    default: "block"
+  outbound:
+    description:
+    - Allow or block outbound connection in the profile.
+    type: str
+    choices: [ allow, block ]
+    default: "allow"
 seealso:
 - module: community.windows.win_firewall_rule
 author:
@@ -46,6 +58,12 @@ EXAMPLES = r'''
     profiles:
     - Domain
   tags: disable_firewall
+- name: Enable firewall for Domain profile and block outbound connections
+  win_firewall:
+    profiles: Domain
+    state: enabled
+    outbound: block
+  tags: block_connection
 '''
 
 RETURN = r'''
@@ -64,4 +82,14 @@ state:
     returned: always
     type: list
     sample: enabled
+inbound:
+    description: Desired state of inbound connection
+    returned: always
+    type: str
+    sample: block
+outbound:
+    description: Desired state of outbound connection
+    returned: always
+    type: str
+    sample: allow
 '''

--- a/tests/integration/targets/win_firewall/tasks/tests.yml
+++ b/tests/integration/targets/win_firewall/tasks/tests.yml
@@ -119,17 +119,17 @@
     - firewall_on.Private.enabled
     - firewall_on.Public.enabled
 
-- name: Turn on Windows Firewall on Domain with block inbound connection
+- name: Turn on Windows Firewall on Domain with allow inbound connection
   win_firewall:
     profiles: Domain
     state: enabled
-    inbound_action: block
+    inbound_action: allow
   register: firewall_domain_on
 
 - name: Test firewall_domain_on (normal mode)
   assert:
     that:
-    - firewall_domain_on is not changed
+    - firewall_domain_on is changed
     - firewall_domain_on.Domain.enabled
   when: not in_check_mode
 
@@ -140,11 +140,11 @@
     - firewall_domain_on.Domain.enabled
   when: in_check_mode
 
-- name: Turn on Windows Firewall on Domain again with block inbound
+- name: Turn on Windows Firewall on Domain again with allow inbound
   win_firewall:
     profiles: [ Domain ]
     state: enabled
-    inbound_action: block
+    inbound_action: allow
   register: firewall_domain_on_again
 
 - name: Test firewall_domain_on_again (normal mode)

--- a/tests/integration/targets/win_firewall/tasks/tests.yml
+++ b/tests/integration/targets/win_firewall/tasks/tests.yml
@@ -119,6 +119,89 @@
     - firewall_on.Private.enabled
     - firewall_on.Public.enabled
 
+- name: Turn on Windows Firewall on Domain with block inbound connection
+  win_firewall:
+    profiles: Domain
+    state: enabled
+    inbound: block
+  register: firewall_domain_on
+
+- name: Test firewall_domain_on (normal mode)
+  assert:
+    that:
+    - firewall_domain_on is not changed
+    - firewall_domain_on.Domain.enabled
+  when: not in_check_mode
+
+- name: Test firewall_domain_on (check-mode)
+  assert:
+    that:
+    - firewall_domain_on is changed
+    - firewall_domain_on.Domain.enabled
+  when: in_check_mode
+
+- name: Turn on Windows Firewall on Domain again with block inbound
+  win_firewall:
+    profiles: [ Domain ]
+    state: enabled
+    inbound: block
+  register: firewall_domain_on_again
+
+- name: Test firewall_domain_on_again (normal mode)
+  assert:
+    that:
+    - firewall_domain_on_again is not changed
+    - firewall_domain_on.Domain.enabled
+  when: not in_check_mode
+
+- name: Test firewall_domain_on_again (check-mode)
+  assert:
+    that:
+    - firewall_domain_on_again is changed
+    - firewall_domain_on.Domain.enabled
+  when: in_check_mode
+
+- name: Turn on Windows Firewall on Domain with allow outbound connection
+  win_firewall:
+    profiles: Domain
+    state: enabled
+    outbound: allow
+  register: firewall_domain_on
+
+- name: Test firewall_domain_on (normal mode)
+  assert:
+    that:
+    - firewall_domain_on is not changed
+    - firewall_domain_on.Domain.enabled
+  when: not in_check_mode
+
+- name: Test firewall_domain_on (check-mode)
+  assert:
+    that:
+    - firewall_domain_on is changed
+    - firewall_domain_on.Domain.enabled
+  when: in_check_mode
+
+- name: Turn on Windows Firewall on Domain again with allow outbound
+  win_firewall:
+    profiles: [ Domain ]
+    state: enabled
+    outbound: allow
+  register: firewall_domain_on_again
+
+- name: Test firewall_domain_on_again (normal mode)
+  assert:
+    that:
+    - firewall_domain_on_again is not changed
+    - firewall_domain_on.Domain.enabled
+  when: not in_check_mode
+
+- name: Test firewall_domain_on_again (check-mode)
+  assert:
+    that:
+    - firewall_domain_on_again is changed
+    - firewall_domain_on.Domain.enabled
+  when: in_check_mode
 
 # On purpose no profiles added
 - name: Turn on Windows Firewall again

--- a/tests/integration/targets/win_firewall/tasks/tests.yml
+++ b/tests/integration/targets/win_firewall/tasks/tests.yml
@@ -161,17 +161,17 @@
     - firewall_domain_on.Domain.enabled
   when: in_check_mode
 
-- name: Turn on Windows Firewall on Domain with allow outbound connection
+- name: Turn on Windows Firewall on Domain with block outbound connection
   win_firewall:
     profiles: Domain
     state: enabled
-    outbound_action: allow
+    outbound_action: block
   register: firewall_domain_on
 
 - name: Test firewall_domain_on (normal mode)
   assert:
     that:
-    - firewall_domain_on is not changed
+    - firewall_domain_on is changed
     - firewall_domain_on.Domain.enabled
   when: not in_check_mode
 
@@ -182,11 +182,11 @@
     - firewall_domain_on.Domain.enabled
   when: in_check_mode
 
-- name: Turn on Windows Firewall on Domain again with allow outbound
+- name: Turn on Windows Firewall on Domain again with block outbound connection
   win_firewall:
     profiles: [ Domain ]
     state: enabled
-    outbound_action: allow
+    outbound_action: block
   register: firewall_domain_on_again
 
 - name: Test firewall_domain_on_again (normal mode)

--- a/tests/integration/targets/win_firewall/tasks/tests.yml
+++ b/tests/integration/targets/win_firewall/tasks/tests.yml
@@ -123,7 +123,7 @@
   win_firewall:
     profiles: Domain
     state: enabled
-    inbound: block
+    inbound_action: block
   register: firewall_domain_on
 
 - name: Test firewall_domain_on (normal mode)
@@ -144,7 +144,7 @@
   win_firewall:
     profiles: [ Domain ]
     state: enabled
-    inbound: block
+    inbound_action: block
   register: firewall_domain_on_again
 
 - name: Test firewall_domain_on_again (normal mode)
@@ -165,7 +165,7 @@
   win_firewall:
     profiles: Domain
     state: enabled
-    outbound: allow
+    outbound_action: allow
   register: firewall_domain_on
 
 - name: Test firewall_domain_on (normal mode)
@@ -186,7 +186,7 @@
   win_firewall:
     profiles: [ Domain ]
     state: enabled
-    outbound: allow
+    outbound_action: allow
   register: firewall_domain_on_again
 
 - name: Test firewall_domain_on_again (normal mode)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#133 
Added a new feature of inbound, outbound connections that allow the user to either block or allow the connection in windows firewall.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Added two parameters with inbound, outbound which takes the value as allow and block.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Enable firewall for Domain profile and block outbound connections
  win_firewall:
    profiles: Domain
    state: enabled
    outbound: block
  tags: block_connection
```
