### PR TITLE
win_scheduled_task: Require password only for password logon type

### DIFF
--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -705,8 +705,8 @@ if ($null -ne $username -and $null -ne $group) {
     Fail-Json -obj $result -message "username and group can not be set at the same time"
 }
 if ($null -ne $logon_type) {
-    if ($logon_type -eq [TASK_LOGON_TYPE]::TASK_LOGON_S4U -and $null -eq $password) {
-        Fail-Json -obj $result -message "password must be set when logon_type=s4u"
+    if ($logon_type -eq [TASK_LOGON_TYPE]::TASK_LOGON_PASSWORD -and $null -eq $password) {
+        Fail-Json -obj $result -message "password must be set when logon_type=password"
     }
 
     if ($logon_type -eq [TASK_LOGON_TYPE]::TASK_LOGON_GROUP -and $null -eq $group) {


### PR DESCRIPTION
##### SUMMARY
When using logon_type of s4u, password should not be required. Providing a password will cause the task registration to fail.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scheduled_task.ps1

##### ADDITIONAL INFORMATION
