### PR TITLE
win_domain_user: Fix issue when trying to update user password when u…

### DIFF
--- a/changelogs/fragments/win_domain_user-missing-upn.yml
+++ b/changelogs/fragments/win_domain_user-missing-upn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_user - Fallback to NETBIOS username for password verification check if the UPN is not set - https://github.com/ansible-collections/community.windows/pull/289

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -186,12 +186,14 @@ If ($state -eq 'present') {
         If ($new_user -or ($update_password -eq "always")) {
             $set_new_credentials = $true
         } elseif ($update_password -eq "when_changed") {
-            If ($user_obj.UserPrincipalName) {
-                $set_new_credentials = -not (Test-Credential -Username $user_obj.UserPrincipalName -Password $password)
+            $user_identifier = If ($user_obj.UserPrincipalName) {
+                $user_obj.UserPrincipalName
             }
             else {
-                $set_new_credentials = -not (Test-Credential -Username $user_obj.'msDS-PrincipalName' -Password $password)
+                $user_obj.'msDS-PrincipalName'
             }
+
+            $set_new_credentials = -not (Test-Credential -Username $user_identifier -Password $password)
         } else {
             $set_new_credentials = $false
         }

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -141,7 +141,7 @@ Function Get-PrincipalGroups {
 }
 
 try {
-    $user_obj = Get-ADUser -Identity $identity -Properties * @extra_args
+    $user_obj = Get-ADUser -Identity $identity -Properties ('*','msDS-PrincipalName') @extra_args
     $user_guid = $user_obj.ObjectGUID
 }
 catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
@@ -175,7 +175,7 @@ If ($state -eq 'present') {
         If ($check_mode) {
             Exit-Json $result
         }
-        $user_obj = Get-ADUser -Identity $user_guid -Properties * @extra_args
+        $user_obj = Get-ADUser -Identity $user_guid -Properties ('*','msDS-PrincipalName') @extra_args
     }
 
     If ($password) {
@@ -190,7 +190,7 @@ If ($state -eq 'present') {
                 $set_new_credentials = -not (Test-Credential -Username $user_obj.UserPrincipalName -Password $password)
             }
             else {
-                $set_new_credentials = -not (Test-Credential -Username $user_obj.SamAccountName -Password $password)
+                $set_new_credentials = -not (Test-Credential -Username $user_obj.'msDS-PrincipalName' -Password $password)
             }
         } else {
             $set_new_credentials = $false

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -186,7 +186,12 @@ If ($state -eq 'present') {
         If ($new_user -or ($update_password -eq "always")) {
             $set_new_credentials = $true
         } elseif ($update_password -eq "when_changed") {
-            $set_new_credentials = -not (Test-Credential -Username $user_obj.UserPrincipalName -Password $password)
+            If ($user_obj.UserPrincipalName) {
+                $set_new_credentials = -not (Test-Credential -Username $user_obj.UserPrincipalName -Password $password)
+            }
+            else {
+                $set_new_credentials = -not (Test-Credential -Username $user_obj.SamAccountName -Password $password)
+            }
         } else {
             $set_new_credentials = $false
         }


### PR DESCRIPTION
win_domain_user: Use SAM when user have no upn during password verification

##### SUMMARY
On AD, explicit upn is not mandatory.

When the following playbook is played
```  community.windows.win_domain_user:
    name: bob
    firstname: Bob
    surname: Smith
    password: B0bP4ssw0rd
    update_password: when_changed
    state: present
    domain_username: DOMAIN\admin-account
    domain_password: SomePas2w0rd
    domain_server: domain@DOMAIN.COM
```

it works properly the first time but when it is played a second time,
it fails because password verification is done using upn of the user.
But user does not have a upn

The error returned is
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was:    at CallSite.Target(Closure , CallSite , Type , String , String , String , String , String )
fatal: [ad1]: FAILED! => {"changed": false, "msg": "Unhandled exception while executing module: Failed to logon  (The parameter is incorrect, Win32ErrorCode 87 - 0x00000057)"}
```

##### WORKAROUND

using
```
update_password: always
```
prevents password verification

