### PR TITLE
Use newer AZP container with PATH fixes

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.7.0
+      image: quay.io/ansible/azure-pipelines-test-container:1.7.1
 
 pool: Standard
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Collection: community.windows
 
-[![Build Status](https://dev.azure.com/ansible/community.windows/_apis/build/status/CI?branchName=refs%2Fpull%2F175%2Fmerge)](https://dev.azure.com/ansible/community.windows/_build/latest?definitionId=23&branchName=refs%2Fpull%2F175%2Fmerge)
+[![Build Status](https://dev.azure.com/ansible/community.windows/_apis/build/status/CI?branchName=main)](https://dev.azure.com/ansible/community.windows/_build/latest?definitionId=23&branchName=main)
 [![codecov](https://codecov.io/gh/ansible-collections/community.windows/branch/main/graph/badge.svg)](https://codecov.io/gh/ansible-collections/community.windows)
 
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -72,7 +72,6 @@ fi
 
 # TODO: put this in a requirements file
 # Install the depss of this collection
-export PATH="${HOME}/.local/bin:${PATH}"
 sudo chown "$(whoami)" "${PWD}/../../"
 retry ansible-galaxy collection install 'ansible.windows' 'chocolatey.chocolatey'
 


### PR DESCRIPTION
Removes the need for the PATH hack in the testing container