### PR TITLE
Hide password for win_psexec module

### DIFF
--- a/changelogs/fragments/win_psexec-cmd-output.yml
+++ b/changelogs/fragments/win_psexec-cmd-output.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- win_psexec - Ensure password is masked in ``psexec_command`` return result - https://github.com/ansible-collections/community.windows/issues/43

--- a/plugins/modules/win_psexec.ps1
+++ b/plugins/modules/win_psexec.ps1
@@ -27,6 +27,7 @@ $spec = @{
         session = @{ type='int' }
         priority = @{ type='str'; choices=@( 'background', 'low', 'belownormal', 'abovenormal', 'high', 'realtime' ) }
         timeout = @{ type='int' }
+        log_password = @{ type='bool'; default=$false }
     }
 }
 
@@ -48,6 +49,7 @@ $interactive = $module.Params.interactive
 $session = $module.Params.session
 $priority = $module.Params.Priority
 $timeout = $module.Params.timeout
+$log_password = $module.Params.log_password
 
 $module.Result.changed = $true
 
@@ -63,7 +65,7 @@ If ($nobanner -eq $true) {
 
 # Support running on local system if no hostname is specified
 If ($hostnames) {
-    $hostname_argument = ($hostnames | sort -Unique) -join ','
+    $hostname_argument = ($hostnames | Sort-Object  -Unique) -join ','
     $arguments.Add("\\$hostname_argument")
 }
 
@@ -129,7 +131,14 @@ $argument_string = Argv-ToString -arguments $arguments
 $argument_string += " $command"
 
 $start_datetime = [DateTime]::UtcNow
-$module.Result.psexec_command = $argument_string
+
+# if the user does not want to present password - we are replacing it with a *PASSWORD_REPLACED* string
+$toLog = $argument_string
+If ($log_password -eq $false) {
+    $toLog.Replace($password, "*PASSWORD_REPLACED*")
+}
+
+$module.Result.psexec_command = $toLog
 
 $command_result = Run-Command -command $argument_string
 

--- a/plugins/modules/win_psexec.ps1
+++ b/plugins/modules/win_psexec.ps1
@@ -135,7 +135,10 @@ $start_datetime = [DateTime]::UtcNow
 # if the user does not want to present password - we are replacing it with a *PASSWORD_REPLACED* string
 $toLog = $argument_string
 If ($log_password -eq $false) {
-    $toLog.Replace($password, "*PASSWORD_REPLACED*")
+    If (!([string]::IsNullOrEmpty($password))) {
+        # change only when password is present as it is optional
+        $toLog.Replace($password, "*PASSWORD_REPLACED*")
+    }
 }
 
 $module.Result.psexec_command = $toLog

--- a/plugins/modules/win_psexec.ps1
+++ b/plugins/modules/win_psexec.ps1
@@ -27,7 +27,6 @@ $spec = @{
         session = @{ type='int' }
         priority = @{ type='str'; choices=@( 'background', 'low', 'belownormal', 'abovenormal', 'high', 'realtime' ) }
         timeout = @{ type='int' }
-        log_password = @{ type='bool'; default=$false }
     }
 }
 
@@ -49,7 +48,6 @@ $interactive = $module.Params.interactive
 $session = $module.Params.session
 $priority = $module.Params.Priority
 $timeout = $module.Params.timeout
-$log_password = $module.Params.log_password
 
 $module.Result.changed = $true
 
@@ -132,13 +130,11 @@ $argument_string += " $command"
 
 $start_datetime = [DateTime]::UtcNow
 
-# if the user does not want to present password - we are replacing it with a *PASSWORD_REPLACED* string
+# Replace password with *PASSWORD_REPLACED* to avoid disclosing sensitive data
 $toLog = $argument_string
-If ($log_password -eq $false) {
-    If (!([string]::IsNullOrEmpty($password))) {
-        # change only when password is present as it is optional
-        $toLog.Replace($password, "*PASSWORD_REPLACED*")
-    }
+if ($password) {
+    $maskedPassword = Argv-ToString $password
+    $toLog = $toLog.Replace($maskedPassword, "*PASSWORD_REPLACED*")
 }
 
 $module.Result.psexec_command = $toLog

--- a/plugins/modules/win_psexec.py
+++ b/plugins/modules/win_psexec.py
@@ -39,7 +39,13 @@ options:
     description:
     - The password for the (remote) user to run the command as.
     - This is mandatory in order authenticate yourself.
+    - You can view the password in log message using log_password option
     type: str
+  log_password:
+    description:
+    - Shows the password in log message
+    type: bool
+    default: no
   chdir:
     description:
     - Run the command from this (remote) directory.

--- a/plugins/modules/win_psexec.py
+++ b/plugins/modules/win_psexec.py
@@ -39,13 +39,7 @@ options:
     description:
     - The password for the (remote) user to run the command as.
     - This is mandatory in order authenticate yourself.
-    - You can view the password in log message using log_password option
     type: str
-  log_password:
-    description:
-    - Shows the password in log message
-    type: bool
-    default: no
   chdir:
     description:
     - Run the command from this (remote) directory.

--- a/tests/integration/targets/win_psexec/tasks/main.yml
+++ b/tests/integration/targets/win_psexec/tasks/main.yml
@@ -88,6 +88,7 @@
     command: whoami.exe
     username: fake_user
     password: '{{ item }}'
+    executable: '{{ testing_dir }}\PsExec.exe'
   ignore_errors: yes  # The username/password isn't valid so it will fail
   loop:
   - Testing123

--- a/tests/integration/targets/win_psexec/tasks/main.yml
+++ b/tests/integration/targets/win_psexec/tasks/main.yml
@@ -82,3 +82,20 @@
     that:
     - whoami_multiple_args.rc == 1
     - whoami_multiple_args.psexec_command == "psexec.exe -accepteula powershell.exe -NonInteractive \"exit 1\""
+
+- name: Run command with password
+  win_psexec:
+    command: whoami.exe
+    username: fake_user
+    password: '{{ item }}'
+  ignore_errors: yes  # The username/password isn't valid so it will fail
+  loop:
+  - Testing123
+  - Testing"123  # This makes sure the escaped password for the cmd is also masked
+  register: psexec_pass
+
+- name: Test password not in psexec_command output
+  assert:
+    that:
+    - psexec_pass.results[0].psexec_command == "psexec.exe -u fake_user -p *PASSWORD_REPLACED* -accepteula whoami.exe"
+    - psexec_pass.results[1].psexec_command == "psexec.exe -u fake_user -p *PASSWORD_REPLACED* -accepteula whoami.exe"

--- a/tests/integration/targets/win_psexec/tasks/main.yml
+++ b/tests/integration/targets/win_psexec/tasks/main.yml
@@ -98,5 +98,5 @@
 - name: Test password not in psexec_command output
   assert:
     that:
-    - psexec_pass.results[0].psexec_command == "psexec.exe -u fake_user -p *PASSWORD_REPLACED* -accepteula whoami.exe"
-    - psexec_pass.results[1].psexec_command == "psexec.exe -u fake_user -p *PASSWORD_REPLACED* -accepteula whoami.exe"
+    - psexec_pass.results[0].psexec_command.endswith("-u fake_user -p *PASSWORD_REPLACED* -accepteula whoami.exe")
+    - psexec_pass.results[1].psexec_command.endswith("-u fake_user -p *PASSWORD_REPLACED* -accepteula whoami.exe")


### PR DESCRIPTION
##### SUMMARY
According to #43 - we do not want to show password when executing win_psexec. This change allows user to explicitly show it (for example when testing) while hiding the password by default

Fixes #43 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psexec

##### ADDITIONAL INFORMATION
Added new parameter log_password