### PR TITLE
win_partition, win_format - Adding directory mountpoint handling

### DIFF
--- a/plugins/modules/win_format.ps1
+++ b/plugins/modules/win_format.ps1
@@ -19,21 +19,29 @@ $spec = @{
         file_system = @{ type = "str"; choices = "ntfs", "refs", "exfat", "fat32", "fat" }
         allocation_unit_size = @{ type = "int" }
         large_frs = @{ type = "bool" }
-        full = @{ type = "bool"; default = $false }
-        compress = @{ type = "bool" }
+        full_format = @{ type = "bool"; default = $false }
+        compress_volume = @{ type = "bool" }
         integrity_streams = @{ type = "bool" }
         force = @{ type = "bool"; default = $false }
+        filepath = @{ type = "str" }
     }
     mutually_exclusive = @(
-        ,@('drive_letter', 'path', 'label')
+        ,@('drive_letter', 'path', 'label', 'filepath')
     )
     required_one_of = @(
-        ,@('drive_letter', 'path', 'label')
+        ,@('drive_letter', 'path', 'label', 'filepath')
     )
     supports_check_mode = $true
 }
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$filepath = $null
+
+if(Test-Path $drive_letter -PathType Container) {
+    $filepath = $drive_letter
+    $drive_letter = $null
+}
 
 $drive_letter = $module.Params.drive_letter
 $path = $module.Params.path
@@ -69,7 +77,8 @@ function Get-AnsibleVolume {
     param(
         $DriveLetter,
         $Path,
-        $Label
+        $Label,
+        $FilePath
     )
 
     if ($null -ne $DriveLetter) {
@@ -93,8 +102,15 @@ function Get-AnsibleVolume {
             $module.FailJson("There was an error retrieving the volume using label $($Label): $($_.Exception.Message)", $_)
         }
     }
+    elseif ($null -ne $FilePath) {
+        try {
+            $volume = Get-Volume -FilePath $FilePath
+        } catch {
+            $module.FailJson("There was an error retrieving the volume using filepath $($FilePath): $($_.Exception.Message)", $_)
+        }
+    }
     else {
-        $module.FailJson("Unable to locate volume: drive_letter, path and label were not specified")
+        $module.FailJson("Unable to locate volume: drive_letter, path, label or filepath were not specified")
     }
 
     return $volume
@@ -138,7 +154,7 @@ function Format-AnsibleVolume {
 
 }
 
-$ansible_volume = Get-AnsibleVolume -DriveLetter $drive_letter -Path $path -Label $label
+$ansible_volume = Get-AnsibleVolume -DriveLetter $drive_letter -Path $path -Label $label -FilePath $filepath
 $ansible_file_system = $ansible_volume.FileSystem
 $ansible_volume_size = $ansible_volume.Size
 $ansible_volume_alu = (Get-CimInstance -ClassName Win32_Volume -Filter "DeviceId = '$($ansible_volume.path.replace('\','\\'))'" -Property BlockSize).BlockSize
@@ -146,7 +162,7 @@ $ansible_volume_alu = (Get-CimInstance -ClassName Win32_Volume -Filter "DeviceId
 $ansible_partition = Get-Partition -Volume $ansible_volume
 
 if (-not $force_format -and $null -ne $allocation_unit_size -and $ansible_volume_alu -ne 0 -and $null -ne $ansible_volume_alu -and $allocation_unit_size -ne $ansible_volume_alu) {
-        $module.FailJson("Force format must be specified since target allocation unit size: $($allocation_unit_size) is different from the current allocation unit size of the volume: $($ansible_volume_alu)")
+    $module.FailJson("Force format must be specified since target allocation unit size: $($allocation_unit_size) is different from the current allocation unit size of the volume: $($ansible_volume_alu)")
 }
 
 foreach ($access_path in $ansible_partition.AccessPaths) {

--- a/plugins/modules/win_format.py
+++ b/plugins/modules/win_format.py
@@ -12,7 +12,7 @@ description:
 options:
   drive_letter:
     description:
-      - Used to specify the drive letter of the volume to be formatted.
+      - Used to specify the drive letter or directory mountpoint of the volume to be formatted.
     type: str
   path:
     description:

--- a/plugins/modules/win_partition.py
+++ b/plugins/modules/win_partition.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2018, Varun Chopra (@chopraaa) <v@chopraaa.com>
+# Mountpoint feature added by Eriol (@aelfwine88)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = r'''
@@ -21,8 +22,13 @@ options:
   drive_letter:
     description:
       - Used for accessing partitions if I(disk_number) and I(partition_number) are not provided.
-      - Use C(auto) for automatically assigning a drive letter, or a letter A-Z for manually assigning a drive letter to a new partition.
+      - In case of a new parition the valid options are the following:
+        Use C(auto) for automatically assigning a drive letter.
+        Any unused letter from A-Z for manually assigning a drive letter.
+        An empty or a non existing directory for manually assigning a mountpoint.
         If not specified, no drive letter is assigned when creating a new partition.
+      - If I(disk_number) and I(partition_number) is specified it can remounting the a parition
+        to the given mountpoint, drive letter or unmount with C(none).
     type: str
   disk_number:
     description:
@@ -77,8 +83,8 @@ options:
 notes:
   - A minimum Operating System Version of 6.2 is required to use this module. To check if your OS is compatible, see
     U(https://docs.microsoft.com/en-us/windows/desktop/sysinfo/operating-system-version).
-  - This module cannot be used for removing the drive letter associated with a partition, initializing a disk or, file system formatting.
-  - Idempotence works only if you're specifying a drive letter or other unique attributes such as a combination of disk number and partition number.
+  - This module cannot be used for initializing a disk or file system formatting.
+  - Idempotence works only if you're specifying a I(drive_letter) or other unique attributes such as a combination of disk number and partition number.
   - For more information, see U(https://msdn.microsoft.com/en-us/library/windows/desktop/hh830524.aspx).
 author:
   - Varun Chopra (@chopraaa) <v@chopraaa.com>
@@ -91,9 +97,9 @@ EXAMPLES = r'''
     partition_size: 5 GiB
     disk_number: 1
 
-- name: Resize previously created partition to it's maximum size and change it's drive letter to E
+- name: Resize previously created partition to it's maximum size and change it's mountpoint to E:\SQL_Log
   community.windows.win_partition:
-    drive_letter: E
+    drive_letter: E:\SQL_Log
     partition_size: -1
     partition_number: 1
     disk_number: 1


### PR DESCRIPTION
##### SUMMARY
New features added to the win_partition module:
- Attach partition to directory mountpoint
- Identify partition by directory mountpoint
- If not already exist create a directory for the directory mountpoint
- Remount partition
- Unmount partition
- Better error handling for drive_letter variable

Bugfix added to the win_partition module:
- Properly unmount partition before partition deletion

New feature added to the win_format module:
- Added a feature to identify volumes based on directory mountpoints

Changes in the python description files:
- Modified the description for the added features

##### ISSUE TYPE
- Feature Pull Request
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
- win_partition
- win_format

##### ADDITIONAL INFORMATION
I had to create a solution to attach partitions to directories in the filesystem so I modified @chopraaa's relevant modules.

With these changes the win_partition module is now able to identify or attach partitions by the file path of these directory mountpoints (eg.: E:\SQL_Log). This function requires an empty or a non existing directory. In later case the module will try to create the directory.

The module now also able to remount the selected partition to a different location or unmount it. Partition unmount can be triggered with setting the _drive_letter_ to **none**.

In every scenario when the module caries out a mounting all the previous mountpoints are getting wiped out. This means with this module it is only possible to mount a partition to one location (drive letter or mountpoint).

I also added some additional error handing / formating to the _drive_letter_ variable to be able to accept root paths like C:\ instead of only letters like C.

Additional bugfix was introduced in this module as well: in case of a partition deletion now the module will try to unmount the partition prior the deletion. This prevents bugged/partially locked drive letter or directory mountpoint residues in the OS.

The win_format module was also upgraded to be able to identify volumes based on directory mountpoints. This ensures that you can format volumes based on this attribute as well (eg.: formating partition attached under E:\SQL_Log).

Naturally I completed the relevant two python man files (win_partition.py, win_format.py) with these changes.
