### PR TITLE
win_product_facts: fix an issue that the module doesn't correctly convert a product id

### DIFF
--- a/changelogs/fragments/251-win_product_facts.yml
+++ b/changelogs/fragments/251-win_product_facts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_product_facts - fixed an issue that the module doesn't correctly convert a product id (https://github.com/ansible-collections/community.windows/pull/251).

--- a/plugins/modules/win_product_facts.ps1
+++ b/plugins/modules/win_product_facts.ps1
@@ -38,6 +38,9 @@ if (-not $product_key) {
 
     if ($data) {
         $product_key = $null
+        $isWin8 = [int]($data[66]/6) -band 1
+        $HF7 = 0xF7
+        $data[66] = ($data[66] -band $HF7) -bOr (($isWin8 -band 2) * 4)
         $hexdata = $data[52..66]
         $chardata = "B","C","D","F","G","H","J","K","M","P","Q","R","T","V","W","X","Y","2","3","4","6","7","8","9"
 
@@ -49,11 +52,24 @@ if (-not $product_key) {
                 $hexdata[$j] = [math]::truncate($k / 24)
                 $k = $k % 24
             }
-            $product_key = $chardata[$k] + $product_key
-            if (($i % 5 -eq 0) -and ($i -ne 0)) {
-                $product_key = "-" + $product_key
-            }
+            $product_key_output = $chardata[$k] + $product_key_output
+            $last = $k
         }
+
+        $product_key_tmp1 = $product_key_output.SubString(1,$last)
+        $product_key_tmp2 = $product_key_output.SubString(1,$product_key_output.Length - 1)
+        if ($last -eq 0) {
+            $product_key_output = "N" + $product_key_tmp2
+        } else {
+            $product_key_output = $product_key_tmp2.Insert($product_key_tmp2.IndexOf($product_key_tmp1) + $product_key_tmp1.Length, "N")
+        }
+        $num = 0
+        $product_key_split = @()
+        for ($i = 0; $i -le 4; $i++) {
+            $product_key_split += $product_key_output.SubString($num,5)
+            $num += 5
+        }
+        $product_key = $product_key_split -join "-"
     }
 }
 


### PR DESCRIPTION
##### SUMMARY

The win_product_facts module has an issue that doesn't convert to the correct id from the registered product id in Windows10.(maybe a bug)
This PR will fix the issue.

fixes: https://github.com/ansible-collections/community.windows/issues/247

I made the patch while referencing the following vbs(productkey.vbs).

https://answers.microsoft.com/en-us/windows/forum/windows_other-windows_install/get-preinstalled-product-key/e39ec36f-ec3b-4495-b049-be02527a21ce  
https://answers.microsoft.com/en-us/windows/forum/windows_10-windows_install-winpc/windows-10-activation-error-0x8007007b/45d12b1c-30b1-4001-bc10-0bcd3da7db1f

By the way, the product id correctly gets with the productkey.vbs.

##### COMPONENT NAME

plugins/modules/win_product_facts.ps1

##### ADDITIONAL INFORMATION

Tested on Windows 10.