### PR TITLE
Module win_route upgraded

### DIFF
--- a/docs/community.windows.win_route_module.rst
+++ b/docs/community.windows.win_route_module.rst
@@ -35,7 +35,7 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>destination</b>
+                    <b>network</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
@@ -45,7 +45,23 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Destination IP address in CIDR format (ip address/prefix length).</div>
+                        <div>Destination network.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mask</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Destination network's mask.</div>
                 </td>
             </tr>
             <tr>
@@ -55,13 +71,13 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>The gateway used by the static route.</div>
-                        <div>If <code>gateway</code> is not provided it will be set to <code>0.0.0.0</code>.</div>
                 </td>
             </tr>
             <tr>
@@ -118,16 +134,19 @@ Examples
 .. code-block:: yaml
 
     ---
-    - name: Add a network static route
+    - name: Add a network static route.
       community.windows.win_route:
-        destination: 192.168.2.10/32
-        gateway: 192.168.1.1
+        network: 192.168.24.0
+        mask: 255.255.255.0
+        gateway: 192.168.24.1
         metric: 1
         state: present
 
-    - name: Remove a network static route
+    - name: Remove a network static route.
       community.windows.win_route:
-        destination: 192.168.2.10/32
+        network: 192.168.24.0
+        mask: 255.255.255.0
+        gateway: 192.168.24.1
         state: absent
 
 
@@ -158,7 +177,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>A message describing the task result.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Route added</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Route added!</div>
                 </td>
             </tr>
     </table>
@@ -173,3 +192,4 @@ Authors
 ~~~~~~~
 
 - Daniele Lazzari (@dlazz)
+- Modified by: Vicente Danzmann Vivian (@iVcente)

--- a/docs/community.windows.win_route_module.rst
+++ b/docs/community.windows.win_route_module.rst
@@ -192,4 +192,4 @@ Authors
 ~~~~~~~
 
 - Daniele Lazzari (@dlazz)
-- Modified by: Vicente Danzmann Vivian (@iVcente)
+- Vicente Danzmann Vivian (@iVcente)

--- a/plugins/modules/win_route.ps1
+++ b/plugins/modules/win_route.ps1
@@ -1,6 +1,7 @@
 #!powershell
 
 # Copyright: (c) 2016, Daniele Lazzari <lazzari@mailup.com>
+# Modified by: Vicente Danzmann Vivian (@iVcente)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
@@ -10,8 +11,9 @@
 $params = Parse-Args $args -supports_check_mode $true
 
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
-$dest = Get-AnsibleParam -obj $params -name "destination" -type "str" -failifempty $true
-$gateway = Get-AnsibleParam -obj $params -name "gateway" -type "str"
+$network = Get-AnsibleParam -obj $params -name "network" -type "str" -failifempty $true
+$mask = Get-AnsibleParam -obj $params -name "mask" -type "str" -failifempty $true
+$gateway = Get-AnsibleParam -obj $params -name "gateway" -type "str" -failifempty $true
 $metric = Get-AnsibleParam -obj $params -name "metric" -type "int" -default 1
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateSet "present","absent"
 $result = @{
@@ -19,86 +21,110 @@ $result = @{
              "output" = ""
            }
 
+########################
+### Add static route ###
+########################
+
 Function Add-Route {
-  Param (
-    [Parameter(Mandatory=$true)]
-    [string]$Destination,
-    [Parameter(Mandatory=$true)]
-    [string]$Gateway,
-    [Parameter(Mandatory=$true)]
-    [int]$Metric,
-    [Parameter(Mandatory=$true)]
-    [bool]$CheckMode
+    Param (
+        [Parameter(Mandatory=$true)]
+        [string]$Network,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Mask,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Gateway,
+
+        [Parameter(Mandatory=$true)]
+        [int]$Metric,
+
+        [Parameter(Mandatory=$true)]
+        [bool]$CheckMode
     )
 
+    # Check if the static route is already present
+    $Route = Get-CimInstance -ClassName Win32_IP4PersistedRouteTable | Where-Object { $_.Destination -EQ "$($Network)" -AND $_.Mask -EQ "$($Mask)" }
 
-  $IpAddress = $Destination.split('/')[0]
-
-  # Check if the static route is already present
-  $Route = Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '$($IpAddress)'"
-  if (!($Route)){
-    try {
-      # Find Interface Index
-      $InterfaceIndex = Find-NetRoute -RemoteIPAddress $Gateway | Select-Object -First 1 -ExpandProperty InterfaceIndex
-
-      # Add network route
-      New-NetRoute -DestinationPrefix $Destination -NextHop $Gateway -InterfaceIndex $InterfaceIndex -RouteMetric $Metric -ErrorAction Stop -WhatIf:$CheckMode|out-null
-      $result.changed = $true
-      $result.output = "Route added"
-
+    # In case of running in Check Mode
+    if ($CheckMode -AND !($Route)) {
+        $result.changed = $true
+        $result.output = "Route can be added!"
+        return
     }
-    catch {
-      $ErrorMessage = $_.Exception.Message
-      Fail-Json $result $ErrorMessage
-    }
-  }
-  else {
-    $result.output = "Static route already exists"
-  }
 
+    # If route doesn't exist, add it
+    if (!($Route)) {
+        try {
+            # Add static route
+            route -p ADD $Network MASK $Mask $Gateway METRIC $Metric
+            $result.changed = $true
+            $result.output = "Route added!"
+        }
+        catch {
+            $ErrorMessage = $_.Exception.Message
+            Fail-Json $result $ErrorMessage
+        }
+    }
+    # If route already exists, just print
+    else {
+        $result.output = "Static route already exists."
+    }
 }
+
+###########################
+### Remove static route ###
+###########################
 
 Function Remove-Route {
-  Param (
-    [Parameter(Mandatory=$true)]
-    [string]$Destination,
-    [bool]$CheckMode
+    Param (
+        [Parameter(Mandatory=$true)]
+        [string]$Network,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Mask,
+
+        [Parameter(Mandatory=$true)]
+        [string]$Gateway,
+
+        [Parameter(Mandatory=$true)]
+        [bool]$CheckMode
     )
-  $IpAddress = $Destination.split('/')[0]
-  $Route = Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '$($IpAddress)'"
-  if ($Route){
-    try {
 
-      Remove-NetRoute -DestinationPrefix $Destination -Confirm:$false -ErrorAction Stop -WhatIf:$CheckMode
-      $result.changed = $true
-      $result.output = "Route removed"
-    }
-    catch {
-      $ErrorMessage = $_.Exception.Message
-      Fail-Json $result $ErrorMessage
-    }
-  }
-  else {
-    $result.output = "No route to remove"
-  }
+    # Check if the static route is already present
+    $Route = Get-CimInstance -ClassName Win32_IP4PersistedRouteTable | Where-Object { $_.Destination -EQ "$($Network)" -AND $_.Mask -EQ "$($Mask)" }
 
+    # In case of running in Check Mode
+    if ($CheckMode -AND $Route) {
+        $result.changed = $true
+        $result.output = "Route can be removed!"
+        return
+    }
+
+    # If route exists, remove it
+    if ($Route) {
+        try {
+            # Remove static route
+            route DELETE $Network MASK $Mask $Gateway
+            $result.changed = $true
+            $result.output = "Route removed!"
+        }
+        catch {
+            $ErrorMessage = $_.Exception.Message
+            Fail-Json $result $ErrorMessage
+        }
+    }
+    # If route doesn't exist, just print
+    else {
+        $result.output = "No route to remove."
+    }
 }
 
-# Set gateway if null
-if(!($gateway)){
-  $gateway = "0.0.0.0"
-}
-
-
-if ($state -eq "present"){
-
-  Add-Route -Destination $dest -Gateway $gateway -Metric $metric -CheckMode $check_mode
-
+if ($state -EQ "absent") {
+    Remove-Route -Network $network -Mask $mask -Gateway $gateway -CheckMode $check_mode
 }
 else {
-
-  Remove-Route -Destination $dest -CheckMode $check_mode
-
+    Add-Route -Network $network -Mask $mask -Gateway $gateway -Metric $metric -CheckMode $check_mode
 }
 
 Exit-Json $result

--- a/plugins/modules/win_route.py
+++ b/plugins/modules/win_route.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+# Modified by: Vicente Danzmann Vivian (@iVcente)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = r'''
@@ -11,16 +12,21 @@ short_description: Add or remove a static route
 description:
     - Add or remove a static route.
 options:
-  destination:
+  network:
     description:
-      - Destination IP address in CIDR format (ip address/prefix length).
+      - Destination network.
+    type: str
+    required: yes
+  mask:
+    description:
+      - Destination network's mask.
     type: str
     required: yes
   gateway:
     description:
         - The gateway used by the static route.
-        - If C(gateway) is not provided it will be set to C(0.0.0.0).
     type: str
+    required: yes
   metric:
     description:
         - Metric used by the static route.
@@ -35,22 +41,26 @@ options:
     default: present
 notes:
   - Works only with Windows 2012 R2 and newer.
-author:
+authors:
 - Daniele Lazzari (@dlazz)
+- Vicente Danzmann Vivian (@iVcente)
 '''
 
 EXAMPLES = r'''
 ---
-- name: Add a network static route
+- name: Add a network static route.
   community.windows.win_route:
-    destination: 192.168.2.10/32
-    gateway: 192.168.1.1
+    network: 192.168.24.0
+    mask: 255.255.255.0
+    gateway: 192.168.24.1
     metric: 1
     state: present
 
-- name: Remove a network static route
+- name: Remove a network static route.
   community.windows.win_route:
-    destination: 192.168.2.10/32
+    network: 192.168.24.0
+    mask: 255.255.255.0
+    gateway: 192.168.24.1
     state: absent
 '''
 RETURN = r'''
@@ -58,5 +68,5 @@ output:
     description: A message describing the task result.
     returned: always
     type: str
-    sample: "Route added"
+    sample: "Route added!"
 '''

--- a/plugins/modules/win_route.py
+++ b/plugins/modules/win_route.py
@@ -41,7 +41,7 @@ options:
     default: present
 notes:
   - Works only with Windows 2012 R2 and newer.
-authors:
+author:
 - Daniele Lazzari (@dlazz)
 - Vicente Danzmann Vivian (@iVcente)
 '''

--- a/tests/integration/targets/win_route/defaults/main.yml
+++ b/tests/integration/targets/win_route/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
-default_gateway: 192.168.1.1
-destination_ip_address: 192.168.2.10
+default_gateway: 192.168.24.1
+destination_network: 192.168.24.0
+destination_mask: 255.255.255.0

--- a/tests/integration/targets/win_route/tasks/main.yml
+++ b/tests/integration/targets/win_route/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # test code for the win_psmodule module when using winrm connection
 # (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+# Modified by: Vicente Danzmann Vivian (iVcente)
 
 # This file is part of Ansible
 #
@@ -18,12 +19,12 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 
-- name: get os info
+- name: Get OS info.
   ansible.windows.win_shell: '[Environment]::OSVersion.Version -ge [Version]"6.3"'
   register: os
 
-- name: Perform with os Windows 2012R2 or newer
+- name: Perform with OS Windows 2012R2 or newer.
   when: os.stdout_lines[0] == "True"
   block:
-    - name: run all tasks
+    - name: Run all tasks.
       include: tests.yml

--- a/tests/integration/targets/win_route/tasks/tests.yml
+++ b/tests/integration/targets/win_route/tasks/tests.yml
@@ -1,79 +1,86 @@
 ---
-- name: add a static route
+- name: Add a static route.
   win_route:
-    destination: "{{ destination_ip_address }}/32"
+    network: "{{ destination_network }}"
+    mask: "{{ destination_mask }}"
     gateway: "{{ default_gateway }}"
     metric: 1
     state: present
   register: route
 
-- name: check if route successfully added
-  ansible.windows.win_shell: (Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '{{ destination_ip_address }}'").Caption
+- name: Check if route successfully added.
+  ansible.windows.win_shell: (Get-CimInstance Win32_IP4PersistedRouteTable -Filter "Destination = '{{ destination_network }}'").Caption
   register: route_added
 
-- name: check route default gateway
-  ansible.windows.win_shell: (Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '{{ destination_ip_address }}'").NextHop
+- name: Check route default gateway.
+  ansible.windows.win_shell: (Get-CimInstance Win32_IP4PersistedRouteTable -Filter "Destination = '{{ destination_network }}'").NextHop
   register: route_gateway
 
-- name: test if route successfully added
+- name: Test if route was successfully added.
   assert:
     that:
       - route is changed
-      - route_added.stdout_lines[0] == "{{ destination_ip_address }}"
+      - route_added.stdout_lines[0] == "{{ destination_network }}"
       - route_gateway.stdout_lines[0] == "{{ default_gateway }}"
 
-- name: add a static route to test idempotency
+- name: Add a static route to test idempotency.
   win_route:
-    destination: "{{ destination_ip_address }}/32"
+    network: "{{ destination_network }}"
+    mask: "{{ destination_mask }}"
     gateway: "{{ default_gateway }}"
     metric: 1
     state: present
   register: idempotent_route
 
-- name: test idempotency
+- name: Test idempotency.
   assert:
     that:
       - idempotent_route is not changed
-      - idempotent_route.output == "Static route already exists"
+      - idempotent_route.output == "Static route already exists."
 
-- name: remove route
+- name: Remove static route.
   win_route:
-    destination: "{{ destination_ip_address }}/32"
+    network: "{{ destination_network }}"
+    mask: "{{ destination_mask }}"
+    gateway: "{{ default_gateway }}"
     state: absent
   register: route_removed
 
-- name: check route is removed
-  ansible.windows.win_shell: Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '{{ destination_ip_address }}'"
+- name: Check if static route was removed.
+  ansible.windows.win_shell: Get-CimInstance Win32_IP4PersistedRouteTable -Filter "Destination = '{{ destination_network }}'"
   register: check_route_removed
 
-- name: test route is removed
+- name: Test if static route was removed.
   assert:
     that:
       - route_removed is changed
       - check_route_removed.stdout == ''
 
-- name: remove static route to test idempotency
+- name: Remove static route to test idempotency.
   win_route:
-    destination: "{{ destination_ip_address }}/32"
+    network: "{{ destination_network }}"
+    mask: "{{ destination_mask }}"
+    gateway: "{{ default_gateway }}"
     state: absent
   register: idempotent_route_removed
 
-- name: test idempotency
+- name: Test idempotency.
   assert:
     that:
       - idempotent_route_removed is not changed
-      - idempotent_route_removed.output == "No route to remove"
+      - idempotent_route_removed.output == "No route to remove."
 
-- name: add route to wrong ip address
+- name: Add static route to wrong IP address.
   win_route:
-    destination: "715.18.0.0/32"
+    network: 715.18.0.0
+    mask: "{{ destination_mask }}"
     gateway: "{{ default_gateway }}"
     metric: 1
     state: present
   ignore_errors: yes
   register: wrong_ip
 
-- name: test route to wrong ip address
+- name: Test static route addition to wrong IP address.
   assert:
     that:
       - wrong_ip is failed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Possibility of adding a static route with the same network destination and gateway, but different mask.
- Moving from `New-NetRoute` and `Remove-NetRoute` PowerShell commands to `route add` and `route delete` CMD commands. The PowerShell commands don't work as expected, while the CMD ones do the job just right.

The idea of adding a `gateway` parameter as a requirement was to help preventing any errors by adding something wrong and causing a big trouble. I mean, why not add a gateway? Even if you actually need a `0.0.0.0` one, it's good to be explicit about it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_route

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I had to create a playbook to add/remove static routes on servers in the company I work for and when I verified the results achieved with the current module, there were some little problems that stopped us from using it. Later, I decided to give it a shot and try to update the module.

Now, it is possible to add (or remove) routes with same network destination and gateway, but with a different mask! Unfortunately, in order to do that, the utilisation of CIDR notation had to be sacrificed.

Also, we faced some problems with the PowerShell commands utilised to add and remove routes: `New-NetRoute` and `Remove-NetRoute`. Although Windows successfully executes these commands - and shows the route on its routing table -, for some reason they don't really work as intended in practice. Servers wouldn't communicate with each other after adding a static route by these commands/module. The solution was to use the old but gold CMD commands: `route add` and `route delete`. After these little fixes, this modified version is currently being used in our production environment with a 100% of success so far.
Doing a little bit of research I found some people with the exactly same problem with these PowerShell commands, the solution to everyone was to abandon the PowerShell commands in favor of the CMD ones.

So after this trouble, I thought about sharing these changes with the community. These fixes helped us a lot and may help others as well. This is my first PR, so in case of any issues, just let me know - and sorry by them.

The documentation was updated as well.