### PR TITLE
Update win_hotfix.ps1

### DIFF
--- a/plugins/modules/win_hotfix.ps1
+++ b/plugins/modules/win_hotfix.ps1
@@ -88,7 +88,9 @@ Function Get-HotfixMetadataFromFile($extract_path) {
     }
     [xml]$xml = Get-Content -LiteralPath $metadata_path.FullName
 
-    $cab_source_filename = $xml.unattend.servicing.package.source.GetAttribute("location")
+	$source = $xml.unattend.servicing.package
+	$source = $source | foreach-object {$_.source.location}
+	$source | foreach-object{$cab_source_filename =  $_
     $cab_source_filename = Split-Path -Path $cab_source_filename -Leaf
     $cab_file = Join-Path -Path $extract_path -ChildPath $cab_source_filename
 
@@ -123,6 +125,7 @@ Function Get-HotfixMetadataFromFile($extract_path) {
     }
 
     return $metadata
+}
 }
 
 Function Get-HotfixMetadataFromKB($kb) {


### PR DESCRIPTION
Indents mended as requested. Thank you for your kind inputs.

##### SUMMARY
MS has added multiple cab files in the msu file which results in win_hotfix not able to find the metadata for the cabfile.

added a foreach loop for the cabfiles so that now both the files are listed in the metadata.

##### ISSUE TYPE
Bugfix Pull Request
win_hotfix does not support the newer combined cumulative update and service stack update packages #284

##### COMPONENT NAME
win_hotfix.ps1

##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->


```
