### PR TITLE
win_dhcp_lease: MAC address update to Docs

### DIFF
--- a/docs/community.windows.win_dhcp_lease_module.rst
+++ b/docs/community.windows.win_dhcp_lease_module.rst
@@ -243,7 +243,7 @@ Examples
 
     - name: Ensure DHCP lease or reservation does not exist
       community.windows.win_dhcp_lease:
-        mac: 00:B1:8A:D1:5A:1F
+        mac: 00-B1-8A-D1-5A-1F
         state: absent
 
     - name: Ensure DHCP lease or reservation does not exist


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using this module I was unable to create a DHCP reservation with a standard MAC address : seperator. Once I checked the code I could see it was looking for - and not : 

You can see it here:

https://github.com/ansible-collections/community.windows/blob/3afe02165344bf46534a9b56766e68531addac43/plugins/modules/win_dhcp_lease.ps1

line 124:

````
# MacAddress was specified
if ($mac) {
    if ($mac -like "*-*") {
        $mac_original = $mac
        $mac = Convert-MacAddress -mac $mac
    }
````

Once I made the update, the DHCP reservation worked.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Document updates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
