### PR TITLE
Fix copy-paste-error in win_firewall_rule

### DIFF
--- a/changelogs/fragments/win_firewall_rule-service-any.yml
+++ b/changelogs/fragments/win_firewall_rule-service-any.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'win_firewall_rule - Ensure ``service: any`` is set to match any service instead of the literal service called ``any`` as per the docs'

--- a/plugins/modules/win_firewall_rule.ps1
+++ b/plugins/modules/win_firewall_rule.ps1
@@ -169,7 +169,7 @@ try {
     if ($null -ne $description) { $new_rule.Description = $description }
     if ($null -ne $group) { $new_rule.Grouping = $group }
     if ($null -ne $program -and $program -ne "any") { $new_rule.ApplicationName = [System.Environment]::ExpandEnvironmentVariables($program) }
-    if ($null -ne $service -and $program -ne "any") { $new_rule.ServiceName = $service }
+    if ($null -ne $service -and $service -ne "any") { $new_rule.ServiceName = $service }
     if ($null -ne $protocol -and $protocol -ne "any") { $new_rule.Protocol = ConvertTo-ProtocolType -protocol $protocol }
     if ($null -ne $localport -and $localport -ne "any") { $new_rule.LocalPorts = $localport }
     if ($null -ne $remoteport -and $remoteport -ne "any") { $new_rule.RemotePorts = $remoteport }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an copy-paste-error for the service parameter in win_firewall_rule.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- win_firewall_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If the task gets executed with "service=any", a firewall rule gets created which effects services named "any" instead of all services.
<!--- Paste verbatim command output below, e.g. before and after your change -->

