### PR TITLE
Fix up broken CI

### DIFF
--- a/tests/integration/targets/win_feature_info/defaults/main.yml
+++ b/tests/integration/targets/win_feature_info/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-test_feature: "Web-Server"
+test_feature: Telnet-Client


### PR DESCRIPTION
Installing IIS in a subsequent tests breaks the httptester, swap the feature in the test to something benign like `Telnet-Client`.