### PR TITLE
Fix failing installation of prerequisites

### DIFF
--- a/changelogs/fragments/win_psmodule-prereq.yml
+++ b/changelogs/fragments/win_psmodule-prereq.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_psmodule - Makes sure ``-AllowClobber`` is used when updating pre-requisites if requested - https://github.com/ansible-collections/community.windows/issues/42

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -60,6 +60,7 @@ Function Install-NugetProvider {
 Function Install-PrereqModule {
     Param(
         [Switch]$TestInstallationOnly,
+        [bool]$AllowClobber,
         [Bool]$CheckMode
     )
 
@@ -84,12 +85,15 @@ Function Install-PrereqModule {
                     $install_params = @{
                         Name = $Name
                         MinimumVersion = $PrereqModules[$Name]
-                        AllowClobber = $allow_clobber
                         Force = $true
                         WhatIf = $CheckMode
                     }
-                    if ((Get-Command -Name Install-Module).Parameters.ContainsKey('SkipPublisherCheck')) {
+                    $installCmd = Get-Command -Name Install-Module
+                    if ($installCmd.Parameters.ContainsKey('SkipPublisherCheck')) {
                         $install_params.SkipPublisherCheck = $true
+                    }
+                    if ($installCmd.Parameters.ContainsKey('AllowClobber')) {
+                        $install_params.AllowClobber = $AllowClobber
                     }
 
                     Install-Module @install_params > $null
@@ -422,7 +426,7 @@ if ( ($allow_clobber -or $allow_prerelease -or $skip_publisher_check -or
     $required_version -or $minimum_version -or $maximum_version) ) {
     # Update the PowerShellGet and PackageManagement modules.
     # It's required to support AllowClobber, AllowPrerelease parameters.
-    Install-PrereqModule -CheckMode $check_mode
+    Install-PrereqModule -AllowClobber $allow_clobber -CheckMode $check_mode
 }
 
 Import-Module -Name PackageManagement, PowerShellGet

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -84,6 +84,7 @@ Function Install-PrereqModule {
                     $install_params = @{
                         Name = $Name
                         MinimumVersion = $PrereqModules[$Name]
+                        AllowClobber = $allow_clobber
                         Force = $true
                         WhatIf = $CheckMode
                     }


### PR DESCRIPTION
#42  win_psmodule fails to install the prerequisites due to absence of AllowClobber

##### SUMMARY
Fixing #42 an error occurred during the installation of the prerequisites, providing an
error message to enable or user -AllowClobber. While using AllowClobber. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule

##### ADDITIONAL INFORMATION
AllowClobber will now also be effective during installation of prerequisites

```
