### PR TITLE
Update win_hotfix.ps1

### DIFF
--- a/plugins/modules/win_hotfix.ps1
+++ b/plugins/modules/win_hotfix.ps1
@@ -88,7 +88,9 @@ Function Get-HotfixMetadataFromFile($extract_path) {
     }
     [xml]$xml = Get-Content -LiteralPath $metadata_path.FullName
 
-    $cab_source_filename = $xml.unattend.servicing.package.source.GetAttribute("location")
+    $source = $xml.unattend.servicing.package
+    $source = $source | foreach-object {$_.source.location}
+    $source | foreach-object{$cab_source_filename =  $_
     $cab_source_filename = Split-Path -Path $cab_source_filename -Leaf
     $cab_file = Join-Path -Path $extract_path -ChildPath $cab_source_filename
 
@@ -124,7 +126,7 @@ Function Get-HotfixMetadataFromFile($extract_path) {
 
     return $metadata
 }
-
+}
 Function Get-HotfixMetadataFromKB($kb) {
     # I really hate doing it this way
     $packages = Get-WindowsPackage -Online

--- a/plugins/modules/win_hotfix.ps1
+++ b/plugins/modules/win_hotfix.ps1
@@ -225,7 +225,9 @@ if ($state -eq "absent") {
         } elseif ($hotfix_metadata.state -ne "Installed") {
             if (-not $check_mode) {
                 try {
-                    $install_result = Add-WindowsPackage -Online -PackagePath $hotfix_metadata.path -NoRestart
+227                 foreach($path in $hotfix_metadata.path) {
+228                     $install_result = Add-WindowsPackage -Online -PackagePath $path -NoRestart
+229                    }
                 } catch {
                     Fail-Json $result "failed to add windows package from path $($hotfix_metadata.path): $($_.Exception.Message)"
                 }


### PR DESCRIPTION
Added changes to show all  the metadata for cumulative updates.

##### SUMMARY
MS has added multiple cab files in the msu file which results in win_hotfix not able to find the metadata for the cabfile.

added a foreach loop for the cabfiles so that now both the files are listed in the metadata.

##### ISSUE TYPE
- Bugfix Pull Request
[https://github.com/ansible-collections/community.windows/issues/284](https://github.com/ansible-collections/community.windows/issues/284)

##### COMPONENT NAME
win_hotfix.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
