### PR TITLE
win_wait_for_process - fix multiple process_name_exact

### DIFF
--- a/changelogs/fragments/win_wait_for_process-exact.yml
+++ b/changelogs/fragments/win_wait_for_process-exact.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_wait_for_process - Fix bug when specifying multiple ``process_name_exact`` values - https://github.com/ansible-collections/community.windows/issues/203

--- a/plugins/modules/win_wait_for_process.ps1
+++ b/plugins/modules/win_wait_for_process.ps1
@@ -92,14 +92,8 @@ Function Get-FilteredProcesses {
         }
 
         # If a process name was specified in the filter, validate that here.
-        if ($ProcessNameExact -is [Array]) {
-            if ($ProcessNameExact -notcontains $Process.ProcessName) {
-                continue
-            }
-        } elseif ($ProcessNameExact) {
-            if ($ProcessNameExact -ne $Process.ProcessName) {
-                continue
-            }
+        if ($ProcessNameExact -and $ProcessNameExact -notcontains $Process.ProcessName) {
+            continue
         }
 
         # If a PID was specified in the filter, validate that here.

--- a/tests/integration/targets/win_wait_for_process/aliases
+++ b/tests/integration/targets/win_wait_for_process/aliases
@@ -1,2 +1,1 @@
 shippable/windows/group4
-unsupported  # cannot run until async_status redirection is in place

--- a/tests/integration/targets/win_wait_for_process/tasks/main.yml
+++ b/tests/integration/targets/win_wait_for_process/tasks/main.yml
@@ -103,6 +103,7 @@
   win_wait_for_process:
     process_name_exact:
     - spoolsv
+    - other_process  # Tests that just 1 needs to match
     timeout: 60
     state: absent
   async: 30


### PR DESCRIPTION
##### SUMMARY
The check for `process_name_exact` was checking against just an Array type when in reality `type = 'list'` creates a `[Collections.Generic.List[Object]]` type. This must have worked when the module was using the older module style which would have been an array but the not for the newer `Ansible.Basic` style. The fix is to not do the check at all because `Ansible.Basic` will always ensure it is a list even with 0 or 1 entry.

Also re-enables the test which was disabled in the initial migration to a collection.

Fixes https://github.com/ansible-collections/community.windows/issues/203

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_wait_for_process