### PR TITLE
win_psrepository_copy - new module

### DIFF
--- a/plugins/modules/win_psrepository_copy.ps1
+++ b/plugins/modules/win_psrepository_copy.ps1
@@ -1,0 +1,234 @@
+#!powershell
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    supports_check_mode = $true
+    options = @{
+        source = @{
+            type = 'path'
+            default = '%LOCALAPPDATA%\Microsoft\Windows\PowerShell\PowerShellGet\PSRepositories.xml'
+        }
+        name = @{
+            type = 'list'
+            elements = 'str'
+            default = @(
+                '*'
+            )
+        }
+        exclude = @{
+            type = 'list'
+            elements = 'str'
+        }
+        profiles = @{
+            type = 'list'
+            elements = 'str'
+            default = @(
+                '*'
+            )
+        }
+        exclude_profiles = @{
+            type = 'list'
+            elements = 'str'
+            default = @(
+                'systemprofile'
+                'LocalService'
+                'NetworkService'
+            )
+        }
+    }
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Diff.changed = @{}
+$module.Diff.unchanged = @{}
+
+function Select-Wildcard {
+    <#
+        .SYNOPSIS
+        Compares a value to an Include and Exclude list of wildcards,
+        returning the input object if a match is found
+
+        .DESCRIPTION
+        If $Property is specified, that property of the input object is
+        compared rather than the object itself, but the original object
+        is returned, not the property.
+    #>
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [object]
+        $InputObject ,
+
+        [Parameter()]
+        [String]
+        $Property ,
+
+        [Parameter()]
+        [String[]]
+        $Include ,
+
+        [Parameter()]
+        [String[]]
+        $Exclude
+    )
+
+    Process {
+        $o = if ($Property) {
+            $InputObject.($Property)
+        }
+        else {
+            $InputObject
+        }
+
+        foreach ($inc in $Include) {
+            $imatch = $o -like $inc
+            if ($imatch) {
+                break
+            }
+        }
+
+        if (-not $imatch) {
+            return
+        }
+
+        foreach ($exc in $Exclude) {
+            if ($o -like $exc) {
+                return
+            }
+        }
+
+        $InputObject
+    }
+}
+
+function Get-ProfileDirectory {
+    <#
+        .SYNOPSIS
+        Returns DirectoryInfo objects for each profile on the system, as reported by the registry
+
+        .DESCRIPTION
+        The special "Default" profile, used as a template for newly created users, is explicitly
+        added to the list of possible profiles returned. Public is explicitly excluded.
+        Paths reported by the registry that don't exist on the filesystem are silently skipped.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.IO.DirectoryInfo])]
+    param(
+        [Parameter()]
+        [String[]]
+        $Include ,
+
+        [Parameter()]
+        [String[]]
+        $Exclude
+    )
+
+    $regPL = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList'
+
+    # note: this is a key named "Default", not the (Default) key
+    $default = Get-ItemProperty -LiteralPath $regPL | Select-Object -ExpandProperty Default
+
+    # "ProfileImagePath" is always the local side of the profile, even if roaming profiles are used
+    # This is what we want, because PSRepositories are stored in AppData/Local and don't roam
+    $profiles = (
+        @($default) +
+        (Get-ChildItem -LiteralPath $regPL | Get-ItemProperty | Select-Object -ExpandProperty ProfileImagePath)
+    ) -as [System.IO.DirectoryInfo[]]
+
+    $profiles |
+        Where-Object -Property Exists -EQ $true |
+        Select-Wildcard -Property Name -Include $Include -Exclude $Exclude
+}
+
+function Compare-Hashtable {
+    <#
+        .SYNOPSIS
+        Attempts to naively compare two hashtables by serializing them and string comparing the serialized versions
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]
+        $ReferenceObject ,
+
+        [Parameter(Mandatory)]
+        [hashtable]
+        $DifferenceObject ,
+
+        [Parameter()]
+        [int]
+        $Depth
+    )
+
+    if ($PSBoundParameters.ContainsKey('Depth')) {
+        $sRef = [System.Management.Automation.PSSerializer]::Serialize($ReferenceObject, $Depth)
+        $sDif = [System.Management.Automation.PSSerializer]::Serialize($DifferenceObject, $Depth)
+    }
+    else {
+        $sRef = [System.Management.Automation.PSSerializer]::Serialize($ReferenceObject)
+        $sDif = [System.Management.Automation.PSSerializer]::Serialize($DifferenceObject)
+    }
+
+    $sRef -ceq $sDif
+}
+
+# load the repositories from the source file
+try {
+    $src = $module.Params.source
+    $src_repos = Import-Clixml -LiteralPath $src -ErrorAction Stop
+}
+catch [System.IO.FileNotFoundException] {
+    $module.FailJson("The source file '$src' was not found.", $_)
+}
+catch {
+    $module.FailJson("There was an error loading the source file '$src'.", $_)
+}
+
+$profiles = Get-ProfileDirectory -Include $module.Params.profiles -Exclude $module.Params.exclude_profiles
+
+foreach ($user in $profiles) {
+    $username = $user.Name
+
+    $repo_dir = $user.FullName | Join-Path -ChildPath 'AppData\Local\Microsoft\Windows\PowerShell\PowerShellGet'
+    $repo_path = $repo_dir | Join-Path -ChildPath 'PSRepositories.xml'
+
+    if (Test-Path -LiteralPath $repo_path) {
+        $cur_repos = Import-Clixml -LiteralPath $repo_path
+    }
+    else {
+        $cur_repos = @{}
+    }
+
+    $new_repos = $cur_repos.Clone()
+    $updated = $false
+
+    $src_repos.Keys |
+        Select-Wildcard -Include $module.Params.name -Exclude $module.Params.exclude |
+        ForEach-Object -Process {
+            # explicit scope used inside ForEach-Object to satisfy lint (PSUseDeclaredVarsMoreThanAssignment)
+            # see https://github.com/PowerShell/PSScriptAnalyzer/issues/827
+            $Script:updated = $true
+            $Script:new_repos[$_] = $Script:src_repos[$_]
+        }
+
+    if ($updated -and -not (Compare-Hashtable -ReferenceObject $cur_repos -DifferenceObject $new_repos)) {
+        if (-not $module.CheckMode) {
+            $null = New-Item -Path $repo_dir -ItemType Directory -Force -ErrorAction SilentlyContinue
+            $new_repos | Export-Clixml -LiteralPath $repo_path -Force
+        }
+        $module.Diff.changed[$username] = $new_repos
+        $module.Result.changed = $true
+    }
+    else {
+        $module.Diff.unchanged[$username] = $cur_repos
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_psrepository_copy.ps1
+++ b/plugins/modules/win_psrepository_copy.ps1
@@ -188,7 +188,7 @@ catch [System.IO.FileNotFoundException] {
     $module.FailJson("The source file '$src' was not found.", $_)
 }
 catch {
-    $module.FailJson("There was an error loading the source file '$src'.", $_)
+    $module.FailJson("There was an error loading the source file '$src': $($_.Exception.Message).", $_)
 }
 
 $profiles = Get-ProfileDirectory -Include $module.Params.profiles -Exclude $module.Params.exclude_profiles

--- a/plugins/modules/win_psrepository_copy.ps1
+++ b/plugins/modules/win_psrepository_copy.ps1
@@ -44,8 +44,8 @@ $spec = @{
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
-$module.Diff.changed = @{}
-$module.Diff.unchanged = @{}
+$module.Diff.before = @{}
+$module.Diff.after = @{}
 
 function Select-Wildcard {
     <#
@@ -218,16 +218,15 @@ foreach ($user in $profiles) {
             $Script:new_repos[$_] = $Script:src_repos[$_]
         }
 
+    $module.Diff.before[$username] = $cur_repos
+    $module.Diff.after[$username] = $new_repos
+
     if ($updated -and -not (Compare-Hashtable -ReferenceObject $cur_repos -DifferenceObject $new_repos)) {
         if (-not $module.CheckMode) {
             $null = New-Item -Path $repo_dir -ItemType Directory -Force -ErrorAction SilentlyContinue
             $new_repos | Export-Clixml -LiteralPath $repo_path -Force
         }
-        $module.Diff.changed[$username] = $new_repos
         $module.Result.changed = $true
-    }
-    else {
-        $module.Diff.unchanged[$username] = $cur_repos
     }
 }
 

--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_psrepository_copy
+short_description: Copies registered PSRepositories to other user profiles
+description:
+  - Copies specified registered PSRepositories to other user profiles on the system.
+  - Can include the C(Default) profile so that new users start with the selected repositories.
+  - Can include special service accounts like the local SYSTEM user, LocalService, NetworkService.
+options:
+  source:
+    description:
+      - The full path to the source repositories XML file.
+      - Defaults to the repositories registered to the current user.
+    type: path
+    default: '%LOCALAPPDATA%\Microsoft\Windows\PowerShell\PowerShellGet\PSRepositories.xml'
+  name:
+    description:
+      - The names of repositories to copy.
+      - Names are interpreted as wildcards.
+    type: list
+    elements: str
+    default: ['*']
+  exclude:
+    description:
+      - The names of repositories to exclude.
+      - Names are interpreted as wildcards.
+      - If a name matches both an include (I(name)) and I(exclude), it will be excluded.
+    type: list
+    elements: str
+  profiles:
+    description:
+      - The names of user profiles to populate with repositories.
+      - Names are interpreted as wildcards.
+      - The C(Default) profile can also be matched.
+      - The C(Public) and C(All Users) profiles cannot be targeted, as PSRepositories are not loaded from them.
+    type: list
+    elements: str
+    default: ['*']
+  exclude_profiles:
+    description:
+      - The names of user profiles to exclude.
+      - If a profile matches both an include (I(profiles)) and I(exclude_profiles), it will be excluded.
+      - By default, the service account profiles are excluded.
+      - To explcitly exclude nothing, set I(exclude_profiles=[]).
+    type: list
+    elements: str
+    default:
+      - systemprofile
+      - LocalService
+      - NetworkService
+notes:
+  - Does not require the C(PowerShellGet) module or any other external dependencies.
+  - User profiles are loaded from the registry. If a given path does not exist (like if the profile directory was deleted), it is silently skipped.
+  - If setting service account profiles, you may need C(become=yes). See examples.
+  - "When PowerShellGet first sets up a repositories file, it always adds C(PSGallery), however if this module creates a new repos file and your selected
+    repositories don't include C(PSGallery), it won't be in your destination."
+  - "The values searched in I(profiles) (and I(exclude_profiles)) are profile names, not necessarily user names. This can happen when the profile is
+    deliberately changed or when domain user names conflict with users from the local computer or another domain. In this case the second+ user may have the
+    domain name or local computer name appended, like C(JoeUser.Contoso) vs. C(JoeUser).
+    If you intend to filter user profiles, ensure your filters catch the right names."
+  - "In the case of the service accounts, the specific profiles are C(systemprofile) (for the C(SYSTEM) user), and C(LocalService) or C(NetworkService)
+    for those accounts respectively."
+seealso:
+  - module: community.windows.win_psrepository
+  - module: community.windiws.win_psrepository_info
+author:
+  - Brian Scholer (@briantist)
+'''
+
+EXAMPLES = r'''
+'''
+
+RETURN = r'''
+'''

--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -68,12 +68,72 @@ notes:
     for those accounts respectively."
 seealso:
   - module: community.windows.win_psrepository
-  - module: community.windiws.win_psrepository_info
+  - module: community.windows.win_psrepository_info
 author:
   - Brian Scholer (@briantist)
 '''
 
 EXAMPLES = r'''
+- name: Copy the current user's PSRepositories to all non-service account profiles and Default profile
+  community.windows.win_psrepository_copy:
+
+- name: Copy the current user's PSRepositories to all profiles and Default profile
+  community.windows.win_psrepository_copy:
+    exclude_profiles: []
+
+- name: Copy the current user's PSRepositories to all profiles beginning with A, B, or C
+  community.windows.win_psrepository_copy:
+    profiles:
+      - 'A*'
+      - 'B*'
+      - 'C*'
+
+- name: Copy the current user's PSRepositories to all profiles beginning B except Brian and Brianna
+  community.windows.win_psrepository_copy:
+    profiles: 'B*'
+    exclude_profiles:
+      - Brian
+      - Brianna
+
+- name: Copy a specific set of repositories to profiles beginning with 'svc' with exceptions
+  community.windows.win_psrepository_copy:
+    name:
+      - CompanyRepo1
+      - CompanyRepo2
+      - PSGallery
+    profiles: 'svc*'
+    exclude_profiles: 'svc-restricted'
+
+- name: Copy repos matching a pattern with exceptions
+  community.windows.win_psrepository_copy:
+    name: 'CompanyRepo*'
+    exclude: 'CompanyRepo*-Beta'
+
+- name: Copy repositories from a custom XML file on the target host
+  community.windows.win_psrepository_copy:
+    source: 'C:\data\CustomRepostories.xml
+
+### A sample workflow of seeding a system with a custom repository
+
+# A playbook that does initial host setup or builds system images
+
+- name: Register custom respository
+  community.windows.win_psrepository:
+    name: PrivateRepo
+    source_location: https://example.com/nuget/feed/etc
+    installation_policy: trusted
+
+- name: Ensure all current and new users have this repository registered
+  community.windows.win_psrepository_copy:
+    name: PrivateRepo
+
+# In another playbook, run by other users (who may have been created later)
+
+- name: Install a module
+  community.windows.win_psmodule:
+    name: CompanyModule
+    repository: PrivateRepo
+    state: present
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -111,7 +111,7 @@ EXAMPLES = r'''
 
 - name: Copy repositories from a custom XML file on the target host
   community.windows.win_psrepository_copy:
-    source: 'C:\data\CustomRepostories.xml
+    source: 'C:\data\CustomRepostories.xml'
 
 ### A sample workflow of seeding a system with a custom repository
 

--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -60,7 +60,7 @@ notes:
   - If setting service account profiles, you may need C(become=yes). See examples.
   - "When PowerShellGet first sets up a repositories file, it always adds C(PSGallery), however if this module creates a new repos file and your selected
     repositories don't include C(PSGallery), it won't be in your destination."
-  - "The values searched in I(profiles) (and I(exclude_profiles)) are profile names, not necessarily user names. This can happen when the profile is
+  - "The values searched in I(profiles) (and I(exclude_profiles)) are profile names, not necessarily user names. This can happen when the profile path is
     deliberately changed or when domain user names conflict with users from the local computer or another domain. In this case the second+ user may have the
     domain name or local computer name appended, like C(JoeUser.Contoso) vs. C(JoeUser).
     If you intend to filter user profiles, ensure your filters catch the right names."

--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -66,6 +66,8 @@ notes:
     If you intend to filter user profiles, ensure your filters catch the right names."
   - "In the case of the service accounts, the specific profiles are C(systemprofile) (for the C(SYSTEM) user), and C(LocalService) or C(NetworkService)
     for those accounts respectively."
+  - "Repositories with credentials (requiring authentication) or proxy information will copy, but the credentials and proxy details will not as that
+    information is not stored with repository."
 seealso:
   - module: community.windows.win_psrepository
   - module: community.windows.win_psrepository_info

--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -8,6 +8,7 @@ DOCUMENTATION = r'''
 ---
 module: win_psrepository_copy
 short_description: Copies registered PSRepositories to other user profiles
+version_added: '1.3.0'
 description:
   - Copies specified registered PSRepositories to other user profiles on the system.
   - Can include the C(Default) profile so that new users start with the selected repositories.

--- a/tests/integration/targets/win_psrepository_copy/aliases
+++ b/tests/integration/targets/win_psrepository_copy/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group4

--- a/tests/integration/targets/win_psrepository_copy/defaults/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-pwdfile_stem: /tmp/win_psrepository_copy/
 user_password: 'gEYB#f74MslYcz&*1!*2WDM65!i&4*H'
 test_users:
   - name: repo_copy1

--- a/tests/integration/targets/win_psrepository_copy/defaults/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/defaults/main.yml
@@ -1,11 +1,13 @@
 ---
-pwdfile: /tmp/win_psrepository_copy
+pwdfile_stem: /tmp/win_psrepository_copy/
+user_password: 'gEYB#f74MslYcz&*1!*2WDM65!i&4*H'
 test_users:
   - name: repo_copy1
   - name: repo_copy2
     profile: '{{ remote_tmp_dir }}\odd_dir'
   - name: copy_repo3
 
-system_users:
-  - name:
-psrepo_path: '\Microsoft\Windows\PowerShell\PowerShellGet\PSRepositories.xml'
+test_repos:
+  - PSGallery
+  - FakeGet
+  - FakeFileServer

--- a/tests/integration/targets/win_psrepository_copy/defaults/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+pwdfile: /tmp/win_psrepository_copy
+test_users:
+  - name: repo_copy1
+  - name: repo_copy2
+    profile: '{{ remote_tmp_dir }}\odd_dir'
+  - name: copy_repo3
+
+system_users:
+  - name:
+psrepo_path: '\Microsoft\Windows\PowerShell\PowerShellGet\PSRepositories.xml'

--- a/tests/integration/targets/win_psrepository_copy/files/SampleRepositories.xml
+++ b/tests/integration/targets/win_psrepository_copy/files/SampleRepositories.xml
@@ -1,0 +1,94 @@
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+  <Obj RefId="0">
+    <TN RefId="0">
+      <T>System.Collections.Hashtable</T>
+      <T>System.Object</T>
+    </TN>
+    <DCT>
+      <En>
+        <S N="Key">FakeFileServer</S>
+        <Obj N="Value" RefId="1">
+          <TN RefId="1">
+            <T>Microsoft.PowerShell.Commands.PSRepository</T>
+            <T>System.Management.Automation.PSCustomObject</T>
+            <T>System.Object</T>
+          </TN>
+          <MS>
+            <S N="Name">FakeFileServer</S>
+            <S N="SourceLocation">\\domain\share\repo\</S>
+            <S N="PublishLocation">\\domain\share\repo\</S>
+            <S N="ScriptSourceLocation">\\domain\share\repo\</S>
+            <S N="ScriptPublishLocation">\\domain\share\repo\</S>
+            <B N="Trusted">false</B>
+            <B N="Registered">true</B>
+            <S N="InstallationPolicy">Untrusted</S>
+            <S N="PackageManagementProvider">NuGet</S>
+            <Obj N="ProviderOptions" RefId="2">
+              <TNRef RefId="0" />
+              <DCT />
+            </Obj>
+          </MS>
+        </Obj>
+      </En>
+      <En>
+        <S N="Key">PSGallery</S>
+        <Obj N="Value" RefId="3">
+          <TN RefId="2">
+            <T>Deserialized.Microsoft.PowerShell.Commands.PSRepository</T>
+            <T>Deserialized.System.Management.Automation.PSCustomObject</T>
+            <T>Deserialized.System.Object</T>
+          </TN>
+          <MS>
+            <S N="Name">PSGallery</S>
+            <S N="SourceLocation">https://www.powershellgallery.com/api/v2</S>
+            <S N="PublishLocation">https://www.powershellgallery.com/api/v2/package/</S>
+            <S N="ScriptSourceLocation">https://www.powershellgallery.com/api/v2/items/psscript</S>
+            <S N="ScriptPublishLocation">https://www.powershellgallery.com/api/v2/package/</S>
+            <Obj N="Trusted" RefId="4">
+              <TN RefId="3">
+                <T>System.Management.Automation.SwitchParameter</T>
+                <T>System.ValueType</T>
+                <T>System.Object</T>
+              </TN>
+              <ToString>False</ToString>
+              <Props>
+                <B N="IsPresent">false</B>
+              </Props>
+            </Obj>
+            <B N="Registered">true</B>
+            <S N="InstallationPolicy">Untrusted</S>
+            <S N="PackageManagementProvider">NuGet</S>
+            <Obj N="ProviderOptions" RefId="5">
+              <TN RefId="4">
+                <T>Deserialized.System.Collections.Hashtable</T>
+                <T>Deserialized.System.Object</T>
+              </TN>
+              <DCT />
+            </Obj>
+          </MS>
+        </Obj>
+      </En>
+      <En>
+        <S N="Key">FakeGet</S>
+        <Obj N="Value" RefId="6">
+          <TNRef RefId="2" />
+          <MS>
+            <S N="Name">FakeGet</S>
+            <S N="SourceLocation">https://www.example.org/api/nuget/v2</S>
+            <S N="PublishLocation">https://www.example.org/api/nuget/v2/package/</S>
+            <S N="ScriptSourceLocation">https://www.exampe.org/api/nuget/v2/items/psscript</S>
+            <S N="ScriptPublishLocation">https://www.example.org/api/nuget/v2/package/</S>
+            <B N="Trusted">true</B>
+            <B N="Registered">true</B>
+            <S N="InstallationPolicy">Trusted</S>
+            <S N="PackageManagementProvider">NuGet</S>
+            <Obj N="ProviderOptions" RefId="7">
+              <TNRef RefId="4" />
+              <DCT />
+            </Obj>
+          </MS>
+        </Obj>
+      </En>
+    </DCT>
+  </Obj>
+</Objs>

--- a/tests/integration/targets/win_psrepository_copy/meta/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/meta/main.yml
@@ -1,4 +1,3 @@
 dependencies:
   - setup_remote_tmp_dir
-  # - setup_http_tests
-  # - setup_win_psget
+  - setup_win_psget

--- a/tests/integration/targets/win_psrepository_copy/meta/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - setup_remote_tmp_dir
+  # - setup_http_tests
+  # - setup_win_psget

--- a/tests/integration/targets/win_psrepository_copy/tasks/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/main.yml
@@ -86,6 +86,9 @@
         state: absent
       loop: "{{ test_users }}"
 
+    - name: Remove test profiles
+      import_tasks: remove_test_profiles.yml
+
     - name: Remove sample file
       ansible.windows.win_file:
         path: '{{ remote_tmp_dir }}\SampleRepositories.xml'

--- a/tests/integration/targets/win_psrepository_copy/tasks/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/main.yml
@@ -11,15 +11,15 @@
     community.windows.win_psrepository_copy:
       source: '{{ remote_tmp_dir }}\SampleRepositories.xml'
   block:
-    # avoiding the use of win_psrepository / Register-PSRepository due to its strict target checking
-    # in the end, this module always looks at the XML file, so we'll just put a pre-baked one in place
+    # avoiding the use of win_psrepository / Register-PSRepository due to its strict target checking.
+    # in the end, this module always looks at the XML file, so we'll just put a pre-baked one in place.
     - name: Put our source file in place
       ansible.windows.win_copy:
         src: SampleRepositories.xml
         dest: "{{ remote_tmp_dir }}"
         force: yes
 
-    - name: Copy repos with module defaults
+    - name: Copy repos with module defaults - check
       community.windows.win_psrepository_copy:
       register: status
       check_mode: yes
@@ -27,9 +27,64 @@
     - assert:
         that: status is changed
 
+    - name: Copy repos with module defaults
+      community.windows.win_psrepository_copy:
+      register: status
+
+    - assert:
+        that: status is changed
+
+    - name: Copy repos with module defaults - again
+      community.windows.win_psrepository_copy:
+      register: status
+
+    - assert:
+        that: status is not changed
+
+    # these users should inherit the repositories via the Default profile
+    - name: Create test users
+      ansible.windows.win_user:
+        name: "{{ item.name }}"
+        profile: "{{ item.profile | default(omit) }}"
+        password: "{{ user_password }}"
+        groups:
+          - Administrators
+      loop: "{{ test_users }}"
+
+    #####################################
+    ## Begin inherited tests
+
+    - name: Test inherited repos via Default profile
+      include_tasks:
+        file: test_by_user.yml
+        apply:
+          vars:
+            user: "{{ item }}"
+            expected_repos: "{{ test_repos }}"
+      loop: "{{ test_users | map(attribute='name') | list }}"
+
+    ## End inherited tests
+    #####################################
+
+    - import_tasks: test_system_users.yml
+
+    - import_tasks: test_exclude_profile.yml
+
+    - import_tasks: test_include_profile.yml
+
+    - import_tasks: test_exclude_repo.yml
+
+    - import_tasks: test_include_repo.yml
+
   always:
     - name: Reset
       import_tasks: reset.yml
+
+    - name: Remove test users
+      ansible.windows.win_user:
+        name: "{{ item.name }}"
+        state: absent
+      loop: "{{ test_users }}"
 
     - name: Remove sample file
       ansible.windows.win_file:

--- a/tests/integration/targets/win_psrepository_copy/tasks/main.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/main.yml
@@ -1,0 +1,37 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Reset
+  import_tasks: reset.yml
+
+- name: Main block
+  module_defaults:
+    community.windows.win_psrepository_copy:
+      source: '{{ remote_tmp_dir }}\SampleRepositories.xml'
+  block:
+    # avoiding the use of win_psrepository / Register-PSRepository due to its strict target checking
+    # in the end, this module always looks at the XML file, so we'll just put a pre-baked one in place
+    - name: Put our source file in place
+      ansible.windows.win_copy:
+        src: SampleRepositories.xml
+        dest: "{{ remote_tmp_dir }}"
+        force: yes
+
+    - name: Copy repos with module defaults
+      community.windows.win_psrepository_copy:
+      register: status
+      check_mode: yes
+
+    - assert:
+        that: status is changed
+
+  always:
+    - name: Reset
+      import_tasks: reset.yml
+
+    - name: Remove sample file
+      ansible.windows.win_file:
+        path: '{{ remote_tmp_dir }}\SampleRepositories.xml'
+        state: absent

--- a/tests/integration/targets/win_psrepository_copy/tasks/remove_test_profiles.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/remove_test_profiles.yml
@@ -9,7 +9,7 @@
 # and then deletes the directory; if that was succesful, it deletes the registry key too.
 #
 # As a result this should also clean up after any old runs that left behind profiles, so an interrupted run
-# that didn't runt he rescue block will still get cleaned up by the next when this runs again.
+# that didn't run the rescue block will still get cleaned up by the next when this runs again.
 
 - name: Remove all the test user profiles from the system
   become: yes

--- a/tests/integration/targets/win_psrepository_copy/tasks/remove_test_profiles.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/remove_test_profiles.yml
@@ -1,0 +1,42 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+# removing a user doesn't remove their profile (which includes the filesystem directory and registry key).
+# without cleaning up, every CI run will create a new path and key and they will build up over time.
+# this finds all profiles on the system, via the registry, whose path basename starts with one of our test users
+# and then deletes the directory; if that was succesful, it deletes the registry key too.
+#
+# As a result this should also clean up after any old runs that left behind profiles, so an interrupted run
+# that didn't runt he rescue block will still get cleaned up by the next when this runs again.
+
+- name: Remove all the test user profiles from the system
+  become: yes
+  become_user: SYSTEM
+  become_method: runas
+  ansible.windows.win_shell: |
+    $names = @'
+    {{ test_users | map(attribute='name') | list | to_json }}
+    '@ | ConvertFrom-Json
+    $regPL = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList'
+    $profiles = Get-ChildItem -LiteralPath $regPL
+
+    $profiles | ForEach-Object -Process {
+        $path = ($_ | Get-ItemProperty | Select-Object -ExpandProperty ProfileImagePath) -as [System.IO.DirectoryInfo]
+        :search foreach ($target in $names) {
+            if ($path.Name  -match "^$target") {
+                $delReg=$true
+                if ($path.Exists) {
+                    & cmd.exe /c rd /s /q $path.FullName
+                    if (-not ($delReg=$?)) {
+                        Write-Warning -Message "Couldn't remove '$path'"
+                    }
+                }
+                if ($delReg) {
+                    $_ | Remove-Item -Force -ErrorAction SilentlyContinue
+                }
+                break search
+            }
+        }
+    }

--- a/tests/integration/targets/win_psrepository_copy/tasks/reset.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/reset.yml
@@ -1,0 +1,22 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Remove the psrepositories for all profiles on the system
+  become: yes
+  become_user: SYSTEM
+  become_method: runas
+  ansible.windows.win_shell: |
+    $regPL = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList'
+    $default = Get-ItemProperty -LiteralPath $regPL | Select-Object -ExpandProperty Default
+    $profiles = (
+        @($default) +
+        (Get-ChildItem -LiteralPath $regPL | Get-ItemProperty | Select-Object -ExpandProperty ProfileImagePath)
+    ) -as [System.IO.DirectoryInfo[]]
+    $profiles |
+        Where-Object -Property Exists -EQ $true |
+        ForEach-Object -Process {
+            $p = [System.IO.Path]::Combine($_.FullName, 'AppData\Local\Microsoft\Windows\PowerShell\PowerShellGet\PSRepositories.xml')
+            Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue
+        }

--- a/tests/integration/targets/win_psrepository_copy/tasks/test_by_user.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/test_by_user.yml
@@ -1,0 +1,32 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Get repository info
+  become: yes
+  become_user: "{{ user }}"
+  become_method: runas
+  community.windows.win_psrepository_info:
+  register: repos
+
+- name: Ensure expected repositories are present
+  assert:
+    that: repo in (repos.repositories | map(attribute='name') | list)
+    success_msg: "expected repository '{{ repo }}' was found for user '{{ user }}'"
+    fail_msg: "expected repository '{{ repo }}' was not found for user '{{ user }}'"
+  loop: "{{ expected_repos }}"
+  loop_control:
+    loop_var: repo
+
+- name: Ensure present repositories are expected
+  assert:
+    that: repo in expected_repos or repo == 'PSGallery'
+    # although not completely consistent depending on OS and/or PowerShellGet versions
+    # often calling Get-PSRepository will register PSGallery if it's missing, so we
+    # must be prepared for it to show up here "unexpectedly" by way of us querying :(
+    success_msg: "found expected repository '{{ repo }}' for user '{{ user }}'"
+    fail_msg: "found unexpected repository '{{ repo }}' for user '{{ user }}'"
+  loop: "{{ repos.repositories | map(attribute='name') | list }}"
+  loop_control:
+    loop_var: repo

--- a/tests/integration/targets/win_psrepository_copy/tasks/test_exclude_profile.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/test_exclude_profile.yml
@@ -1,0 +1,58 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+#####################################
+## Begin filter profile (exclusive) tests
+- name: Reset
+  import_tasks: reset.yml
+
+- name: Copy repos with excluded profiles - check
+  community.windows.win_psrepository_copy:
+    exclude_profiles: 'repo*'
+  register: status
+  check_mode: yes
+
+- assert:
+    that: status is changed
+
+- name: Copy repos with excluded profiles
+  community.windows.win_psrepository_copy:
+    exclude_profiles: 'repo*'
+  register: status
+
+- assert:
+    that: status is changed
+
+- name: Copy repos with excluded profiles - again
+  community.windows.win_psrepository_copy:
+    exclude_profiles: 'repo*'
+  register: status
+
+- assert:
+    that: status is not changed
+
+- name: Test filtered profiles (excluded)
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos: []
+  loop:
+    - repo_copy1
+    - repo_copy2
+
+- name: Test filtered profiles (not excluded)
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos: "{{ test_repos }}"
+  loop:
+    - copy_repo3
+
+## End filter profile (exclusive) tests
+#####################################

--- a/tests/integration/targets/win_psrepository_copy/tasks/test_exclude_repo.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/test_exclude_repo.yml
@@ -1,0 +1,49 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+#####################################
+## Begin filter repo (exclusive) tests
+
+- name: Reset
+  import_tasks: reset.yml
+
+- name: Copy filtered repos by exclusion - check
+  community.windows.win_psrepository_copy:
+    exclude: '*Server'
+  register: status
+  check_mode: yes
+
+- assert:
+    that: status is changed
+
+- name: Copy filtered repos by exclusion
+  community.windows.win_psrepository_copy:
+    exclude: '*Server'
+  register: status
+
+- assert:
+    that: status is changed
+
+- name: Copy filtered repos by exclusion - again
+  community.windows.win_psrepository_copy:
+    exclude: '*Server'
+  register: status
+
+- assert:
+    that: status is not changed
+
+- name: Test filtered repos (included)
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos:
+          - PSGallery
+          - FakeGet
+  loop: "{{ test_users | map(attribute='name') | list }}"
+
+## End filter repo (exclusive) tests
+#####################################

--- a/tests/integration/targets/win_psrepository_copy/tasks/test_include_profile.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/test_include_profile.yml
@@ -1,0 +1,59 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+#####################################
+## Begin filter profile (inclusive) tests
+
+- name: Reset
+  import_tasks: reset.yml
+
+- name: Copy repos with filtered profiles - check
+  community.windows.win_psrepository_copy:
+    profiles: 'repo*'
+  register: status
+  check_mode: yes
+
+- assert:
+    that: status is changed
+
+- name: Copy repos with filtered profiles
+  community.windows.win_psrepository_copy:
+    profiles: 'repo*'
+  register: status
+
+- assert:
+    that: status is changed
+
+- name: Copy repos with filtered profiles - again
+  community.windows.win_psrepository_copy:
+    profiles: 'repo*'
+  register: status
+
+- assert:
+    that: status is not changed
+
+- name: Test filtered profiles (included)
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos: "{{ test_repos }}"
+  loop:
+    - repo_copy1
+    - repo_copy2
+
+- name: Test filtered profiles (not included)
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos: []
+  loop:
+    - copy_repo3
+
+## End filter profile (inclusive) tests
+#####################################

--- a/tests/integration/targets/win_psrepository_copy/tasks/test_include_repo.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/test_include_repo.yml
@@ -1,0 +1,49 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+#####################################
+## Begin filter repo (inclusive) tests
+
+- name: Reset
+  import_tasks: reset.yml
+
+- name: Copy filtered repos - check
+  community.windows.win_psrepository_copy:
+    name: '*G*'
+  register: status
+  check_mode: yes
+
+- assert:
+    that: status is changed
+
+- name: Copy filtered repos
+  community.windows.win_psrepository_copy:
+    name: '*G*'
+  register: status
+
+- assert:
+    that: status is changed
+
+- name: Copy filtered repos - again
+  community.windows.win_psrepository_copy:
+    name: '*G*'
+  register: status
+
+- assert:
+    that: status is not changed
+
+- name: Test filtered repos (included)
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos:
+          - PSGallery
+          - FakeGet
+  loop: "{{ test_users | map(attribute='name') | list }}"
+
+## End filter repo (inclusive) tests
+#####################################

--- a/tests/integration/targets/win_psrepository_copy/tasks/test_system_users.yml
+++ b/tests/integration/targets/win_psrepository_copy/tasks/test_system_users.yml
@@ -1,0 +1,68 @@
+# This file is part of Ansible
+
+# Copyright: (c) 2020, Brian Scholer <@briantist>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+#####################################
+## Begin system user tests
+
+- name: Reset
+  import_tasks: reset.yml
+
+- name: Copy repos only to special system users - check
+  community.windows.win_psrepository_copy:
+    profiles:
+      - '*Service'
+      - 'systemprofile'
+    exclude_profiles: []
+  register: status
+  check_mode: yes
+
+- assert:
+    that: status is changed
+
+- name: Copy repos only to special system users
+  community.windows.win_psrepository_copy:
+    profiles:
+      - '*Service'
+      - 'systemprofile'
+    exclude_profiles: []
+  register: status
+
+- assert:
+    that: status is changed
+
+- name: Copy repos only to special system users - again
+  community.windows.win_psrepository_copy:
+    profiles:
+      - '*Service'
+      - 'systemprofile'
+    exclude_profiles: []
+  register: status
+
+- assert:
+    that: status is not changed
+
+- name: Test system users
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ 'SYSTEM' if item == 'systemprofile' else item }}"
+        expected_repos: "{{ test_repos }}"
+  loop:
+    - systemprofile
+    - LocalService
+    - NetworkService
+
+- name: Test other users
+  include_tasks:
+    file: test_by_user.yml
+    apply:
+      vars:
+        user: "{{ item }}"
+        expected_repos: []
+  loop: "{{ test_users | map(attribute='name') | list }}"
+
+## End system user tests
+#####################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds new module `win_psrepository_copy` for copying PSRepositories to other user profiles on the system.
This solves for the lack of host-wide registered PSRepositories.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_psrepository_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
