### PR TITLE
Fixes for failing tests in CI

### DIFF
--- a/changelogs/fragments/win_scoop-tls.yml
+++ b/changelogs/fragments/win_scoop-tls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_scoop - Make sure we enable TLS 1.2 when installing scoop

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -35,6 +35,9 @@ $state = $module.Params.state
 $module.Result.rc = 0
 
 function Install-Scoop {
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '', Justification='This is one use case where we want to use iex')]
+  [CmdletBinding()]
+  param ()
 
   # Scoop doesn't have refreshenv like Chocolatey
   # Let's try to update PATH first

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -61,10 +61,6 @@ function Install-Scoop {
       $enc_command = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($install_script.ToString()))
       $cmd = "powershell.exe -NoProfile -NoLogo -EncodedCommand $enc_command"
       $res = Run-Command -Command $cmd -environment $environment
-      $module.Result.rc = $res.rc
-      $module.Result.stdout = $res.stdout
-      $module.Result.stderr = $res.stderr
-
       if ($res.rc -ne 0) {
         $module.Result.rc = $res.rc
         $module.Result.stdout = $res.stdout

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -43,26 +43,24 @@ function Install-Scoop {
   $scoop_app = Get-Command -Name scoop.ps1 -Type ExternalScript -ErrorAction SilentlyContinue
   if ($null -eq $scoop_app) {
     # We need to install scoop
-    # Enable TLS1.2 if it's available but disabled (eg. .NET 4.5)
-    $security_protocols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
-    if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
-      $security_protocols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
-    }
-    [Net.ServicePointManager]::SecurityProtocol = $security_protocols
+    # We run this in a separate process to make it easier to get the result in a failure and capture any output that
+    # might be sent to the host. We also need to enable TLS 1.2 in that process and not here so it can download the
+    # install script and other components.
+    $install_script = {
+      # Enable TLS1.2 if it's available but disabled (eg. .NET 4.5)
+      $security_protocols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
+      if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+        $security_protocols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
+      }
+      [Net.ServicePointManager]::SecurityProtocol = $security_protocols
 
-    $client = New-Object -TypeName System.Net.WebClient
-
-    $script_url = "https://get.scoop.sh"
-
-    try {
-      $install_script = $client.DownloadString($script_url)
-    }
-    catch {
-      $module.FailJson("Failed to download Scoop script from '$script_url'; $($_.Exception.Message)", $_)
+      Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
     }
 
     if (-not $module.CheckMode) {
-      $res = Run-Command -Command "powershell.exe -" -stdin $install_script -environment $environment
+      $enc_command = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($install_script.ToString()))
+      $cmd = "powershell.exe -NoProfile -NoLogo -EncodedCommand $enc_command"
+      $res = Run-Command -Command $cmd -environment $environment
       $module.Result.rc = $res.rc
       $module.Result.stdout = $res.stdout
       $module.Result.stderr = $res.stderr

--- a/plugins/modules/win_scoop.ps1
+++ b/plugins/modules/win_scoop.ps1
@@ -63,6 +63,10 @@ function Install-Scoop {
 
     if (-not $module.CheckMode) {
       $res = Run-Command -Command "powershell.exe -" -stdin $install_script -environment $environment
+      $module.Result.rc = $res.rc
+      $module.Result.stdout = $res.stdout
+      $module.Result.stderr = $res.stderr
+
       if ($res.rc -ne 0) {
         $module.Result.rc = $res.rc
         $module.Result.stdout = $res.stdout

--- a/tests/integration/targets/win_scoop/aliases
+++ b/tests/integration/targets/win_scoop/aliases
@@ -1,1 +1,3 @@
 shippable/windows/group3
+skip/windows/2012  # Need pwsh 5+
+skip/windows/2012-R2  # Need pwsh 5+

--- a/tests/unit/plugins/lookup/test_laps_password.py
+++ b/tests/unit/plugins/lookup/test_laps_password.py
@@ -116,21 +116,6 @@ def test_missing_ldap(laps_password):
     assert str(err.value).endswith(". Import Error: no import for you!")
 
 
-def test_invalid_cert_mapping():
-    with pytest.raises(AnsibleLookupError) as err:
-        lookup_loader.get('community.windows.laps_password').run(["host"], domain="test", validate_certs="incorrect")
-
-    assert str(err.value) == "Invalid validate_certs value 'incorrect': valid values are 'allow', 'demand', " \
-                             "'never', 'try'"
-
-
-def test_invalid_auth():
-    with pytest.raises(AnsibleLookupError) as err:
-        lookup_loader.get('community.windows.laps_password').run(["host"], domain="test", auth="fail")
-
-    assert str(err.value) == "Invalid auth value 'fail': expecting either 'gssapi', or 'simple'"
-
-
 def test_gssapi_without_sasl(monkeypatch, ):
     monkeypatch.setattr("ldap.SASL_AVAIL", 0)
 


### PR DESCRIPTION
##### SUMMARY
Fixes for CI failures.

~I'm not sure why win_scoop and win_scoop_bucket is failing on CI, they are passing locally so I'm just adding some more messages to the return result to figure out what's wrong.~

There were 2 issues

* The install script had a check for PowerShell 5 or newer, our 2012 hosts come with 3/4
* We enable TLS 1.2 on the module's process but not the one where we are executing the scoop install script

The unit test failures are due to a recent validation addition to plugin config. I've just removed the tests are trying to detect the Ansible version and determining the correct error/msg will be too hard to maintain.

##### ISSUE TYPE
- Bugfix Pull Request