### PR TITLE
Fix new devel sanity check

### DIFF
--- a/plugins/modules/win_http_proxy.ps1
+++ b/plugins/modules/win_http_proxy.ps1
@@ -8,7 +8,7 @@
 
 $spec = @{
     options = @{
-        bypass = @{ type = "list"; elements = "str" }
+        bypass = @{ type = "list"; elements = "str"; no_log = $false }
         proxy = @{ type = "raw" }
         source = @{ type = "str"; choices = @("ie") }
     }

--- a/plugins/modules/win_inet_proxy.ps1
+++ b/plugins/modules/win_inet_proxy.ps1
@@ -11,7 +11,7 @@ $spec = @{
         auto_detect = @{ type = "bool"; default = $true }
         auto_config_url = @{ type = "str" }
         proxy = @{ type = "raw" }
-        bypass = @{ type = "list"; elements = "str" }
+        bypass = @{ type = "list"; elements = "str"; no_log = $false }
         connection = @{ type = "str" }
     }
     required_by = @{

--- a/plugins/modules/win_shortcut.ps1
+++ b/plugins/modules/win_shortcut.ps1
@@ -15,7 +15,7 @@ $spec = @{
         state = @{ type='str'; default='present'; choices=@( 'absent', 'present' ) }
         arguments = @{ type='str'; aliases=@( 'args' ) }
         directory = @{ type='path' }
-        hotkey = @{ type='str' }
+        hotkey = @{ type='str'; no_log=$false }
         icon = @{ type='path' }
         description = @{ type='str' }
         windowstyle = @{ type='str'; choices=@( 'maximized', 'minimized', 'normal' ) }


### PR DESCRIPTION
##### SUMMARY
A new devel sanity check makes sure that options with the value `pass`, `key`, and probably others have an explicit `no_log` entry to ensure sensitive fields are masked. In this case all 3 just need `no_log = $false` as they are not sensitive.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_inet_proxy
win_http_proxy
win_shortcut