### PR TITLE
win_disk_facts fails on un-numbered disks

### DIFF
--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -32,7 +32,7 @@ $result = @{
 
 # Search disks
 try {
-    $disks = Get-Disk
+    $disks = Get-Disk | Where-Object { $null -ne $_.Number }
 } catch {
     Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
 }


### PR DESCRIPTION
##### SUMMARY
win_disk_facts throws a null reference exception when it encounters a disk without a drive number.
This fixes that problem by ignoring unnumbered disks.

Fixes #16 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_disk_facts 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
