### PR TITLE
Fix new santiy check and stabilise external downloads

### DIFF
--- a/plugins/modules/win_format.py
+++ b/plugins/modules/win_format.py
@@ -57,11 +57,13 @@ options:
         default (quick) format, and is not recommended on storage that is thinly provisioned.
       - Specify C(true) for full format.
     type: bool
+    default: no
   force:
     description:
       - Specify if formatting should be forced for volumes that are not created from new partitions
         or if the source and target file system are different.
     type: bool
+    default: no
 notes:
   - Microsoft Windows Server 2012 or Microsoft Windows 8 or newer is required to use this module. To check if your system is compatible, see
     U(https://docs.microsoft.com/en-us/windows/desktop/sysinfo/operating-system-version).

--- a/plugins/modules/win_initialize_disk.py
+++ b/plugins/modules/win_initialize_disk.py
@@ -37,6 +37,7 @@ options:
         description:
             - Specify if initializing should be forced for disks that are already initialized.
         type: bool
+        default: no
 
 notes:
     - One of three parameters (I(disk_number), I(uniqueid), and I(path)) are mandatory to identify the target disk, but

--- a/tests/integration/targets/setup_win_psget/tasks/main.yml
+++ b/tests/integration/targets/setup_win_psget/tasks/main.yml
@@ -13,6 +13,10 @@
       path: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_win_psget/PackageManagement_x64.msi
       product_id: '{57E5A8BB-41EB-4F09-B332-B535C5954A28}'
       state: present
+    register: download_res
+    until: download_res is successful
+    retries: 3
+    delay: 5
 
   - name: create the required folder
     ansible.windows.win_file:

--- a/tests/integration/targets/win_hotfix/tasks/tests_2012R2.yml
+++ b/tests/integration/targets/win_hotfix/tasks/tests_2012R2.yml
@@ -8,16 +8,28 @@
   ansible.windows.win_get_url:
     url: '{{test_win_hotfix_good_url}}'
     dest: '{{test_win_hotfix_path}}\good.msu'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: download reboot hotfix
   ansible.windows.win_get_url:
     url: '{{test_win_hotfix_reboot_url}}'
     dest: '{{test_win_hotfix_path}}\reboot.msu'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: download bad hotfix
   ansible.windows.win_get_url:
     url: '{{test_win_hotfix_bad_url}}'
     dest: '{{test_win_hotfix_path}}\bad.msu'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: fail install install hotfix where kb doesn't match
   win_hotfix:

--- a/tests/integration/targets/win_pester/tasks/main.yml
+++ b/tests/integration/targets/win_pester/tasks/main.yml
@@ -13,6 +13,10 @@
     # https://github.com/pester/Pester/releases 
     url: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_pester/Pester-4.3.1.zip'
     dest: '{{test_win_pester_path}}\Pester-4.3.1.zip'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: unzip Pester module
   win_unzip:

--- a/tests/integration/targets/win_psexec/tasks/main.yml
+++ b/tests/integration/targets/win_psexec/tasks/main.yml
@@ -12,6 +12,10 @@
   ansible.windows.win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/win_psexec/PsExec.exe
     dest: '{{ testing_dir }}\PsExec.exe'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: Get the existing PATH env var
   ansible.windows.win_shell: '$env:PATH'

--- a/tests/integration/targets/win_psmodule/tasks/setup.yml
+++ b/tests/integration/targets/win_psmodule/tasks/setup.yml
@@ -109,6 +109,10 @@
   ansible.windows.win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/win_psmodule/nuget.exe
     dest: '{{ remote_tmp_dir }}'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: create test PowerShell modules
   script: setup_modules.ps1 "{{ remote_tmp_dir }}"


### PR DESCRIPTION
##### SUMMARY
There's a new sanity check that correctly checks the default of `type: bool` in the docs that we need to handle.

Also adds a retry to the various download steps in our tests to try and avoid unstable failures due to random S3 failures that we see from time to time.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests