### PR TITLE
win_domain_user - handle password must be changed

### DIFF
--- a/changelogs/fragments/win_domain_user-pass-change.yaml
+++ b/changelogs/fragments/win_domain_user-pass-change.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_user - Make sure a password is set to change when it is marked as password needs to be changed before logging in - https://github.com/ansible-collections/community.windows/issues/223

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -35,7 +35,8 @@ Function Test-Credential {
         )
         $failed_codes = @(
             0x0000052E,  # ERROR_LOGON_FAILURE
-            0x00000532  # ERROR_PASSWORD_EXPIRED
+            0x00000532,  # ERROR_PASSWORD_EXPIRED
+            0x00000773  # ERROR_PASSWORD_MUST_CHANGE
         )
 
         if ($_.Exception.NativeErrorCode -in $failed_codes) {


### PR DESCRIPTION
##### SUMMARY
When testing a credential the return code may be `ERROR_PASSWORD_MUST_CHANGE` indicating the password isn't valid. Added that to the list of failed code so the password is updated in the module.

Fixes https://github.com/ansible-collections/community.windows/issues/223

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user