### PR TITLE
streamline AD user attribute setting

### DIFF
--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -280,12 +280,9 @@ If ($state -eq 'present') {
     }
 
     if ($run_change) {
-        try {
-            $user_obj = $user_obj | Set-ADUser -WhatIf:$check_mode -PassThru @set_args
-        } catch {
-            Fail-Json $result "failed to change user $($name): $($_.Exception.Message)"
-        }
+        Set-ADUser -Identity $user_guid -WhatIf:$check_mode @set_args
         $result.changed = $true
+        $user_obj = Get-ADUser -Identity $user_guid -Properties * @extra_args
     }
 
 


### PR DESCRIPTION
##### SUMMARY
This change set ensures that running in change mode does return the user
object as well. Otherwise, Ansible reports the user as being absent. Which is
pretty confusing for the caller.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user

##### ADDITIONAL INFORMATION
N/A
