### PR TITLE
Fixed module param in win_dns_record.ps1

### DIFF
--- a/changelogs/fragments/win_dns_record-comp-name.yml
+++ b/changelogs/fragments/win_dns_record-comp-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dns_record - Fix issue when trying to use the ``computer_name`` option - https://github.com/ansible-collections/community.windows/issues/276

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -31,7 +31,7 @@ $type = $module.Params.type
 $values = $module.Params.value
 $weight = $module.Params.weight
 $zone = $module.Params.zone
-$dns_computer_name = $module.Params.server
+$dns_computer_name = $module.Params.computer_name
 $extra_args = @{}
 if ($null -ne $dns_computer_name) {
     $extra_args.ComputerName = $dns_computer_name


### PR DESCRIPTION
##### SUMMARY
This mr changes the `$module.Params.server` back to `$module.Params.computer_name` since server is not recognized in the module as an accepted parameter. And computer_name has been used before. If you want to change to server. I would suggest to document this correctly as a breaking change :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dns_record

Fixes #276 