### PR TITLE
add computer name parameter to win_dns_zone module

### DIFF
--- a/changelogs/fragments/cjpit.yml
+++ b/changelogs/fragments/cjpit.yml
@@ -1,0 +1,3 @@
+minor_changes:
+    - win_dns_record - Added ``server`` to specify the DNS server to connect to when managing the zone object. This replaces the ``computer_name`` option.
+    - win_dns_zone - Added ``server`` to specify the DNS server to connect to when managing the zone object

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -16,7 +16,7 @@ $spec = @{
         value = @{ type = "list"; elements = "str"; default = @() ; aliases=@( 'values' )}
         weight = @{ type = "int"}
         zone = @{ type = "str"; required = $true }
-        computer_name = @{ type = "str" }
+        server = @{ type = "str" }
     }
     required_if = @(,@("type", "SRV", @("port", "priority", "weight")))
     supports_check_mode = $true
@@ -33,12 +33,12 @@ $type = $module.Params.type
 $values = $module.Params.value
 $weight = $module.Params.weight
 $zone = $module.Params.zone
-$dns_computer_name = $module.Params.computer_name
+$server = $module.Params.server
 
 
 $extra_args = @{}
-if ($null -ne $dns_computer_name) {
-    $extra_args.ComputerName = $dns_computer_name
+if ($null -ne $server) {
+    $extra_args.ComputerName = $server
 }
 
 if ($state -eq 'present') {

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -77,12 +77,13 @@ options:
     - The zone must already exist.
     required: yes
     type: str
-  computer_name:
+  server:
     description:
       - Specifies a DNS server.
       - You can specify an IP address or any value that resolves to an IP
         address, such as a fully qualified domain name (FQDN), host name, or
         NETBIOS name.
+    version_added: 1.2.0
     type: str
 '''
 

--- a/plugins/modules/win_dns_zone.ps1
+++ b/plugins/modules/win_dns_zone.ps1
@@ -15,7 +15,7 @@ $spec = @{
         state = @{ type = "str"; choices = "absent", "present"; default = "present" }
         forwarder_timeout = @{ type = "int" }
         dns_servers = @{ type = "list"; elements = "str" }
-        computer_name = @{ type = "str" }
+        server = @{ type = "str" }
     }
     supports_check_mode = $true
 }
@@ -30,12 +30,12 @@ $dynamic_update = $module.Params.dynamic_update
 $state = $module.Params.state
 $dns_servers = $module.Params.dns_servers
 $forwarder_timeout = $module.Params.forwarder_timeout
-$dns_computer_name = $module.Params.computer_name
+$server = $module.Params.server
 
 
 $extra_args = @{}
-if ($null -ne $dns_computer_name) {
-    $extra_args.ComputerName = $dns_computer_name
+if ($null -ne $server) {
+    $extra_args.ComputerName = $server
 }
 
 $parms = @{ name = $name }

--- a/plugins/modules/win_dns_zone.py
+++ b/plugins/modules/win_dns_zone.py
@@ -80,12 +80,13 @@ options:
       - At least one server is required.
     elements: str
     type: list
-  computer_name:
+  server:
     description:
       - Specifies a DNS server.
       - You can specify an IP address or any value that resolves to an IP
         address, such as a fully qualified domain name (FQDN), host name, or
         NETBIOS name.
+    version_added: 1.2.0
     type: str
 '''
 

--- a/plugins/modules/win_dns_zone.py
+++ b/plugins/modules/win_dns_zone.py
@@ -80,6 +80,13 @@ options:
       - At least one server is required.
     elements: str
     type: list
+  computer_name:
+    description:
+      - Specifies a DNS server.
+      - You can specify an IP address or any value that resolves to an IP
+        address, such as a fully qualified domain name (FQDN), host name, or
+        NETBIOS name.
+    type: str
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### SUMMARY
Adds computer name parameter, similar to win_dns_record

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_dns_zone

##### ADDITIONAL INFORMATION
https://docs.microsoft.com/en-us/powershell/module/dnsserver/add-dnsserverprimaryzone?view=win10-ps


