### PR TITLE
win_domain_user: Add sam_account_name parameter

### DIFF
--- a/changelogs/fragments/win_domain_user_samaccount.yml
+++ b/changelogs/fragments/win_domain_user_samaccount.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_domain_user - Added ``sam_account_name`` to explicitly set the ``sAMAccountName`` property of an object - https://github.com/ansible-collections/community.windows/issues/281

--- a/docs/community.windows.win_domain_user_module.rst
+++ b/docs/community.windows.win_domain_user_module.rst
@@ -394,6 +394,23 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sam_account_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Configures the SAM Account Name (<code>sAMAccountName</code>) for the account.</div>
+                        <div>This is allowed to a maximum of 20 characters due to pre-Windows 2000 restrictions.</div>
+                        <div>Default to the <code>&lt;username&gt;</code> specified in <code>upn</code> or <code>name</code> if not set.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -894,6 +911,23 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">46033</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sam_account_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>The SAM Account Name of the account</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">nick</div>
                 </td>
             </tr>
             <tr>

--- a/docs/community.windows.win_domain_user_module.rst
+++ b/docs/community.windows.win_domain_user_module.rst
@@ -399,6 +399,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.7.0</div>
                 </td>
                 <td>
                 </td>
@@ -921,6 +922,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <div style="font-size: small">
                       <span style="color: purple">string</span>
                     </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.7.0</div>
                 </td>
                 <td>always</td>
                 <td>

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -89,6 +89,7 @@ $groups = Get-AnsibleParam -obj $params -name "groups" -type "list"
 $enabled = Get-AnsibleParam -obj $params -name "enabled" -type "bool" -default $true
 $path = Get-AnsibleParam -obj $params -name "path" -type "str"
 $upn = Get-AnsibleParam -obj $params -name "upn" -type "str"
+$sam_account_name = Get-AnsibleParam -obj $params -name "sam_account_name" -type "str"
 
 # User informational parameters
 $user_info = @{
@@ -163,6 +164,9 @@ If ($state -eq 'present') {
           $create_args.UserPrincipalName  = $upn
           $create_args.SamAccountName  = $upn.Split('@')[0]
         }
+        If ($null -ne $sam_account_name) {
+          $create_args.SamAccountName  = $sam_account_name
+        }
         $user_obj = New-ADUser @create_args -WhatIf:$check_mode -PassThru @extra_args
         $user_guid = $user_obj.ObjectGUID
         $new_user = $true
@@ -215,6 +219,11 @@ If ($state -eq 'present') {
     # Assign other account settings
     If (($null -ne $upn) -and ($upn -ne $user_obj.UserPrincipalName)) {
         Set-ADUser -Identity $user_guid -UserPrincipalName $upn -WhatIf:$check_mode @extra_args
+        $user_obj = Get-ADUser -Identity $user_guid -Properties * @extra_args
+        $result.changed = $true
+    }
+    If (($null -ne $sam_account_name) -and ($sam_account_name -ne $user_obj.SamAccountName)) {
+        Set-ADUser -Identity $user_guid -SamAccountName $sam_account_name -WhatIf:$check_mode @extra_args
         $user_obj = Get-ADUser -Identity $user_guid -Properties * @extra_args
         $result.changed = $true
     }
@@ -367,6 +376,7 @@ If ($user_obj) {
     $result.account_locked = $user_obj.LockedOut
     $result.sid = [string]$user_obj.SID
     $result.upn = $user_obj.UserPrincipalName
+    $result.sam_account_name = $user_obj.SamAccountName
     $result.groups = Get-PrincipalGroups $user_guid $extra_args
     $result.msg = "User '$name' is present"
     $result.state = "present"

--- a/plugins/modules/win_domain_user.py
+++ b/plugins/modules/win_domain_user.py
@@ -120,6 +120,7 @@ options:
       - This is allowed to a maximum of 20 characters due to pre-Windows 2000 restrictions.
       - Default to the C(<username>) specified in C(upn) or C(name) if not set.
     type: str
+    version_added: 1.7.0
   email:
     description:
       - Configures the user's email address.
@@ -361,6 +362,7 @@ sam_account_name:
     returned: always
     type: str
     sample: nick
+    version_added: 1.7.0
 user_cannot_change_password:
     description: true if the user is not allowed to change password
     returned: always

--- a/plugins/modules/win_domain_user.py
+++ b/plugins/modules/win_domain_user.py
@@ -114,6 +114,12 @@ options:
         versions of Active Directory.
       - The format is C(<username>@<domain>).
     type: str
+  sam_account_name:
+    description:
+      - Configures the SAM Account Name (C(sAMAccountName)) for the account.
+      - This is allowed to a maximum of 20 characters due to pre-Windows 2000 restrictions.
+      - Default to the C(<username>) specified in C(upn) or C(name) if not set.
+    type: str
   email:
     description:
       - Configures the user's email address.
@@ -350,6 +356,11 @@ upn:
     returned: always
     type: str
     sample: nick@domain.local
+sam_account_name:
+    description: The SAM Account Name of the account
+    returned: always
+    type: str
+    sample: nick
 user_cannot_change_password:
     description: true if the user is not allowed to change password
     returned: always


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `sam_account_name` to `win_domain_user` module.
This also updates related documentation.

Fixes #281 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This fix allows us to manage a user with a long name over 20 chars or UPN and a short `sAMAccountName`, such as:

- Name: `over20charactersaccount`
- UPN: `over20charactersaccount@ansible.local`
- SAM Account Name: `o20c`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ cat site.yml 
---
- hosts: addc
  gather_facts: false

  tasks:
    - name: Ensure user over20charactersaccount is present
      community.windows.win_domain_user:
        identity: CN=over20charactersaccount,CN=Users,DC=ansible,DC=local
        name: over20charactersaccount
        upn: over20charactersaccount@ansible.local
        sam_account_name: o20c     👈👈👈 New parameter
        password: B0bP4ssw0rd
        update_password: on_create
        state: present
      register: result

    - name: Debug user
      ansible.builtin.debug:
        var: result

$ ansible-playbook -i inventory site.yml 
PLAY [addc] ***************************************************************************************************************

TASK [Ensure user over20charactersaccount is present] *********************************************************************
changed: [192.168.0.218]

TASK [Debug user] *********************************************************************************************************
ok: [192.168.0.218] => {
    "result": {
        "account_locked": false,
        "changed": true,
        "city": null,
        "company": null,
        "country": null,
        "created": true,
        "description": null,
        "distinguished_name": "CN=over20charactersaccount,CN=Users,DC=ansible,DC=local",
        "email": null,
        "enabled": true,
        "failed": false,
        "firstname": null,
        "groups": "CN=Domain Users,CN=Users,DC=ansible,DC=local",
        "msg": "User 'over20charactersaccount' is present",
        "name": "over20charactersaccount",
        "password_expired": false,
        "password_never_expires": false,
        "password_updated": true,
        "postal_code": null,
        "sam_account_name": "o20c",     👈👈👈 New return value
        "sid": "S-1-5-21-1001936577-731867389-1873172614-1122",
        "state": "present",
        "state_province": null,
        "street": null,
        "surname": null,
        "upn": "over20charactersaccount@ansible.local",
        "user_cannot_change_password": false
    }
}

PLAY RECAP ****************************************************************************************************************
192.168.0.218              : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
