### PR TITLE
win_scheduled_task - Validate task names against forbidden characters

### DIFF
--- a/changelogs/fragments/168-win_scheduled_task-invalid-task-name.yml
+++ b/changelogs/fragments/168-win_scheduled_task-invalid-task-name.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_scheduled_task - validate task name against invalid characters (https://github.com/ansible-collections/community.windows/pull/168)

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -665,6 +665,15 @@ Function Test-XmlDurationFormat($key, $value) {
 ######################################
 ### VALIDATION/BUILDING OF OPTIONS ###
 ######################################
+
+# invalid characters in task name
+$invalid_name_chars = '\/:*?"<>|'
+$invalid_name_chars_regex = "[$([regex]::Escape($invalid_name_chars))]"
+
+if ($name -cmatch $invalid_name_chars_regex) {
+    Fail-Json -obj $result -message "Invalid task name '$name'. The following characters are not valid: $invalid_name_chars"
+}
+
 # convert username and group to SID if set
 $username_sid = $null
 if ($username) {

--- a/tests/integration/targets/win_scheduled_task/defaults/main.yml
+++ b/tests/integration/targets/win_scheduled_task/defaults/main.yml
@@ -3,3 +3,13 @@ test_scheduled_task_name: Ansible Test
 test_scheduled_task_path: \Ansible Test Folder
 test_scheduled_task_user: MooCow
 test_scheduled_task_pass: Password01
+
+test_scheduled_task_invalid_chars:
+  - '\'
+  - '/'
+  - ':'
+  - '*'
+  - '"'
+  - '<'
+  - '>'
+  - '|'

--- a/tests/integration/targets/win_scheduled_task/tasks/failures.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/failures.yml
@@ -1,5 +1,17 @@
 # test out the known failure cases to ensure we have decent error messages
 ---
+# ensure we have good error messages for invalid task chars
+- name: fail to create tasks with invalid characters
+  win_scheduled_task:
+    name: "Bad {{ item }} {{ test_scheduled_task_name }}"
+    state: present
+    actions:
+      - path: cmd.exe
+        arguments: /c echo hi
+  loop: "{{ test_scheduled_task_invalid_chars }}"
+  register: fail_invalid_chars
+  failed_when: fail_invalid_chars is not failed or fail_invalid_chars.msg is not search('The following characters are not valid')
+
 - name: fail create task without an action
   win_scheduled_task:
     name: '{{test_scheduled_task_name}}'


### PR DESCRIPTION
##### SUMMARY
Fixes: #60

- Does early validation with a friendly error message for scheduled tasks that contain invalid characters ( `\ / : * ? " < > |` )
- Added test to ensure these are caught with the right error message

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_scheduled_task.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
