### PR TITLE
Fixed get-adprincipalgroupmembership

### DIFF
--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -126,7 +126,7 @@ if ($null -ne $domain_server) {
 Function Get-PrincipalGroups {
     Param ($identity, $args_extra)
     try{
-        $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -ErrorAction Stop
+        $groups = Get-ADPrincipalGroupMembership -Identity $identity @args_extra -Server $domain_server -ErrorAction Stop
     } catch {
         Add-Warning -obj $result -message "Failed to enumerate user groups but continuing on.: $($_.Exception.Message)"
         return @()


### PR DESCRIPTION
##### SUMMARY
Fixes #71 when `Get-ADPrincipalGroupMembership` results in Error `The server is not operational`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user

##### ADDITIONAL INFORMATION
Added `-Server` to `Get-ADPrincipalGroupMembership` on line 131
