### PR TITLE
win_pssession_configuration - fix async_poll implementation and test

### DIFF
--- a/changelogs/fragments/212-win_pssession_configuration-async_poll.yml
+++ b/changelogs/fragments/212-win_pssession_configuration-async_poll.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - win_pssession_configuration - the ``async_poll`` option was not actually used and polling mode was always used with the default poll delay (https://github.com/ansible-collections/community.windows/pull/212).
+  - win_pssession_configuration - the ``async_poll`` option was not actually used and polling mode was always used with the default poll delay; this change also formally disables ``async_poll=0`` (https://github.com/ansible-collections/community.windows/pull/212).

--- a/changelogs/fragments/212-win_pssession_configuration-async_poll.yml
+++ b/changelogs/fragments/212-win_pssession_configuration-async_poll.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - win_pssession_configuration - the ``async_poll`` option was not actually used and polling mode was always used with the default poll delay (https://github.com/ansible-collections/community.windows/pull/212).

--- a/plugins/action/win_pssession_configuration.py
+++ b/plugins/action/win_pssession_configuration.py
@@ -56,6 +56,7 @@ class ActionModule(ActionBase):
         # if it's not in check mode, call the module async so the WinRM restart doesn't kill ansible
         if not check_mode:
             self._task.async_val = async_timeout
+            self._task.poll = async_poll
 
         result = status = self._execute_module(
             task_vars=task_vars,

--- a/plugins/action/win_pssession_configuration.py
+++ b/plugins/action/win_pssession_configuration.py
@@ -4,12 +4,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import ntpath
 import time
 
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
-from ansible.utils.vars import merge_hash
 from ansible.playbook.task import Task
 from ansible.utils.display import Display
 display = Display()
@@ -36,6 +34,9 @@ class ActionModule(ActionBase):
         async_poll = self._task.args.get('async_poll', self._default_async_poll)
 
         result = super(ActionModule, self).run(tmp, task_vars)
+
+        if async_poll <= 0:
+            raise AnsibleError("The 'async_poll' option must be greater than 0, got: %i" % async_poll)
 
         # build the wait_for_connection object for later use
         wait_for_connection_task = self._task.copy()
@@ -64,8 +65,8 @@ class ActionModule(ActionBase):
         )
         display.vvvv("Internal Async Result: %r" % status)
 
-        # if we're in check mode (not doing async) or not polling, return the result now
-        if check_mode or async_poll == 0:
+        # if we're in check mode (not doing async) return the result now
+        if check_mode:
             return result
 
         # turn off async so we don't run the following actions as async

--- a/plugins/modules/win_pssession_configuration.py
+++ b/plugins/modules/win_pssession_configuration.py
@@ -295,15 +295,13 @@ options:
       - Sets a delay in seconds between each check of the asynchronous execution status.
       - Replicates the functionality of the C(poll) keyword.
       - Has no effect in check mode.
+      - I(async_poll=0) is not supported.
     type: int
     default: 1
 notes:
   - This module will restart the WinRM service on any change. This will terminate all WinRM connections including those by other Ansible runs.
-  - Internally this module uses C(async) when not in check mode to ensure things goes smoothly when restarting the WinRM service.
+  - Internally this module uses C(async) when not in check mode to ensure things go smoothly when restarting the WinRM service.
   - The standard C(async) and C(poll) keywords cannot be used; instead use the I(async_timeout) and I(async_poll) options to control asynchronous execution.
-  - Setting I(async_poll=0) will return a result that can be used with M(async_status).
-  - I(async_poll=0) is B(highly unlikely) to be useful, unless you have very long-running tasks in between that don't require a remote connection.
-  - This is because M(async_status) will encounter a connection error that cannot be retried with C(until) and C(retries).
   - Options that don't list a default value here will use the defaults of C(New-PSSessionConfigurationFile) and C(Register-PSSessionConfiguration).
   - If a value can be specified in both a session config file and directly in the session options, this module will prefer the setting be in the config file.
 seealso:

--- a/plugins/modules/win_pssession_configuration.py
+++ b/plugins/modules/win_pssession_configuration.py
@@ -301,7 +301,9 @@ notes:
   - This module will restart the WinRM service on any change. This will terminate all WinRM connections including those by other Ansible runs.
   - Internally this module uses C(async) when not in check mode to ensure things goes smoothly when restarting the WinRM service.
   - The standard C(async) and C(poll) keywords cannot be used; instead use the I(async_timeout) and I(async_poll) options to control asynchronous execution.
-  - Setting I(async_poll=0) will return a result that can be used with C(async_status).
+  - Setting I(async_poll=0) will return a result that can be used with M(async_status).
+  - I(async_poll=0) is B(highly unlikely) to be useful, unless you have very long-running tasks in between that don't require a remote connection.
+  - This is because M(async_status) will encounter a connection error that cannot be retried with C(until) and C(retries).
   - Options that don't list a default value here will use the defaults of C(New-PSSessionConfigurationFile) and C(Register-PSSessionConfiguration).
   - If a value can be specified in both a session config file and directly in the session options, this module will prefer the setting be in the config file.
 seealso:

--- a/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
+++ b/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
@@ -64,13 +64,44 @@
     async_poll: 0
   register: status
 
-- name: Wait for it to complete
-  async_status:
-    jid: "{{ status.ansible_job_id }}"
-  until: status.finished
-  retries: 10
-  delay: 1
-  register: status
+- name: Check that the task is not finished (was started async)
+  assert:
+    that: not status.finished
+    quiet: yes
+
+- name: Try to wait for it, so we're back in a good state for the next set of tests
+  # this block represents roughly what you would have to do in your plays if it weren't for the action plugin
+  # except the action is still more robust, as some of the operations restart the WinRM service more than once
+  # and none of this would work with check mode.
+  # If this becomes unstable, we may need to consider nesting another block/rescue, or putting this into another
+  # task file so we can loop over it, or introduce a "long enough" pause task, or possibly
+  # removing the async_poll: 0 tests altogether.
+  # Note that removing the test means not having any test that we're correctly returning asynchronously.
+  # https://github.com/ansible-collections/community.windows/issues/211
+  block:
+    - set_fact:
+        jid: "{{ status.ansible_job_id }}"
+
+    # we expect this one to fail with a connection error eventually and fall into to the rescue block
+    - name: Wait for it to complete
+      async_status:
+        jid: "{{ jid }}"
+      until: status.finished
+      retries: 10
+      delay: 1
+      register: status
+  rescue:
+    # once here, we'll use wait_for_connection before attempting to wait for status again
+    - wait_for_connection:
+
+    # repeat this task to ensure we finish the remote work
+    - name: Wait for it to complete
+      async_status:
+        jid: "{{ jid }}"
+      until: status.finished
+      retries: 10
+      delay: 1
+      register: status
 
 - name: Check for changed status
   assert:

--- a/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
+++ b/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
@@ -55,7 +55,7 @@
 
 #######
 
-- name: Change something async fire-and-forget
+- name: Try to disable polling (failure expected)
   win_pssession_configuration:
     name: "{{ config_name }}"
     description: "{{ config_description }}~~~~"
@@ -63,63 +63,13 @@
     async_timeout: 500
     async_poll: 0
   register: status
+  ignore_errors: yes
 
-- name: Check that the task is not finished (was started async)
+- name: Ensure it failed
   assert:
-    that: not status.finished
-    quiet: yes
-
-- name: Try to wait for it, so we're back in a good state for the next set of tests
-  # this block represents roughly what you would have to do in your plays if it weren't for the action plugin
-  # except the action is still more robust, as some of the operations restart the WinRM service more than once
-  # and none of this would work with check mode.
-  # If this becomes unstable, we may need to consider nesting another block/rescue, or putting this into another
-  # task file so we can loop over it, or introduce a "long enough" pause task, or possibly
-  # removing the async_poll: 0 tests altogether.
-  # Note that removing the test means not having any test that we're correctly returning asynchronously.
-  # https://github.com/ansible-collections/community.windows/issues/211
-  block:
-    - set_fact:
-        jid: "{{ status.ansible_job_id }}"
-
-    # we expect this one to fail with a connection error eventually and fall into to the rescue block
-    - name: Wait for it to complete
-      async_status:
-        jid: "{{ jid }}"
-      until: status.finished
-      retries: 10
-      delay: 1
-      register: status
-  rescue:
-    # once here, we'll use wait_for_connection before attempting to wait for status again
-    - wait_for_connection:
-
-    # repeat this task to ensure we finish the remote work
-    - name: Wait for it to complete
-      async_status:
-        jid: "{{ jid }}"
-      until: status.finished
-      retries: 10
-      delay: 1
-      register: status
-
-- name: Check for changed status
-  assert:
-    that: status is changed
-    quiet: yes
-
-- name: Change it back with custom async values
-  win_pssession_configuration:
-    name: "{{ config_name }}"
-    description: "{{ config_description }}"
-    modules_to_import: Microsoft.PowerShell.Utility
-    async_timeout: 500
-    async_poll: 2
-  register: status
-
-- name: Check for changed status
-  assert:
-    that: status is changed
+    that:
+      - status is failed
+      - status.msg is search('async_poll')
     quiet: yes
 
 - name: Try it with the keywords (failure expected)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes: #211
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

So this is interesting. A change in behavior in core around cleaning up after async tasks (https://github.com/ansible/ansible/pull/73760) seemed to be breaking the custom action in this module.

What it actually did was expose a bug in the implementation: when you set the `async_poll` option the action was never actually setting it on the task execution, so it always used the default polling of `15`. 

So the whole thing ends up running in polling mode anyway, and the action's loop of status checking only ever got invoked on the (inevitable) connection error that can't be handled properly by using `async_status` alone.

That fix is quite easy; what it then breaks is the "fire and forget" test, which.. should always have been broken (because if it wasn't, there'd be little need for the action other than convenience and check mode, since callers could use `async_status`).

~So I've updated the test to 1) actually ensure that the resulting `register:` result shows a status of `finished: 0` (this would have prevented this bug from being released in the first place), and 2) have enough stuff in the play tasks to actually wait for the result (hopefully). That last one may prove to be unstable in the future... I doubt it, but it could happen. If so, I have some remediation possibilities in the comments; in the worst case / quick fix that whole test case could be commented out or removed.~ 
this stuff is not all accurate, some of it is but I don't wanna edit it, just see later comments in this issue :-p

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_psession_configuration.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
