### PR TITLE
fix Get-ADPrincipalGroupMembership command

### DIFF
--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -126,7 +126,7 @@ if ($null -ne $domain_server) {
 Function Get-PrincipalGroups {
     Param ($identity, $args_extra)
     try{
-        $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -ErrorAction Stop
+        $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -ResourceContextServer $domain_server -ErrorAction Stop
     } catch {
         Add-Warning -obj $result -message "Failed to enumerate user groups but continuing on.: $($_.Exception.Message)"
         return @()


### PR DESCRIPTION
##### SUMMARY
Fixes #71 as I added the parameter "ResourceContextServer" to Get-ADPrincipalGroupMembership

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user

##### ADDITIONAL INFORMATION
Fixes the error "The server is not operational" when using the Module win_domain_user in specific environments.
