### PR TITLE
fix big group problem

### DIFF
--- a/changelogs/fragments/win_domain_group_membership-large.yml
+++ b/changelogs/fragments/win_domain_group_membership-large.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_group_membership - Handle timeouts when dealing with group with lots of members - https://github.com/ansible-collections/community.windows/pull/204

--- a/plugins/modules/win_domain_group_membership.ps1
+++ b/plugins/modules/win_domain_group_membership.ps1
@@ -50,8 +50,7 @@ if ($diff_mode) {
     $result.diff = @{}
 }
 
-$group = Get-ADGroup $ADGroup @extra_args
-$filter = " (&(objectClass=groupOfNames)(memberOf=$($group.DistinguishedName)))"
+$filter = "(memberOf=$($ADGroup.DistinguishedName))"
 
 
 $members_before = Get-ADObject -LDAPFilter $filter -Properties sAMAccountName, objectSID @extra_args

--- a/plugins/modules/win_domain_group_membership.ps1
+++ b/plugins/modules/win_domain_group_membership.ps1
@@ -50,7 +50,8 @@ if ($diff_mode) {
     $result.diff = @{}
 }
 
-$members_before = Get-AdGroupMember -Identity $ADGroup @extra_args
+$members_before = Get-AdGroup -Identity $ADGroup @extra_args -Properties Member | select-Object -Property 'Member' -ExpandProperty 'Member'
+$members_before = $members_before | %{Get-AdUser $_ @extra_args -Properties SamAccountName, sid | select-object -Property SamAccountName, sid}
 $pure_members = [System.Collections.Generic.List`1[String]]@()
 
 foreach ($member in $members) {
@@ -89,7 +90,9 @@ foreach ($member in $members) {
 
 if ($state -eq "pure") {
     # Perform removals for existing group members not defined in $members
-    $current_members = Get-AdGroupMember -Identity $ADGroup @extra_args
+    $current_members = Get-AdGroup -Identity $ADGroup @extra_args -Properties Member | select-Object -Property 'Member' -ExpandProperty 'Member'
+    $current_members = $current_members | %{Get-AdUser $_ @extra_args -Properties SamAccountName, sid | select-object -Property SamAccountName, sid}
+
 
     foreach ($current_member in $current_members) {
         $user_to_remove = $true
@@ -108,7 +111,8 @@ if ($state -eq "pure") {
     }
 }
 
-$final_members = Get-AdGroupMember -Identity $ADGroup @extra_args
+$final_members = Get-AdGroup -Identity $ADGroup @extra_args -Properties Member | select-Object -Property 'Member' -ExpandProperty 'Member'
+$final_members = $final_members | %{Get-AdUser $_ @extra_args -Properties SamAccountName | select-object -Property SamAccountName}
 
 if ($final_members) {
     $result.members = [Array]$final_members.SamAccountName

--- a/plugins/modules/win_domain_group_membership.ps1
+++ b/plugins/modules/win_domain_group_membership.ps1
@@ -52,7 +52,6 @@ if ($diff_mode) {
 
 $filter = "(memberOf=$($ADGroup.DistinguishedName))"
 
-
 $members_before = Get-ADObject -LDAPFilter $filter -Properties sAMAccountName, objectSID @extra_args
 $pure_members = [System.Collections.Generic.List`1[String]]@()
 

--- a/plugins/modules/win_domain_group_membership.ps1
+++ b/plugins/modules/win_domain_group_membership.ps1
@@ -51,7 +51,7 @@ if ($diff_mode) {
 }
 
 $members_before = Get-AdGroup -Identity $ADGroup @extra_args -Properties Member | select-Object -Property 'Member' -ExpandProperty 'Member'
-$members_before = $members_before | %{Get-AdUser $_ @extra_args -Properties SamAccountName, sid | select-object -Property SamAccountName, sid}
+$members_before = $members_before | ForEach-Object{Get-AdUser $_ @extra_args -Properties SamAccountName, sid | select-object -Property SamAccountName, sid}
 $pure_members = [System.Collections.Generic.List`1[String]]@()
 
 foreach ($member in $members) {
@@ -91,7 +91,7 @@ foreach ($member in $members) {
 if ($state -eq "pure") {
     # Perform removals for existing group members not defined in $members
     $current_members = Get-AdGroup -Identity $ADGroup @extra_args -Properties Member | select-Object -Property 'Member' -ExpandProperty 'Member'
-    $current_members = $current_members | %{Get-AdUser $_ @extra_args -Properties SamAccountName, sid | select-object -Property SamAccountName, sid}
+    $current_members = $current_members | ForEach-Object{Get-AdUser $_ @extra_args -Properties SamAccountName, sid | select-object -Property SamAccountName, sid}
 
 
     foreach ($current_member in $current_members) {
@@ -112,7 +112,7 @@ if ($state -eq "pure") {
 }
 
 $final_members = Get-AdGroup -Identity $ADGroup @extra_args -Properties Member | select-Object -Property 'Member' -ExpandProperty 'Member'
-$final_members = $final_members | %{Get-AdUser $_ @extra_args -Properties SamAccountName | select-object -Property SamAccountName}
+$final_members = $final_members | ForEach-Object{Get-AdUser $_ @extra_args -Properties SamAccountName | select-object -Property SamAccountName}
 
 if ($final_members) {
     $result.members = [Array]$final_members.SamAccountName


### PR DESCRIPTION
##### SUMMARY
win_domain_group_membership might fail if the group has a lot of members

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_group_membership 

##### ADDITIONAL INFORMATION
Get-ADGroupMember might hit a timeout if used against a big group. The behavior is described here: https://pscustomobject.github.io/powershell/powershell%20tips/Get-AdGroupMember-Timeout/

I'm proposing a fix to this problem by implementing the solution proposed in the article.
The change isn't a breaking change as the output object's format doesn't change.

Please feel free to accept this PR in case you think the enhancement might be useful. 