### PR TITLE
win_region - remove reliance on reg.exe

### DIFF
--- a/changelogs/fragments/win_region_hardened_registry.yml
+++ b/changelogs/fragments/win_region_hardened_registry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_region - Fix ``copy_settings`` on a host that has disabled ``reg.exe`` access - https://github.com/ansible-collections/community.windows/issues/287


### PR DESCRIPTION
##### SUMMARY
If `reg.exe` is disable per group policy on the host then `win_region` will fail to load the hive. This will load the hive using the Win32 API instead avoiding this problem.

Fixes https://github.com/ansible-collections/community.windows/issues/287

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_region