### PR TITLE
Added changelog fragment for win_domain_user fix

### DIFF
--- a/changelogs/fragments/win_domain_user-check-reporting.yml
+++ b/changelogs/fragments/win_domain_user-check-reporting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_user - fix reporting on user when running in check mode - https://github.com/ansible-collections/community.windows/pull/248


### PR DESCRIPTION
##### SUMMARY
Adds changelog for https://github.com/ansible-collections/community.windows/pull/248, the repository was locked so I couldn't update the PR before the merge.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_domain_user