### PR TITLE
win_route - not identifying IPv6 routes

### DIFF
--- a/plugins/modules/win_route.ps1
+++ b/plugins/modules/win_route.ps1
@@ -31,11 +31,8 @@ Function Add-Route {
     [bool]$CheckMode
     )
 
-
-  $IpAddress = $Destination.split('/')[0]
-
   # Check if the static route is already present
-  $Route = Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '$($IpAddress)'"
+  $Route = Get-NetRoute | Where-Object -FilterScript { $_.DestinationPrefix -EQ $Destination }
   if (!($Route)){
     try {
       # Find Interface Index
@@ -64,8 +61,8 @@ Function Remove-Route {
     [string]$Destination,
     [bool]$CheckMode
     )
-  $IpAddress = $Destination.split('/')[0]
-  $Route = Get-CimInstance win32_ip4PersistedrouteTable -Filter "Destination = '$($IpAddress)'"
+  # Check if the static route is already present
+  $Route = Get-NetRoute | Where-Object -FilterScript { $_.DestinationPrefix -EQ $Destination }
   if ($Route){
     try {
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed powershell command to use "Get-NetRoute" as opposed to "Get-CimInstance", this allows to pull both IPv4 and IPv6 routes

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #312 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_route

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
