### PR TITLE
win_partition: Return size as number when set in bytes

### DIFF
--- a/changelogs/fragments/159-win_partition_bytes_as_number.yaml
+++ b/changelogs/fragments/159-win_partition_bytes_as_number.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_partition - fix size comparison errors when size specified in bytes

--- a/changelogs/fragments/159-win_partition_bytes_as_number.yaml
+++ b/changelogs/fragments/159-win_partition_bytes_as_number.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - win_partition - fix size comparison errors when size specified in bytes
+  - win_partition - fix size comparison errors when size specified in bytes (https://github.com/ansible-collections/community.windows/pull/159)

--- a/plugins/modules/win_partition.ps1
+++ b/plugins/modules/win_partition.ps1
@@ -69,7 +69,7 @@ function Convert-SizeToBytes {
     )
 
     switch ($Units) {
-        "B"   { return $Size }
+        "B"   { return 1 * $Size }
         "KB"  { return 1000 * $Size }
         "KiB" { return 1024 * $Size }
         "MB"  { return [Math]::Pow(1000, 2) * $Size }


### PR DESCRIPTION
##### SUMMARY
Small change to ensure size is returned as a number when set in bytes

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
win_partition

##### ADDITIONAL INFORMATION
win_partition can return incorrect size comparisons when the size is submitted in bytes as the value was returned as a string rather than a number.

This PR returns the partition size as a number even when submitted in bytes so the size comparison works.

Before change:
```paste below
    "msg": "Specified partition size (53687091200) exceeds size supported by the partition (107238899200)"

```
