### PR TITLE
Fix current member comparison for correct sid

### DIFF
--- a/changelogs/fragments/win_domain_group_membership-comparison.yml
+++ b/changelogs/fragments/win_domain_group_membership-comparison.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_group_member - Fix faulty logic when comparing existing group members - https://github.com/ansible-collections/community.windows/issues/256

--- a/plugins/modules/win_domain_group_membership.ps1
+++ b/plugins/modules/win_domain_group_membership.ps1
@@ -72,7 +72,7 @@ foreach ($member in $members) {
 
     $user_in_group = $false
     foreach ($current_member in $members_before) {
-        if ($current_member.sid -eq $group_member.objectSid) {
+        if ($current_member.objectSid -eq $group_member.objectSid) {
             $user_in_group = $true
             break
         }
@@ -96,7 +96,7 @@ if ($state -eq "pure") {
     foreach ($current_member in $current_members) {
         $user_to_remove = $true
         foreach ($pure_member in $pure_members) {
-            if ($pure_member -eq $current_member.sid) {
+            if ($pure_member -eq $current_member.objectSid) {
                 $user_to_remove = $false
                 break
             }


### PR DESCRIPTION
The value "$current_member.sid" is empty and therefore, the account is always added again to the group. As a result, the module reports changed every time.

This patch sets the correct sid for comparison.

The bug was likely introduced by 72e4a1acc73f92037b118557159854ece506b832 and fetching only the objectSID, which was not used for comparison.

Also, I think this will fix issue: https://github.com/ansible-collections/community.windows/issues/256