### PR TITLE
win_security_policy - fix encoding issue with non-ASCII chars

### DIFF
--- a/changelogs/fragments/win_security_policy_encoding.yml
+++ b/changelogs/fragments/win_security_policy_encoding.yml
@@ -1,2 +1,3 @@
 bugfixes:
 - win_security_policy - read config file with correct encoding to avoid breaking non-ASCII chars
+- win_security_policy - strip of null char added by secedit for ``LegalNoticeText`` so the existing value is preserved

--- a/changelogs/fragments/win_security_policy_encoding.yml
+++ b/changelogs/fragments/win_security_policy_encoding.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_security_policy - read config file with correct encoding to avoid breaking non-ASCII chars

--- a/plugins/modules/win_security_policy.ps1
+++ b/plugins/modules/win_security_policy.ps1
@@ -105,10 +105,10 @@ Function Import-SecEdit($ini) {
     # We manually trim off that extra null char so the legal text does not contain the unknown character symbol.
     $legalPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
     $legalName = 'LegalNoticeText'
-    $prop = Get-ItemProperty -Path $legalPath
+    $prop = Get-ItemProperty -LiteralPath $legalPath
     if ($legalName -in $prop.PSObject.Properties.Name) {
         $existingText = $prop.LegalNoticeText.TrimEnd("`0")
-        Set-ItemProperty -Path $legalPath -Name $legalName -Value $existingText
+        Set-ItemProperty -LiteralPath $legalPath -Name $legalName -Value $existingText
     }
 }
 

--- a/tests/integration/targets/win_security_policy/tasks/main.yml
+++ b/tests/integration/targets/win_security_policy/tasks/main.yml
@@ -11,6 +11,12 @@
     key: NewGuestName
   register: before_value_guest
 
+- name: get current value for the LegalNoticeText
+  ansible.windows.win_reg_stat:
+    path: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System
+    name: LegalNoticeText
+  register: original_legal_notice
+
 - block:
   - name: set AuditSystemEvents entry before tests
     win_security_policy:
@@ -23,9 +29,28 @@
       section: System Access
       key: NewGuestName
       value: Guest
-  
+
+  - name: set LegalNoticeText with non-ASCII chars
+    ansible.windows.win_regedit:
+      path: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System
+      name: LegalNoticeText
+      data: Légal Noticé
+
   - name: run tests
     include_tasks: tests.yml
+
+  # https://github.com/ansible-collections/community.windows/issues/153
+  - name: get the value for the LegalNoticeText after running tests
+    ansible.windows.win_reg_stat:
+      path: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System
+      name: LegalNoticeText
+    register: legal_notice
+
+  - name: verify the non-ASCII chars weren't corrupted
+    assert:
+      that:
+      # secedit adds the NUL char, the original value stays the same though
+      - legal_notice.value == "Légal Noticé\u0000"
 
   always:
   - name: reset entries for AuditSystemEvents
@@ -39,3 +64,9 @@
       section: System Access
       key: NewGuestName
       value: "{{before_value_guest.value}}"
+
+  - name: reset LegalNoticeText
+    ansible.windows.win_regedit:
+      path: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System
+      name: LegalNoticeText
+      data: '{{ original_legal_notice.value }}'

--- a/tests/integration/targets/win_security_policy/tasks/main.yml
+++ b/tests/integration/targets/win_security_policy/tasks/main.yml
@@ -34,7 +34,7 @@
     ansible.windows.win_regedit:
       path: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System
       name: LegalNoticeText
-      data: Légal Noticé
+      data: "Légal Noticé\r\nNewline"
 
   - name: run tests
     include_tasks: tests.yml
@@ -49,8 +49,7 @@
   - name: verify the non-ASCII chars weren't corrupted
     assert:
       that:
-      # secedit adds the NUL char, the original value stays the same though
-      - legal_notice.value == "Légal Noticé\u0000"
+      - legal_notice.value == "Légal Noticé\r\nNewline"
 
   always:
   - name: reset entries for AuditSystemEvents


### PR DESCRIPTION
##### SUMMARY
The `secedit.exe` command exports the ini in an interesting way. Here is the logic as I understand it based on the path specified by `/cfg`:

* Path does not exist
    * Use UTF-16-LE
* Path exists with a UTF-16-LE BOM
    * Uses UTF-16-LE
* Path exists but does not have UTF-16-LE BOM
    * Use the system's "ANSI" encoding

Our current code uses `[IO.Path]::GetTempFileName()` to get the temp path for the cfg file and this creates a blank file resulting in the ini being encoded using the ANSI encoding. When we go to read this file it seems like the switch statement reads it as UTF-8 breaking any non-ASCII chars that may be set for any existing policies.

What this code does is makes sure the cfg file has the UTF-16-LE BOM so our parser reads it correctly without breaking any non-ASCII chars. While not necessary we also make sure the method to import the ini uses UTF-16-LE to avoid any issues with secedit trying to read some of those non-ASCII chars in the future.

Fixes https://github.com/ansible-collections/community.windows/issues/153

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_security_policy