### PR TITLE
Add Proxy Option for win_psrepository

### DIFF
--- a/plugins/modules/win_psrepository.ps1
+++ b/plugins/modules/win_psrepository.ps1
@@ -23,6 +23,7 @@ $script_publish_location = Get-AnsibleParam -obj $params -name "script_publish_l
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
 $installation_policy = Get-AnsibleParam -obj $params -name "installation_policy" -type "str" -validateset "trusted", "untrusted"
 $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
+$proxy = Get-AnsibleParam -obj $params -name "proxy" -type "str" -failifempty $false
 
 $result = @{"changed" = $false}
 
@@ -48,6 +49,10 @@ $Repo = Get-PSRepository @repository_params -ErrorAction SilentlyContinue
 
 if ($installation_policy) {
     $repository_params.InstallationPolicy = $installation_policy
+}
+
+if ($proxy) {
+    $repository_params.Proxy = $Proxy
 }
 
 function Resolve-LocationParameter {

--- a/plugins/modules/win_psrepository.py
+++ b/plugins/modules/win_psrepository.py
@@ -62,6 +62,7 @@ options:
       - Proxy to use for repository.
     type: str
     required: no
+    version_added: 1.1.0
 requirements:
   - PowerShell Module L(PowerShellGet >= 1.6.0,https://www.powershellgallery.com/packages/PowerShellGet/)
   - PowerShell Module L(PackageManagement >= 1.1.7,https://www.powershellgallery.com/packages/PackageManagement/)

--- a/plugins/modules/win_psrepository.py
+++ b/plugins/modules/win_psrepository.py
@@ -57,6 +57,11 @@ options:
       - I(force) has no effect when I(state=absent). See notes for additional context.
     type: bool
     default: False
+  proxy:
+    description:
+      - Proxy to use for repository.
+    type: str
+    required: no
 requirements:
   - PowerShell Module L(PowerShellGet >= 1.6.0,https://www.powershellgallery.com/packages/PowerShellGet/)
   - PowerShell Module L(PackageManagement >= 1.1.7,https://www.powershellgallery.com/packages/PackageManagement/)


### PR DESCRIPTION
##### SUMMARY
adds an optional proxy setting for win_psrepository

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_psrepository

##### ADDITIONAL INFORMATION
When servers are located behind restrictive firewalls and require proxies to setup a repository. This allow the module to still be used.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. to reproduce build a system in a network that requires a proxy to reach your psrepository.
1. attempt to use the module.
Without Proxy
```
community.windows.win_psrepository:
    name: PSRemote
    source: "{{ my_repo }}"
    state: present
```

With Proxy
```
community.windows.win_psrepository:
    name: PSRemote
    source: "{{ my_repo }}"
    state: present
    proxy: "http://{{ proxy_addr }}"
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE
An exception occurred during task execution. To see the full traceback, use -vvv. The error was:    at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
fatal: [myhost]: FAILED! => {"changed": false, "msg": "Unhandled exception while executing module: The specified Uri 'https://repository.location.com/api/blah/blah' for parameter 'SourceLocation' is an invalid Web Uri. Please ensure that it meets the Web Uri requirements."}

AFTER
TASK [package_management : Register PSRemote] **********************************
changed: [myhost] => {"changed": true}


```
