### PR TITLE
Added Conditional to check if disk should be brought online.

### DIFF
--- a/changelogs/fragments/win_initialize_disk-offline.yml
+++ b/changelogs/fragments/win_initialize_disk-offline.yml
@@ -1,2 +1,3 @@
 bugfixes:
-- win_initialize_disk - Ensure ``online: False`` doesn't bring the disk online again - https://github.com/ansible-collections/community.windows/pull/268
+- >-
+  win_initialize_disk - Ensure ``online: False`` doesn't bring the disk online again - https://github.com/ansible-collections/community.windows/pull/268

--- a/changelogs/fragments/win_initialize_disk-offline.yml
+++ b/changelogs/fragments/win_initialize_disk-offline.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_initialize_disk - Ensure ``online: False`` doesn't bring the disk online again - https://github.com/ansible-collections/community.windows/pull/268

--- a/plugins/modules/win_initialize_disk.ps1
+++ b/plugins/modules/win_initialize_disk.ps1
@@ -144,7 +144,7 @@ if ("RAW" -eq $ansible_part_style) {
     } elseif ($force_init) {
         $ansible_disk = Set-AnsibleDisk -AnsibleDisk $ansible_disk -BringOnline $bring_online
         Clear-AnsibleDisk -AnsibleDisk $ansible_disk
-        Initialize-AnsibleDisk -AnsibleDisk $ansible_disk -PartitionStyle $partition_style
+        if ( $bring_online ) { Initialize-AnsibleDisk -AnsibleDisk $ansible_disk -PartitionStyle $partition_style }
     }
 }
 


### PR DESCRIPTION

##### SUMMARY

This fixes a bug where if you want to bring a disk offline by using the parameter "online" set to "false/no" it would bring the disk online again anyways. All needed is the added conditional to fix this, where the parameter gets taken in to account at the end.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_initialize_disk

##### ADDITIONAL INFORMATION

###### Code used
```
- name: Take disk offline bases on UUID
      win_initialize_disk:
        uniqueid: "DiskUUID"
        online: no
        force: yes
```

###### Expected behaviour
We expected the Disk to be taken offline (and staying offline) after the ansible run.

###### Actual behaviour
The disk was shortly taken offline, but then brought back online by the line we fixed in the module.
