### PR TITLE
win_scheduled_task_stat - add check mode support

### DIFF
--- a/changelogs/fragments/167-win_scheduled_task_stat-check_mode.yml
+++ b/changelogs/fragments/167-win_scheduled_task_stat-check_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_scheduled_task_stat - add check mode support (https://github.com/ansible-collections/community.windows/pull/167)

--- a/plugins/modules/win_scheduled_task_stat.ps1
+++ b/plugins/modules/win_scheduled_task_stat.ps1
@@ -7,7 +7,7 @@
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.SID
 
-$params = Parse-Args -arguments $args
+$params = Parse-Args -arguments $args -supports_check_mode $true
 $_remote_tmp = Get-AnsibleParam $params "_ansible_remote_tmp" -type "path" -default $env:TMP
 
 $path = Get-AnsibleParam -obj $params -name "path" -type "str" -default "\"

--- a/tests/integration/targets/win_scheduled_task_stat/tasks/main.yml
+++ b/tests/integration/targets/win_scheduled_task_stat/tasks/main.yml
@@ -14,6 +14,18 @@
     state: absent
 
 # folder stat tests
+
+# check_mode operation test
+- name: check_mode - get stat of a folder that is missing
+  win_scheduled_task_stat:
+    path: '{{test_scheduled_task_stat_path}}'
+  register: stat_folder_missing
+  check_mode: True
+
+- name: assert that check_mode works
+  assert:
+    that: stat_folder_missing is not skipped
+
 - name: get stat of a folder that is missing
   win_scheduled_task_stat:
     path: '{{test_scheduled_task_stat_path}}'


### PR DESCRIPTION
##### SUMMARY
Fixes #51

- Adds support for `check_mode` in `win_scheduled_task_stat`
- Adds a test to prevent regression (ensure check mode doesn't skip)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_scheduled_task_stat.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
