### PR TITLE
Fix win_lineinfile crash

### DIFF
--- a/changelogs/fragments/win_lineinfile-warning.yaml
+++ b/changelogs/fragments/win_lineinfile-warning.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_lineinfile - Fix crash when using ``insertbefore`` and ``insertafter`` at the same time - https://github.com/ansible-collections/community.windows/issues/220

--- a/plugins/modules/win_lineinfile.ps1
+++ b/plugins/modules/win_lineinfile.ps1
@@ -85,6 +85,10 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 		msg = "";
 	}
 
+	If ($insertbefore -and $insertafter) {
+		Add-Warning $result "Both insertbefore and insertafter parameters found, ignoring `"insertafter=$insertafter`""
+	}
+
 	# Read the dest file lines using the indicated encoding into a mutable ArrayList.
 	$before = [System.IO.File]::ReadAllLines($cleanpath, $encodingobj)
 	If ($null -eq $before) {
@@ -401,10 +405,6 @@ If ($state -eq "present") {
 
 	If (-not $line) {
 		Fail-Json @{} "line= is required with state=present";
-	}
-
-	If ($insertbefore -and $insertafter) {
-		Add-Warning $result "Both insertbefore and insertafter parameters found, ignoring `"insertafter=$insertafter`""
 	}
 
 	If (-not $insertbefore -and -not $insertafter) {


### PR DESCRIPTION
##### SUMMARY
win_lineinfile module crashes if insertafter and insertbefore
parameters are simultaneously given. By moving when the warning
is issued to after init of result variable, the crash is avoided.

Fixes #220 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_lineinfile