### PR TITLE
Enable keeping last empty line for win_lineinfile

### DIFF
--- a/changelogs/fragments/win_lineinfile-newline.yml
+++ b/changelogs/fragments/win_lineinfile-newline.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_lineinfile - Avoid stripping the newline at the end of a file - https://github.com/ansible-collections/community.windows/pull/219

--- a/plugins/modules/win_lineinfile.ps1
+++ b/plugins/modules/win_lineinfile.ps1
@@ -67,6 +67,7 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 	# Note that we have to clean up the path because ansible wants to treat / and \ as
 	# interchangeable in windows pathnames, but .NET framework internals do not support that.
 	$cleanpath = $path.Replace("/", "\");
+    $endswithnewline = $null
 
 	# Check if path exists. If it does not exist, either create it if create == "yes"
 	# was specified or fail with a reasonable error message.
@@ -76,6 +77,7 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 		}
 		# Create new empty file, using the specified encoding to write correct BOM
 		[System.IO.File]::WriteAllLines($cleanpath, "", $encodingobj);
+        $endswithnewline = $false
 	}
 
 	# Initialize result information
@@ -96,6 +98,10 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 	}
 	Else {
 		$lines = [System.Collections.ArrayList] $before;
+        If ($null -eq $endswithnewline ) {
+            $alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
+            $endswithnewline = (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r"))
+        }
 	}
 
 	if ($diff_support) {
@@ -195,6 +201,10 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 			$result.backup = $result.backup_file
 		}
 
+        if ($endswithnewline) {
+            $lines.Add("")
+        }
+
 		$writelines_params = @{
 			outlines = $lines
 			path = $path
@@ -241,6 +251,10 @@ function Absent($path, $regex, $line, $backup, $validate, $encodingobj, $linesep
 	}
 	Else {
 		$lines = [System.Collections.ArrayList] $before;
+        $alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
+        If (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r")) {
+            $lines.Add("")
+        }
 	}
 
 	if ($diff_support) {

--- a/plugins/modules/win_lineinfile.ps1
+++ b/plugins/modules/win_lineinfile.ps1
@@ -67,7 +67,7 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 	# Note that we have to clean up the path because ansible wants to treat / and \ as
 	# interchangeable in windows pathnames, but .NET framework internals do not support that.
 	$cleanpath = $path.Replace("/", "\");
-    $endswithnewline = $null
+	$endswithnewline = $null
 
 	# Check if path exists. If it does not exist, either create it if create == "yes"
 	# was specified or fail with a reasonable error message.
@@ -77,7 +77,7 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 		}
 		# Create new empty file, using the specified encoding to write correct BOM
 		[System.IO.File]::WriteAllLines($cleanpath, "", $encodingobj);
-        $endswithnewline = $false
+		$endswithnewline = $false
 	}
 
 	# Initialize result information
@@ -98,10 +98,10 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 	}
 	Else {
 		$lines = [System.Collections.ArrayList] $before;
-        If ($null -eq $endswithnewline ) {
-            $alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
-            $endswithnewline = (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r"))
-        }
+		If ($null -eq $endswithnewline ) {
+			$alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
+			$endswithnewline = (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r"))
+		}
 	}
 
 	if ($diff_support) {
@@ -201,9 +201,9 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 			$result.backup = $result.backup_file
 		}
 
-        if ($endswithnewline) {
-            $lines.Add("")
-        }
+		if ($endswithnewline) {
+			$lines.Add("")
+		}
 
 		$writelines_params = @{
 			outlines = $lines
@@ -251,10 +251,10 @@ function Absent($path, $regex, $line, $backup, $validate, $encodingobj, $linesep
 	}
 	Else {
 		$lines = [System.Collections.ArrayList] $before;
-        $alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
-        If (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r")) {
-            $lines.Add("")
-        }
+		$alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
+		If (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r")) {
+			$lines.Add("")
+		}
 	}
 
 	if ($diff_support) {

--- a/tests/integration/targets/win_lineinfile/files/expectations/.gitattributes
+++ b/tests/integration/targets/win_lineinfile/files/expectations/.gitattributes
@@ -1,0 +1,4 @@
+*.text text eol=LF
+*.txt text eol=CRLF
+*.txt16 text working-tree-encoding=UTF-16 eol=CRLF
+*.txt32	text working-tree-encoding=UTF-32 eol=CRLF

--- a/tests/integration/targets/win_lineinfile/files/expectations/01_new_line_at_bof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/01_new_line_at_bof.txt
@@ -1,0 +1,6 @@
+New line at the beginning
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5

--- a/tests/integration/targets/win_lineinfile/files/expectations/02_new_line_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/02_new_line_at_eof.txt
@@ -1,0 +1,7 @@
+New line at the beginning
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/03_new_line_after_1.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/03_new_line_after_1.txt
@@ -1,0 +1,8 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/04_new_line_before_5.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/04_new_line_before_5.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+New line before line 5
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/05_new_line_at_REF.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/05_new_line_at_REF.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 3
+This is line 4
+New line before line 5
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/06_remove_middle_line.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/06_remove_middle_line.txt
@@ -1,0 +1,8 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/07_remove_line_5.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/07_remove_line_5.txt
@@ -1,0 +1,7 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/08_no_expected_change.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/08_no_expected_change.txt
@@ -1,0 +1,7 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/09_new_file.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/09_new_file.txt
@@ -1,0 +1,1 @@
+This is a new file

--- a/tests/integration/targets/win_lineinfile/files/expectations/10_no_eof_new_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/10_no_eof_new_at_eof.txt
@@ -1,0 +1,3 @@
+This is line 1
+This is line 2
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/11_multiline_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/11_multiline_at_eof.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+New line at the end
+This is a line
+with newline character

--- a/tests/integration/targets/win_lineinfile/files/expectations/12_empty_file_add_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/12_empty_file_add_at_eof.txt
@@ -1,0 +1,1 @@
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/13_new_4_with_backref.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/13_new_4_with_backref.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+New line 4 created with the backref
+New line before line 5
+New line at the end
+This is a line
+with newline character

--- a/tests/integration/targets/win_lineinfile/files/expectations/14_quoting_code.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/14_quoting_code.txt
@@ -1,0 +1,3 @@
+var dotenv = require('dotenv');
+dotenv.load();
+'foo'

--- a/tests/integration/targets/win_lineinfile/files/expectations/15_single_quote.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/15_single_quote.txt
@@ -1,0 +1,4 @@
+var dotenv = require('dotenv');
+dotenv.load();
+'foo'
+import g'

--- a/tests/integration/targets/win_lineinfile/files/expectations/16_multiple_quotes.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/16_multiple_quotes.txt
@@ -1,0 +1,5 @@
+var dotenv = require('dotenv');
+dotenv.load();
+'foo'
+import g'
+"quote" and "unquote"

--- a/tests/integration/targets/win_lineinfile/files/expectations/17_new_file_win.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/17_new_file_win.txt
@@ -1,0 +1,1 @@
+This is a new file

--- a/tests/integration/targets/win_lineinfile/files/expectations/18_sep_win.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/18_sep_win.txt
@@ -1,0 +1,2 @@
+This is a new file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/19_new_file_unix.text
+++ b/tests/integration/targets/win_lineinfile/files/expectations/19_new_file_unix.text
@@ -1,0 +1,1 @@
+This is a new file

--- a/tests/integration/targets/win_lineinfile/files/expectations/20_sep_unix.text
+++ b/tests/integration/targets/win_lineinfile/files/expectations/20_sep_unix.text
@@ -1,0 +1,2 @@
+This is a new file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/21_utf8_no_bom.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/21_utf8_no_bom.txt
@@ -1,0 +1,1 @@
+This is a new utf-8 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/22_utf8_no_bom_line_added.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/22_utf8_no_bom_line_added.txt
@@ -1,0 +1,2 @@
+This is a new utf-8 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt
@@ -1,0 +1,1 @@
+﻿This is a new utf-8 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt
@@ -1,0 +1,2 @@
+﻿This is a new utf-8 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/25_utf16.txt16
+++ b/tests/integration/targets/win_lineinfile/files/expectations/25_utf16.txt16
@@ -1,0 +1,1 @@
+This is a new utf-16 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/26_utf16_line_added.txt16
+++ b/tests/integration/targets/win_lineinfile/files/expectations/26_utf16_line_added.txt16
@@ -1,0 +1,2 @@
+This is a new utf-16 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/27_utf32.txt32
+++ b/tests/integration/targets/win_lineinfile/files/expectations/27_utf32.txt32
@@ -1,0 +1,1 @@
+This is a new utf-32 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/28_utf32_line_added.txt32
+++ b/tests/integration/targets/win_lineinfile/files/expectations/28_utf32_line_added.txt32
@@ -1,0 +1,2 @@
+This is a new utf-32 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/29_no_linebreak.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/29_no_linebreak.txt
@@ -1,0 +1,1 @@
+c:\return\new

--- a/tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt
@@ -1,0 +1,3 @@
+c:\return\new
+c:eturn
+ew

--- a/tests/integration/targets/win_lineinfile/files/expectations/31_relative_path.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/31_relative_path.txt
@@ -1,0 +1,6 @@
+New line at the beginning
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5

--- a/tests/integration/targets/win_lineinfile/files/expectations/99_README.md
+++ b/tests/integration/targets/win_lineinfile/files/expectations/99_README.md
@@ -1,0 +1,36 @@
+***WIN LINEINFILE Expectations***
+
+This folder contains expected files as the tests in this playbook executes on the
+files in 'files'. 
+
+To get the checksum as would win_stat in the tests, go to this folder in powershell and
+execute
+
+```powershell
+Get-ChildItem | ForEach-Object {
+    $fp = [System.IO.File]::Open("$pwd/$($_.Name)", [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    Write-Output $_.Name
+    try {
+        [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower()
+    } finally {
+        $fp.Dispose()
+    }
+    Write-Output ""
+}
+```
+
+There is one exception right now: 30_linebreaks_checksum_bad.txt which requires mixed line endings that 
+git cannot handle without turning the file binary. The file should read
+
+```
+c:\return\newCRLF
+c:CR
+eturnLF
+ew
+```
+where CR and LF denote carriage return (\r) and line feed (\n) respectively, to get the correct checksum.
+
+Also, the .gitattributes files is important as it assures that the EOL characters
+for the files are correct, regardless of environment. The files may be checked out on
+linux but the resulting files will be created using windows EOL, and the comparison must
+match.

--- a/tests/integration/targets/win_lineinfile/tasks/main.yml
+++ b/tests/integration/targets/win_lineinfile/tasks/main.yml
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-
 - name: deploy the test file for lineinfile
   ansible.windows.win_copy: src=test.txt dest={{ remote_tmp_dir }}/test.txt
   register: result
@@ -26,6 +25,10 @@
     - "result.changed == true"
 
 - name: stat the test file
+  # Note: The test.txt is copied from a Linux host, therefore it will retain
+  # unix line ending when stat'd here. This affects checksum, meaning that
+  # when this repo is checked out to Windows, checksum does not match checked-
+  # out file checksum unless line-endings are altered.
   ansible.windows.win_stat: path={{ remote_tmp_dir }}/test.txt
   register: result
 
@@ -40,6 +43,7 @@
 
 
 - name: insert a line at the beginning of the file, and back it up
+  # 01
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="New line at the beginning" insertbefore="BOF" backup=yes
   register: result
 
@@ -71,9 +75,10 @@
 - name: assert test hash is what we expect for the file with the insert at the head
   assert:
     that:
-    - "result.stat.checksum == 'b526e2e044defc64dfb0fad2f56e105178f317d8'"
+    - result.stat.checksum == 'c61233b0ee2038aab41b5f30683c57b2a013b376'
 
 - name: insert a line at the end of the file
+  # 02
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="New line at the end" insertafter="EOF"
   register: result
 
@@ -90,9 +95,10 @@
 - name: assert test checksum matches after the insert at the end
   assert:
     that:
-    - "result.stat.checksum == 'dd5e207e28ce694ab18e41c2b16deb74fde93b14'"
+    - result.stat.checksum == 'a91260ad67b00609cc0737ff70ac5170c6a519a8'
 
 - name: insert a line after the first line
+  # 03
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="New line after line 1" insertafter="^This is line 1$"
   register: result
 
@@ -109,9 +115,10 @@
 - name: assert test checksum matches after the insert after the first line
   assert:
     that:
-    - "result.stat.checksum == '604b17405f2088e6868af9680b7834087acdc8f4'"
+    - result.stat.checksum == '6ffbabdaa21ecb3593d32144de535598cfd7c6ea'
 
 - name: insert a line before the last line
+  # 04
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="New line before line 5" insertbefore="^This is line 5$"
   register: result
 
@@ -128,9 +135,10 @@
 - name: assert test checksum matches after the insert before the last line
   assert:
     that:
-    - "result.stat.checksum == '8f5b30e8f01578043d782e5a68d4c327e75a6e34'"
+    - result.stat.checksum == '49d988ad97fb4cce3ad795c8459f1cde231a891b'
 
 - name: replace a line with backrefs
+  # 05
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="This is line 3" backrefs=yes regexp="^(REF).*$"
   register: result
 
@@ -140,6 +148,7 @@
     - "result.changed == true"
     - "result.msg == 'line replaced'"
 
+
 - name: stat the test after the backref line was replaced
   ansible.windows.win_stat: path={{ remote_tmp_dir }}/test.txt
   register: result
@@ -147,9 +156,10 @@
 - name: assert test checksum matches after backref line was replaced
   assert:
     that:
-    - "result.stat.checksum == 'ef6b02645908511a2cfd2df29d50dd008897c580'"
+    - result.stat.checksum == '6f9c2128f4c886f3c40c1f1cf50241d74f160437'
 
 - name: remove the middle line
+  # 06
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=absent regexp="^This is line 3$"
   register: result
 
@@ -166,9 +176,10 @@
 - name: assert test checksum matches after the middle line was removed
   assert:
     that:
-    - "result.stat.checksum == '11695efa472be5c31c736bc43e055f8ac90eabdf'"
+    - result.stat.checksum == '4b7910c84bd1177b9013f277c85d5be55f384a36'
 
 - name: run a validation script that succeeds
+  # 07
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=absent regexp="^This is line 5$" validate="sort.exe %s"
   register: result
 
@@ -185,9 +196,10 @@
 - name: assert test checksum matches after the validation succeeded
   assert:
     that:
-    - "result.stat.checksum == '39c38a30aa6ac6af9ec41f54c7ed7683f1249347'"
+    - result.stat.checksum == '938afecdcde51fda42ddbea6f2e92876e710f289'
 
 - name: run a validation script that fails
+  # 08
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=absent regexp="^This is line 1$" validate="sort.exe %s.foo"
   register: result
   ignore_errors: yes
@@ -204,9 +216,10 @@
 - name: assert test checksum matches the previous after the validation failed
   assert:
     that:
-    - "result.stat.checksum == '39c38a30aa6ac6af9ec41f54c7ed7683f1249347'"
+    - result.stat.checksum == '938afecdcde51fda42ddbea6f2e92876e710f289'
 
 - name: use create=yes
+  # 09
   win_lineinfile: dest={{ remote_tmp_dir }}/new_test.txt create=yes insertbefore=BOF state=present line="This is a new file"
   register: result
 
@@ -224,7 +237,7 @@
 - name: assert the newly created test checksum matches
   assert:
     that:
-    - "result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'"
+    - result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
 
 # Test EOF in cases where file has no newline at EOF
 - name: testnoeof deploy the file for lineinfile
@@ -232,6 +245,7 @@
   register: result
 
 - name: testnoeof insert a line at the end of the file
+  # 10
   win_lineinfile: dest={{ remote_tmp_dir }}/testnoeof.txt state=present line="New line at the end" insertafter="EOF"
   register: result
 
@@ -248,9 +262,10 @@
 - name: testnoeof assert test checksum matches after the insert at the end
   assert:
     that:
-    - "result.stat.checksum == '229852b09f7e9921fbcbb0ee0166ba78f7f7f261'"
+    - result.stat.checksum == '229852b09f7e9921fbcbb0ee0166ba78f7f7f261'
 
 - name: add multiple lines at the end of the file
+  # 11
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="This is a line\r\nwith newline character" insertafter="EOF"
   register: result
 
@@ -267,7 +282,7 @@
 - name: assert test checksum matches after inserting multiple lines
   assert:
     that:
-    - "result.stat.checksum == '1401413cd4eac732be66cd6aceddd334c4240f86'"
+    - result.stat.checksum == 'd10d70cb77a16fb54f143bccbf711f3177acd310'
 
 
 
@@ -277,6 +292,7 @@
   register: result
 
 - name: testempty insert a line at the end of the file
+  # 12
   win_lineinfile: dest={{ remote_tmp_dir }}/testempty.txt state=present line="New line at the end" insertafter="EOF"
   register: result
 
@@ -293,11 +309,10 @@
 - name: testempty assert test checksum matches after the insert at the end
   assert:
     that:
-    - "result.stat.checksum == 'd3d34f11edda51be7ca5dcb0757cf3e1257c0bfe'"
-
-
+    - result.stat.checksum == 'd3d34f11edda51be7ca5dcb0757cf3e1257c0bfe'
 
 - name: replace a line with backrefs included in the line
+  # 13
   win_lineinfile: dest={{ remote_tmp_dir }}/test.txt state=present line="New $1 created with the backref" backrefs=yes regexp="^This is (line 4)$"
   register: result
 
@@ -314,12 +329,13 @@
 - name: assert test checksum matches after backref line was replaced
   assert:
     that:
-    - "result.stat.checksum == 'e6ff42e926dac2274c93dff0b8a323e07ae09149'"
+    - result.stat.checksum == '9c1a1451b50665e59be666c5d8c08fb99603d4f1'
 
 ###################################################################
 # issue 8535
 
 - name: create a new file for testing quoting issues
+  # 14
   ansible.windows.win_copy: src=test_quoting.txt dest={{ remote_tmp_dir }}/test_quoting.txt
   register: result
 
@@ -357,9 +373,10 @@
 - name: assert test checksum matches for quote test file
   assert:
     that:
-    - "result.stat.checksum == 'f3bccdbdfa1d7176c497ef87d04957af40ab48d2'"
+    - result.stat.checksum == 'f3bccdbdfa1d7176c497ef87d04957af40ab48d2'
 
 - name: append a line into the quoted file with a single quote
+  # 15
   win_lineinfile: dest={{ remote_tmp_dir }}/test_quoting.txt line="import g'"
   register: result
 
@@ -375,9 +392,10 @@
 - name: assert test checksum matches adding line with single quote
   assert:
     that:
-    - "result.stat.checksum == 'dabf4cbe471e1797d8dcfc773b6b638c524d5237'"
+    - result.stat.checksum == 'dabf4cbe471e1797d8dcfc773b6b638c524d5237'
 
 - name: insert a line into the quoted file with many double quotation strings
+  # 16
   win_lineinfile: dest={{ remote_tmp_dir }}/test_quoting.txt line='"quote" and "unquote"'
   register: result
 
@@ -393,12 +411,12 @@
 - name: assert test checksum matches quoted line added
   assert:
     that:
-    - "result.stat.checksum == '9dc1fc1ff19942e2936564102ad37134fa83b91d'"
+    - result.stat.checksum == '9dc1fc1ff19942e2936564102ad37134fa83b91d'
 
 
 # Windows vs. Unix line separator test cases
-
 - name: Create windows test file with initial line
+  # 17
   win_lineinfile: dest={{ remote_tmp_dir }}/test_windows_sep.txt create=yes insertbefore=BOF state=present line="This is a new file"
   register: result
 
@@ -415,9 +433,10 @@
 - name: assert the newly created file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'"
+    - result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
 
 - name: Test appending to the file using the default (windows) line separator
+  # 18
   win_lineinfile: dest={{ remote_tmp_dir }}/test_windows_sep.txt insertbefore=EOF state=present line="This is the last line"
   register: result
 
@@ -434,10 +453,11 @@
 - name: assert the file checksum matches expected checksum
   assert:
     that:
-    - "result.stat.checksum == '71a17ddd1d57ed7c7912e4fd11ecb2ead0b27033'"
+    - result.stat.checksum == '6c6f51f98eb499852fbb7ef3b212c26752c25c31'
 
 
 - name: Create unix test file with initial line
+  # 19
   win_lineinfile: dest={{ remote_tmp_dir }}/test_unix_sep.txt create=yes insertbefore=BOF state=present line="This is a new file"
   register: result
 
@@ -454,9 +474,10 @@
 - name: assert the newly created file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'"
+    - result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
 
 - name: Test appending to the file using unix line separator
+  # 20
   win_lineinfile: dest={{ remote_tmp_dir }}/test_unix_sep.txt insertbefore=EOF state=present line="This is the last line" newline="unix"
   register: result
 
@@ -473,13 +494,14 @@
 - name: assert the file checksum matches expected checksum
   assert:
     that:
-    - "result.stat.checksum == 'f1f634a37ab1c73efb77a71a5ad2cc87b61b17ae'"
+    - result.stat.checksum == '4aa2ad771bb1453406760eadee8234265d599dcf'
 
 
 # Encoding management test cases
 
 # Default (auto) encoding should use utf-8 with no BOM
 - name: Test create file without explicit encoding results in utf-8 without BOM
+  # 21
   win_lineinfile: dest={{ remote_tmp_dir }}/test_auto_utf8.txt create=yes insertbefore=BOF state=present line="This is a new utf-8 file"
   register: result
 
@@ -497,9 +519,10 @@
 - name: assert the newly created file checksum matches
   assert:
     that:
-    - "result.stat.checksum == 'b69fcbacca8291a4668f57fba91d7c022f1c3dc7'"
+    - result.stat.checksum == 'b69fcbacca8291a4668f57fba91d7c022f1c3dc7'
 
 - name: Test appending to the utf-8 without BOM file - should autodetect UTF-8 no BOM
+  # 22
   win_lineinfile: dest={{ remote_tmp_dir }}/test_auto_utf8.txt insertbefore=EOF state=present line="This is the last line"
   register: result
 
@@ -517,11 +540,12 @@
 - name: assert the file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '64d747f1ebf8c9d793dbfd27126e4152d39a3848'"
+    - result.stat.checksum == 'aeb246a40f614889534f4983f47c5567625ade53'
 
 
 # UTF-8 explicit (with BOM)
 - name: Test create file with explicit utf-8 encoding results in utf-8 with a BOM
+  # 23
   win_lineinfile: dest={{ remote_tmp_dir }}/test_utf8.txt create=yes encoding="utf-8" insertbefore=BOF state=present line="This is a new utf-8 file"
   register: result
 
@@ -539,9 +563,10 @@
 - name: assert the newly created file checksum matches
   assert:
     that:
-    - "result.stat.checksum == 'd45344b2b3bf1cf90eae851b40612f5f37a88bbb'"
+    - result.stat.checksum == 'd45344b2b3bf1cf90eae851b40612f5f37a88bbb'
 
 - name: Test appending to the utf-8 with BOM file - should autodetect utf-8 with BOM encoding
+  # 24
   win_lineinfile: dest={{ remote_tmp_dir }}/test_utf8.txt insertbefore=EOF state=present line="This is the last line"
   register: result
 
@@ -559,11 +584,12 @@
 - name: assert the file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '9b84254489f40f258871a4c6573cacc65895ee1a'"
+    - result.stat.checksum == '64c62066d06ea6c807a8fe98bc40c4903cf4c119'
 
 
 # UTF-16 explicit
 - name: Test create file with explicit utf-16 encoding
+  # 25
   win_lineinfile: dest={{ remote_tmp_dir }}/test_utf16.txt create=yes encoding="utf-16" insertbefore=BOF state=present line="This is a new utf-16 file"
   register: result
 
@@ -581,9 +607,10 @@
 - name: assert the newly created file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '785b0693cec13b60e2c232782adeda2f8a967434'"
+    - result.stat.checksum == '785b0693cec13b60e2c232782adeda2f8a967434'
 
 - name: Test appending to the utf-16 file - should autodetect utf-16 encoding
+  # 26
   win_lineinfile: dest={{ remote_tmp_dir }}/test_utf16.txt insertbefore=EOF state=present line="This is the last line"
   register: result
 
@@ -601,10 +628,11 @@
 - name: assert the file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '70e4eb3ba795e1ba94d262db47e4fd17c64b2e73'"
+    - result.stat.checksum == '7f790f323e496b7138883a3634514cc2a3426919'
 
 # UTF-32 explicit
 - name: Test create file with explicit utf-32 encoding
+  # 27
   win_lineinfile: dest={{ remote_tmp_dir }}/test_utf32.txt create=yes encoding="utf-32" insertbefore=BOF state=present line="This is a new utf-32 file"
   register: result
 
@@ -622,9 +650,10 @@
 - name: assert the newly created file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '7a6e3f3604c0def431aaa813173a4ddaa10fd1fb'"
+    - result.stat.checksum == '7a6e3f3604c0def431aaa813173a4ddaa10fd1fb'
 
 - name: Test appending to the utf-32 file - should autodetect utf-32 encoding
+  # 28
   win_lineinfile: dest={{ remote_tmp_dir }}/test_utf32.txt insertbefore=EOF state=present line="This is the last line"
   register: result
 
@@ -642,7 +671,7 @@
 - name: assert the file checksum matches
   assert:
     that:
-    - "result.stat.checksum == '66a72e71f42c4775f4326da95cfe82c8830e5022'"
+    - result.stat.checksum == 'd13e135c7d466cc2f985d72f12ffaa73567772e6'
 
 #########################################################################
 # issue #33858
@@ -658,23 +687,24 @@
     path: "{{ remote_tmp_dir }}/test_linebreak.txt"
   register: result
 
-# (Get-FileHash -path C:\ansible\test\integration\targets\win_lineinfile\files\test_linebreak.txt -Algorithm sha1).hash.tolower()
 - name: check win_stat file result
   assert:
     that:
-      - result.stat.exists
-      - not result.stat.isdir
-      - result.stat.checksum == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
-      - result is not failed
-      - result is not changed
+    - result.stat.exists
+    - not result.stat.isdir
+    - result.stat.checksum == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    - result is not failed
+    - result is not changed
 
 - name: insert path c:\return\new to test file
+  # 29
   win_lineinfile:
     dest: "{{ remote_tmp_dir }}/test_linebreak.txt"
     line: c:\return\new
   register: result_literal
 
 - name: insert path "c:\return\new" to test file, will cause line breaks
+  # 30
   win_lineinfile:
     dest: "{{ remote_tmp_dir }}/test_linebreak.txt"
     line: "c:\return\new"
@@ -692,17 +722,82 @@
   ansible.windows.win_stat:
     path: "{{ remote_tmp_dir }}/test_linebreak.txt"
   register: result
-
-- debug:
-    var: result
-    verbosity: 1
-
-# expect that the file looks like this:
-# c:\return\new
-# c:
-# eturn
-# ew #or c:eturnew  on windows
+    
 - name: assert that one line is literal and the other has breaks
   assert:
     that:
     - result.stat.checksum == 'd2dfd11bc70526ff13a91153c76a7ae5595a845b'
+
+- name: Get current working directory
+  win_shell: $pwd.Path
+  register: pwd
+
+- name: create a relative tmp dir
+  ansible.windows.win_tempfile:
+    path: "{{ pwd.stdout | trim | win_dirname  }}"
+    state: directory
+  register: relative_tmp_dir
+
+- name: Check that relative paths work
+  block:
+    - name: deploy the test file for lineinfile
+      ansible.windows.win_copy: src=test.txt dest={{ relative_tmp_dir.path }}/test.txt
+      register: result
+
+    - name: assert that the test file was deployed
+      assert:
+        that:
+        - "result.changed == true"
+
+    - name: stat the test file
+      ansible.windows.win_stat: path={{ relative_tmp_dir.path }}/test.txt
+      register: result
+
+    - name: check win_stat file result
+      assert:
+        that:
+          - "result.stat.exists"
+          - "not result.stat.isdir"
+          - "result.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'"
+          - "result is not failed"
+          - "result is not changed"
+
+    - name: insert a line at the beginning of the file, and back it up
+      # 31
+      win_lineinfile: dest=../{{ relative_tmp_dir.path | win_basename  }}/test.txt state=present line="New line at the beginning" insertbefore="BOF" backup=yes
+      register: result
+
+    - name: check backup_file
+      ansible.windows.win_stat:
+        path: '{{ result.backup_file }}'
+      register: backup_file
+
+    - name: assert that the line was inserted at the head of the file
+      assert:
+        that:
+        - result.changed == true
+        - result.msg == 'line added'
+        - backup_file.stat.exists == true
+
+    - name: stat the backup file
+      ansible.windows.win_stat: path={{result.backup}}
+      register: result
+
+    - name: assert the backup file matches the previous hash
+      assert:
+        that:
+        - "result.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'"
+
+    - name: stat the test after the insert at the head
+      ansible.windows.win_stat: path={{ relative_tmp_dir.path }}/test.txt
+      register: result
+
+    - name: assert test hash is what we expect for the file with the insert at the head
+      assert:
+        that:
+        - result.stat.checksum == 'c61233b0ee2038aab41b5f30683c57b2a013b376'
+
+  always:
+    - ansible.windows.win_file:
+        path: "{{ relative_tmp_dir.path  }}"
+        state: absent

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -5,6 +5,9 @@ plugins/modules/win_region.ps1 pslint:PSAvoidUsingEmptyCatchBlock # Keep
 plugins/modules/win_regmerge.ps1 pslint:PSCustomUseLiteralPath
 plugins/modules/win_robocopy.ps1 pslint:PSCustomUseLiteralPath
 tests/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 pslint:PSCustomUseLiteralPath
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings
 tests/integration/targets/win_psmodule/files/module/template.psd1 pslint!skip
 tests/integration/targets/win_psmodule/files/module/template.psm1 pslint!skip
 tests/integration/targets/win_psmodule/files/setup_modules.ps1 pslint:PSCustomUseLiteralPath

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -5,6 +5,9 @@ plugins/modules/win_region.ps1 pslint:PSAvoidUsingEmptyCatchBlock # Keep
 plugins/modules/win_regmerge.ps1 pslint:PSCustomUseLiteralPath
 plugins/modules/win_robocopy.ps1 pslint:PSCustomUseLiteralPath
 tests/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 pslint:PSCustomUseLiteralPath
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings
 tests/integration/targets/win_psmodule/files/module/template.psd1 pslint!skip
 tests/integration/targets/win_psmodule/files/module/template.psm1 pslint!skip
 tests/integration/targets/win_psmodule/files/setup_modules.ps1 pslint:PSCustomUseLiteralPath

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -5,6 +5,9 @@ plugins/modules/win_region.ps1 pslint:PSAvoidUsingEmptyCatchBlock # Keep
 plugins/modules/win_regmerge.ps1 pslint:PSCustomUseLiteralPath
 plugins/modules/win_robocopy.ps1 pslint:PSCustomUseLiteralPath
 tests/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 pslint:PSCustomUseLiteralPath
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings
 tests/integration/targets/win_psmodule/files/module/template.psd1 pslint!skip
 tests/integration/targets/win_psmodule/files/module/template.psm1 pslint!skip
 tests/integration/targets/win_psmodule/files/setup_modules.ps1 pslint:PSCustomUseLiteralPath


### PR DESCRIPTION
##### SUMMARY
Ensure that  win_lineinfile keeps empty last line
in the output file when changed.

Fixes: #218

##### ISSUE TYPE
- Bug fix

##### COMPONENT NAME
win_lineinfile

