### PR TITLE
win_lineinfile: fixes the inconsistent of the last emtpy line on diff.

### DIFF
--- a/changelogs/fragments/win_lineinfile-diff.yml
+++ b/changelogs/fragments/win_lineinfile-diff.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_lineinfile - Fix up diff output with ending newlines - https://github.com/ansible-collections/community.windows/pull/283

--- a/plugins/modules/win_lineinfile.ps1
+++ b/plugins/modules/win_lineinfile.ps1
@@ -105,6 +105,9 @@ function Present($path, $regex, $line, $insertafter, $insertbefore, $create, $ba
 	}
 
 	if ($diff_support) {
+		if ($endswithnewline) {
+			$before += ""
+		}
 		$result.diff = @{
 			before = $before -join $linesep;
 		}
@@ -254,6 +257,7 @@ function Absent($path, $regex, $line, $backup, $validate, $encodingobj, $linesep
 		$alltext = [System.IO.File]::ReadAllText($cleanpath, $encodingobj);
 		If (($alltext[-1] -eq "`n") -or ($alltext[-1] -eq "`r")) {
 			$lines.Add("")
+			$before += ""
 		}
 	}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The last empty line is stripped from the only before data of diff.
While the after data of diff is fixed on #219.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_lineinfile

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Related #219
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
