### PR TITLE
Remove obsolte ssl parameter in win_iis_website

### DIFF
--- a/plugins/modules/win_iis_website.py
+++ b/plugins/modules/win_iis_website.py
@@ -47,10 +47,6 @@ options:
     description:
       - The host header to bind to / use for the new site.
     type: str
-  ssl:
-    description:
-      - Enables HTTPS binding on the site..
-    type: str
   parameters:
     description:
       - Custom site Parameters from string where properties are separated by a pipe and property name/values by colon Ex. "foo:1|bar:2"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The SSL parameter is not used and therefore can be removed from the documentation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_iis_website

