### PR TITLE
Fixed requirements for win_scheduled_task

### DIFF
--- a/changelogs/fragments/scheduled_task_state.yml
+++ b/changelogs/fragments/scheduled_task_state.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- win_scheduled_task - Support setting human friendly ``state_change`` values on a ``session_state_change`` trigger
+- win_scheduled_task_state - Added ``state_change_str`` to the trigger output to give a human readable description of the value

--- a/changelogs/fragments/scheduled_task_state.yml
+++ b/changelogs/fragments/scheduled_task_state.yml
@@ -1,3 +1,3 @@
 minor_changes:
-- win_scheduled_task - Support setting human friendly ``state_change`` values on a ``session_state_change`` trigger
+- win_scheduled_task - Added support for setting a ``session_state_change`` trigger by documenting the human friendly values for ``state_change``
 - win_scheduled_task_state - Added ``state_change_str`` to the trigger output to give a human readable description of the value

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -624,8 +624,8 @@ Function Compare-Triggers($task_definition) {
             optional = @('enabled', 'end_boundary', 'execution_time_limit', 'random_delay', 'weeks_interval', 'repetition')
         }
         [TASK_TRIGGER_TYPE2]::TASK_TRIGGER_SESSION_STATE_CHANGE = @{
-            mandatory = @('days_of_week', 'start_boundary')
-            optional = @('delay', 'enabled', 'end_boundary', 'execution_time_limit', 'state_change', 'user_id', 'repetition')
+            mandatory = @()
+            optional = @('delay', 'enabled', 'end_boundary', 'execution_time_limit', 'repetition', 'start_boundary', 'state_change', 'user_id' )
         }
     }
     $changes = Compare-PropertyList -collection $task_triggers -property_name "trigger" -new $triggers -existing $existing_triggers -map $map -enum TASK_TRIGGER_TYPE2

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -122,6 +122,16 @@ public enum TASK_TRIGGER_TYPE2 // https://msdn.microsoft.com/en-us/library/windo
     TASK_TRIGGER_LOGON                 = 9,
     TASK_TRIGGER_SESSION_STATE_CHANGE  = 11
 }
+
+public enum TASK_SESSION_STATE_CHANGE_TYPE // https://docs.microsoft.com/en-us/windows/win32/api/taskschd/ne-taskschd-task_session_state_change_type
+{
+    TASK_CONSOLE_CONNECT	= 1,
+    TASK_CONSOLE_DISCONNECT	= 2,
+    TASK_REMOTE_CONNECT	    = 3,
+    TASK_REMOTE_DISCONNECT	= 4,
+    TASK_SESSION_LOCK	    = 7,
+    TASK_SESSION_UNLOCK	    = 8
+}
 "@
 
 $original_tmp = $env:TMP
@@ -925,6 +935,29 @@ for ($i = 0; $i -lt $triggers.Count; $i++) {
             $month_value = $null
         }
         $trigger.months_of_year = $month_value
+    }
+    if ($trigger.ContainsKey("state_change")) {
+        $trigger.state_change = if ($trigger.state_change -in @(1, 'console_connect')) {
+            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_CONSOLE_CONNECT
+        }
+        elseif ($trigger.state_change -in @(2, 'console_disconnect')) {
+            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_CONSOLE_DISCONNECT
+        }
+        elseif ($trigger.state_change -in @(3, 'remote_connect')) {
+            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_REMOTE_CONNECT
+        }
+        elseif ($trigger.state_change -in @(4, 'remote_disconnect')) {
+            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_REMOTE_DISCONNECT
+        }
+        elseif ($trigger.state_change -in @(7, 'session_lock')) {
+            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_SESSION_LOCK
+        }
+        elseif ($trigger.state_change -in @(8, 'session_unlock')) {
+            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_SESSION_UNLOCK
+        }
+        else {
+            Fail-Json -obj $result -message "invalid state_change '$($trigger.state_change)'"
+        }
     }
     $triggers[$i] = $trigger
 }

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -125,12 +125,12 @@ public enum TASK_TRIGGER_TYPE2 // https://msdn.microsoft.com/en-us/library/windo
 
 public enum TASK_SESSION_STATE_CHANGE_TYPE // https://docs.microsoft.com/en-us/windows/win32/api/taskschd/ne-taskschd-task_session_state_change_type
 {
-    TASK_CONSOLE_CONNECT	= 1,
-    TASK_CONSOLE_DISCONNECT	= 2,
-    TASK_REMOTE_CONNECT	    = 3,
-    TASK_REMOTE_DISCONNECT	= 4,
-    TASK_SESSION_LOCK	    = 7,
-    TASK_SESSION_UNLOCK	    = 8
+    TASK_CONSOLE_CONNECT    = 1,
+    TASK_CONSOLE_DISCONNECT = 2,
+    TASK_REMOTE_CONNECT     = 3,
+    TASK_REMOTE_DISCONNECT  = 4,
+    TASK_SESSION_LOCK       = 7,
+    TASK_SESSION_UNLOCK     = 8
 }
 "@
 
@@ -937,26 +937,16 @@ for ($i = 0; $i -lt $triggers.Count; $i++) {
         $trigger.months_of_year = $month_value
     }
     if ($trigger.ContainsKey("state_change")) {
-        $trigger.state_change = if ($trigger.state_change -in @(1, 'console_connect')) {
-            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_CONSOLE_CONNECT
-        }
-        elseif ($trigger.state_change -in @(2, 'console_disconnect')) {
-            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_CONSOLE_DISCONNECT
-        }
-        elseif ($trigger.state_change -in @(3, 'remote_connect')) {
-            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_REMOTE_CONNECT
-        }
-        elseif ($trigger.state_change -in @(4, 'remote_disconnect')) {
-            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_REMOTE_DISCONNECT
-        }
-        elseif ($trigger.state_change -in @(7, 'session_lock')) {
-            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_SESSION_LOCK
-        }
-        elseif ($trigger.state_change -in @(8, 'session_unlock')) {
-            [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_SESSION_UNLOCK
-        }
-        else {
-            Fail-Json -obj $result -message "invalid state_change '$($trigger.state_change)'"
+        $trigger.state_change = switch($trigger.state_change) {
+            console_connect { [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_CONSOLE_CONNECT }
+            console_disconnect { [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_CONSOLE_DISCONNECT }
+            remote_connect { [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_REMOTE_CONNECT }
+            remote_disconnect { [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_REMOTE_DISCONNECT }
+            session_lock { [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_SESSION_LOCK }
+            session_unlock { [TASK_SESSION_STATE_CHANGE_TYPE]::TASK_SESSION_UNLOCK }
+            default {
+                Fail-Json -obj $result -message "invalid state_change '$($trigger.state_change)'"
+            }
         }
     }
     $triggers[$i] = $trigger

--- a/plugins/modules/win_scheduled_task.py
+++ b/plugins/modules/win_scheduled_task.py
@@ -94,7 +94,7 @@ options:
           the date on which the trigger is activated, you can set any date even
           ones in the past.
         - Required when C(type) is C(daily), C(monthlydow), C(monthly),
-          C(time), C(weekly), (session_state_change).
+          C(time), C(weekly).
         - Optional for the rest of the trigger types.
         - This is in ISO 8601 DateTime format C(YYYY-MM-DDThh:mm:ss).
         type: str
@@ -145,7 +145,7 @@ options:
         - The days of the week for the trigger.
         - Can be a list or comma separated string of full day names e.g. monday
           instead of mon.
-        - Required when C(type) is C(weekly), C(type=session_state_change).
+        - Required when C(type) is C(weekly).
         - Optional when C(type=monthlydow).
         type: str
       days_of_month:
@@ -209,6 +209,18 @@ options:
             description:
             - Whether a running instance of the task is stopped at the end of the repetition pattern.
             type: bool
+      state_change:
+        description:
+        - Allows you to define the kind of Terminal Server session change that triggers a task.
+        - Optional when C(type=session_state_change)
+        - C(1) means TASK_CONSOLE_CONNECT
+        - C(2) means TASK_CONSOLE_DISCONNECT
+        - C(3) means TASK_REMOTE_CONNECT
+        - C(4) means TASK_REMOTE_DISCONNECT
+        - C(7) means TASK_SESSION_LOCK
+        - C(8) means TASK_SESSION_UNLOCK
+        type: int
+        choices: [ 1, 2, 3, 4, 7, 8 ]
 
   # Principal options
   display_name:

--- a/plugins/modules/win_scheduled_task.py
+++ b/plugins/modules/win_scheduled_task.py
@@ -212,15 +212,16 @@ options:
       state_change:
         description:
         - Allows you to define the kind of Terminal Server session change that triggers a task.
+        - Before C(v1.6.0) of this collection this could only be set by the raw integer values.
         - Optional when C(type=session_state_change)
-        - C(1) means TASK_CONSOLE_CONNECT
-        - C(2) means TASK_CONSOLE_DISCONNECT
-        - C(3) means TASK_REMOTE_CONNECT
-        - C(4) means TASK_REMOTE_DISCONNECT
-        - C(7) means TASK_SESSION_LOCK
-        - C(8) means TASK_SESSION_UNLOCK
-        type: int
-        choices: [ 1, 2, 3, 4, 7, 8 ]
+        type: str
+        choices:
+        - console_connect
+        - console_disconnect
+        - remote_connect
+        - remote_disconnect
+        - session_lock
+        - session_unlock
 
   # Principal options
   display_name:

--- a/plugins/modules/win_scheduled_task.py
+++ b/plugins/modules/win_scheduled_task.py
@@ -212,7 +212,6 @@ options:
       state_change:
         description:
         - Allows you to define the kind of Terminal Server session change that triggers a task.
-        - Before C(v1.6.0) of this collection this could only be set by the raw integer values.
         - Optional when C(type=session_state_change)
         type: str
         choices:
@@ -222,6 +221,7 @@ options:
         - remote_disconnect
         - session_lock
         - session_unlock
+        version_added: 1.6.0
 
   # Principal options
   display_name:

--- a/plugins/modules/win_scheduled_task_stat.ps1
+++ b/plugins/modules/win_scheduled_task_stat.ps1
@@ -67,6 +67,16 @@ public enum TASK_TRIGGER_TYPE2
     TASK_TRIGGER_LOGON                 = 9,
     TASK_TRIGGER_SESSION_STATE_CHANGE  = 11
 }
+
+public enum TASK_SESSION_STATE_CHANGE_TYPE
+{
+    TASK_CONSOLE_CONNECT	= 1,
+    TASK_CONSOLE_DISCONNECT	= 2,
+    TASK_REMOTE_CONNECT	    = 3,
+    TASK_REMOTE_DISCONNECT	= 4,
+    TASK_SESSION_LOCK	    = 7,
+    TASK_SESSION_UNLOCK	    = 8
+}
 "@
 
 $original_tmp = $env:TMP
@@ -314,7 +324,16 @@ if ($null -ne $name) {
 
                 Get-Member -InputObject $item -MemberType Property | ForEach-Object {
                     if ($_.Name -notin $ignored_properties) {
-                        $item_info.$($_.Name) = (Get-PropertyValue -task_property $property -com $item -property $_.Name)
+                        $value = (Get-PropertyValue -task_property $property -com $item -property $_.Name)
+                        $item_info.$($_.Name) = $value
+
+                        # This was added after StateChange was represented by the raw enum value so we include both
+                        # for backwards compatibility.
+                        if ($_.Name -eq 'StateChange') {
+                            $item_info.StateChangeStr = if ($value) {
+                                [Enum]::ToObject([TASK_SESSION_STATE_CHANGE_TYPE], $value).ToString()
+                            }
+                        }
                     }
                 }
                 $result.$property += $item_info

--- a/tests/integration/targets/win_scheduled_task/tasks/main.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/main.yml
@@ -10,7 +10,7 @@
     include_tasks: tests.yml
 
   - include_tasks: clean.yml
-  
+
   - name: Test principals
     include_tasks: principals.yml
 
@@ -18,7 +18,7 @@
 
   - name: Test triggers
     include_tasks: triggers.yml
-  
+
   always:
   - name: remove test tasks after test
     include_tasks: clean.yml

--- a/tests/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -257,6 +257,10 @@
     name: '{{test_scheduled_task_name}}'
   register: trigger_monthlydow_result
 
+- name: get expected date based on host timezone
+  ansible.windows.win_shell: (Get-Date '1999-12-31T21:00:01+00:00').ToString('yyyy-MM-ddTHH:mm:sszzz')
+  register: trigger_monthlydow_date
+
 - name: assert results of create monthly dow trigger
   assert:
     that:
@@ -265,7 +269,7 @@
     - trigger_monthlydow_result.triggers|count == 1
     - trigger_monthlydow_result.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
     - trigger_monthlydow_result.triggers[0].enabled == True
-    - trigger_monthlydow_result.triggers[0].start_boundary == "1999-12-31T21:00:01+00:00"
+    - trigger_monthlydow_result.triggers[0].start_boundary == trigger_monthlydow_date.stdout|trim
     - trigger_monthlydow_result.triggers[0].end_boundary == None
     - trigger_monthlydow_result.triggers[0].weeks_of_month == "1,2"
     - trigger_monthlydow_result.triggers[0].days_of_week == "monday,wednesday"
@@ -321,7 +325,7 @@
     - create_trigger_repetition_result_check.triggers|count == 1
     - create_trigger_repetition_result_check.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
     - create_trigger_repetition_result_check.triggers[0].enabled == True
-    - create_trigger_repetition_result_check.triggers[0].start_boundary == "1999-12-31T21:00:01+00:00"
+    - create_trigger_repetition_result_check.triggers[0].start_boundary == trigger_monthlydow_date.stdout|trim
     - create_trigger_repetition_result_check.triggers[0].end_boundary == None
     - create_trigger_repetition_result_check.triggers[0].weeks_of_month == "1,2"
     - create_trigger_repetition_result_check.triggers[0].days_of_week == "monday,wednesday"
@@ -470,6 +474,33 @@
     that:
     - change_trigger_repetition_again is not changed
 
+- name: create trigger with state_change
+  win_scheduled_task:
+    name: '{{ test_scheduled_task_name }}'
+    state: present
+    actions:
+    - path: cmd.exe
+    triggers:
+    - type: session_state_change
+      state_change: session_lock
+  register: trigger_state_change
+
+- name: get result of create trigger with state change
+  win_scheduled_task_stat:
+    path: \
+    name: '{{ test_scheduled_task_name }}'
+  register: trigger_state_change_result
+
+- name: assert results of create trigger with state_change
+  assert:
+    that:
+    - trigger_state_change is changed
+    - trigger_state_change_result.triggers|count == 1
+    - trigger_state_change_result.triggers[0].type == "TASK_TRIGGER_SESSION_STATE_CHANGE"
+    - trigger_state_change_result.triggers[0].state_change == 7
+    - trigger_state_change_result.triggers[0].state_change_str == "TASK_SESSION_LOCK"
+    - trigger_state_change_result.triggers[0].user_id == None
+
 - name: create task with multiple triggers (check mode)
   win_scheduled_task:
     name: '{{test_scheduled_task_name}}'
@@ -503,13 +534,10 @@
     - create_multiple_triggers_check is changed
     - create_multiple_triggers_result_check.task_exists == True
     - create_multiple_triggers_result_check.triggers|count == 1
-    - create_multiple_triggers_result_check.triggers[0].type == "TASK_TRIGGER_REGISTRATION"
-    - create_multiple_triggers_result_check.triggers[0].enabled == True
-    - create_multiple_triggers_result_check.triggers[0].start_boundary == None
-    - create_multiple_triggers_result_check.triggers[0].end_boundary == None
-    - create_multiple_triggers_result_check.triggers[0].repetition.interval == "PT10M"
-    - create_multiple_triggers_result_check.triggers[0].repetition.duration == "PT20M"
-    - create_multiple_triggers_result_check.triggers[0].repetition.stop_at_duration_end == False
+    - create_multiple_triggers_result_check.triggers[0].type == "TASK_TRIGGER_SESSION_STATE_CHANGE"
+    - create_multiple_triggers_result_check.triggers[0].state_change == 7
+    - create_multiple_triggers_result_check.triggers[0].state_change_str == "TASK_SESSION_LOCK"
+    - create_multiple_triggers_result_check.triggers[0].user_id == None
 
 - name: create task with multiple triggers
   win_scheduled_task:

--- a/tests/integration/targets/win_scheduled_task_stat/tasks/main.yml
+++ b/tests/integration/targets/win_scheduled_task_stat/tasks/main.yml
@@ -62,6 +62,9 @@
       months_of_year: june,december
       run_on_last_day_of_month: true
       start_boundary: '2017-09-20T03:44:38'
+    - type: session_state_change
+      state_change: console_disconnect
+      user_id: '{{ admin_account_name }}'
 
 - name: get stat of existing folder with task
   win_scheduled_task_stat:
@@ -131,7 +134,7 @@
     - stat_task_present.settings.restart_count == 3
     - stat_task_present.settings.restart_interval == "PT15M"
     - stat_task_present.state.status == "TASK_STATE_READY"
-    - stat_task_present.triggers|count == 2
+    - stat_task_present.triggers|count == 3
     - stat_task_present.triggers[0].delay == "PT15M"
     - stat_task_present.triggers[0].type == "TASK_TRIGGER_BOOT"
     - stat_task_present.triggers[0].repetition.stop_at_duration_end == False
@@ -145,6 +148,10 @@
     - stat_task_present.triggers[1].repetition.stop_at_duration_end == False
     - stat_task_present.triggers[1].repetition.duration == None
     - stat_task_present.triggers[1].repetition.interval == None
+    - stat_task_present.triggers[2].type == "TASK_TRIGGER_SESSION_STATE_CHANGE"
+    - stat_task_present.triggers[2].user_id.endswith(admin_account_name)
+    - stat_task_present.triggers[2].state_change == 2
+    - stat_task_present.triggers[2].state_change_str == "TASK_CONSOLE_DISCONNECT"
 
 - name: change principal to system account so it will run in the next step
   win_scheduled_task:


### PR DESCRIPTION
* Removed unneeded required properties

* Added (already supported) trigger state_change to documentation

##### SUMMARY

Fixes the inability to use `session_state_change` trigger types in scheduled tasks. The module was requiring properties that were not permitted by Powershell. Also added in the documentation for the `state_change` property which, although supported, was not documented.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Supporting documentation for the Scheduled Task State Change Trigger: https://docs.microsoft.com/en-us/windows/win32/taskschd/sessionstatechangetrigger

Supporting documentation for the Scheduled Task State Change Trigger expected state change type: https://docs.microsoft.com/en-us/windows/win32/taskschd/sessionstatechangetrigger-statechange

When running the playbook, an error would be thrown that the key was mandatory:
```
fatal: [172.24.0.160]: FAILED! => {"changed": true, "msg": "mandatory key 'days_of_week' for trigger is not set, mandatory keys are 'days_of_week', 'start_boundary'"}
```

But when you included it, Powershell rejected it:
```
fatal: [172.24.0.160]: FAILED! => {"changed": false, "msg": "failed to set trigger property 'DaysOfWeek' to '127': Exception setting \"DaysOfWeek\": \"The property 'DaysOfWeek' cannot be found on this object. Verify that the property exists and can be set.\""}
```
