### PR TITLE
Added braces to the gpt styles.

### DIFF
--- a/changelogs/fragments/win_partition-gpttype.yml
+++ b/changelogs/fragments/win_partition-gpttype.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_partition - Fix gtp_type setting in win_partition - https://github.com/ansible-collections/community.windows/issues/241

--- a/plugins/modules/win_partition.ps1
+++ b/plugins/modules/win_partition.ps1
@@ -47,10 +47,10 @@ $ansible_partition_size = $null
 $partition_style = $null
 
 $gpt_styles = @{
-    system_partition = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
-    microsoft_reserved = "e3c9e316-0b5c-4db8-817d-f92df00215ae"
-    basic_data = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7"
-    microsoft_recovery = "de94bba4-06d1-4d40-a16a-bfd50179d6ac"
+    system_partition = "{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}"
+    microsoft_reserved = "{e3c9e316-0b5c-4db8-817d-f92df00215ae}"
+    basic_data = "{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}"
+    microsoft_recovery = "{de94bba4-06d1-4d40-a16a-bfd50179d6ac}"
 }
 
 $mbr_styles = @{


### PR DESCRIPTION
Per https://docs.microsoft.com/en-us/powershell/module/storage/new-partition?view=windowsserver2019-ps#parameters, the values for the GptType parameter should have braces around the guid.

##### SUMMARY
Fixes #241

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.windows.win_partition
