### PR TITLE
fix forwarder replicationscope none

### DIFF
--- a/changelogs/fragments/win_dns_zone-forwarder.yml
+++ b/changelogs/fragments/win_dns_zone-forwarder.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dns_zone - Fix idempotency when using a DNS zone with forwarders - https://github.com/ansible-collections/community.windows/issues/259

--- a/plugins/modules/win_dns_zone.ps1
+++ b/plugins/modules/win_dns_zone.ps1
@@ -188,6 +188,7 @@ if ($state -eq "present") {
             if ($forwarder_timeout -and -not ($forwarder_timeout -in 0..15)) {
                 $module.Warn("The forwarder_timeout param must be an integer value between 0 and 15")
             }
+            if ($parms.ReplicationScope -eq 'none'){$parms.Remove('ReplicationScope')}
             if (-not $current_zone) {
                 # create zone
                 Try { Add-DnsServerConditionalForwarderZone @parms -WhatIf:$check_mode }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes issue #259

plays with forwarders without replication are now idempotent & updatable. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_dns_zone

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Dropping parameter ReplicationScope from processing if it was already set to none for conditional forwarding dns zones. 
```
