### PR TITLE
Fix "Unhandled exception while executing module: The property 'removed' cannot be found on this object. Verify that the property exists."

### DIFF
--- a/changelogs/fragments/275-win_xml-verbose-removed.yml
+++ b/changelogs/fragments/275-win_xml-verbose-removed.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  win_xml - Fix removal operation when running with higher verbosities - https://github.com/ansible-collections/community.windows/issues/275

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -154,14 +154,21 @@ $result.removed = ""
 
 if ($type -eq "element") {
     if ($state -eq "absent") {
+
+      $removals = [System.Collections.Generic.List[String]]@()
+
         foreach ($node in $nodeList) {
             # there are some nodes that match xpath, delete without comparing them to fragment
             if (-Not $check_mode) {
                 $removedNode = $node.get_ParentNode().RemoveChild($node)
                 $changed = $true
                 if ($debug) {
-                    $result.removed += $removedNode.get_OuterXml() + ", "
+                    $removals.Add($removedNode.get_OuterXml())
                 }
+            }
+
+            if ($removals) {
+              $result.removed = $removals -join ", "
             }
         }
     } else { # state -eq 'present'

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -150,26 +150,26 @@ if ($nodeListCount -eq 0) {
 
 $changed = $false
 $result.msg = "not changed"
-$result.removed = ""
 
 if ($type -eq "element") {
     if ($state -eq "absent") {
 
-      $removals = [System.Collections.Generic.List[String]]@()
+        $removals = [System.Collections.Generic.List[String]]@()
 
         foreach ($node in $nodeList) {
             # there are some nodes that match xpath, delete without comparing them to fragment
             if (-Not $check_mode) {
-                $removedNode = $node.get_ParentNode().RemoveChild($node)
+                [void]$node.get_ParentNode().RemoveChild($node)
                 $changed = $true
-                if ($debug) {
-                    $removals.Add($removedNode.get_OuterXml())
-                }
             }
 
-            if ($removals) {
-              $result.removed = $removals -join ", "
+            if ($debug) {
+                $removals.Add($node.get_OuterXml())
             }
+        }
+
+        if ($removals) {
+            $result.removed = $removals -join ", "
         }
     } else { # state -eq 'present'
         $xmlfragment = $null

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -150,6 +150,7 @@ if ($nodeListCount -eq 0) {
 
 $changed = $false
 $result.msg = "not changed"
+$result.removed = ""
 
 if ($type -eq "element") {
     if ($state -eq "absent") {
@@ -159,7 +160,7 @@ if ($type -eq "element") {
                 $removedNode = $node.get_ParentNode().RemoveChild($node)
                 $changed = $true
                 if ($debug) {
-                    $result.removed += $result.removed + $removedNode.get_OuterXml()
+                    $result.removed += $removedNode.get_OuterXml() + ", "
                 }
             }
         }


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Initialized $result.removed so that it would not fail when in debug.

Add spacing for multiple removals. Not sure this is the right format.

Fixes #275

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_xml
Fixes the issue when running an "absent" state while passing verbosity. 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This fix implements the "removed" object that was already defined in the code. This member of return is not included in the win_xml documentation. If this was the intended use of this return object, it should be added to the documentation. If not, I can modify the code to use the msg string instead. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```bash
The full traceback is:
The property 'removed' cannot be found on this object. Verify that the property exists.
At line:162 char:21
+ ...             $result.removed += $result.removed + $removedNode.get_Out ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : PropertyNotFoundStrict

ScriptStackTrace:
at <ScriptBlock>, <No file>: line 162
fatal: [testhost]: FAILED! => {
    "changed": false,
    "msg": "Unhandled exception while executing module: The property 'removed' cannot be found on this object. Verify that the property exists."
}
```
After:

```bash
changed: [testhost] => {
    "changed": true,
    "msg": "element removed",
    "removed": "<Property>testing1</Property>, <Property>testing2</Property>, <Property>testing3</Property>, <Property>testing4</Property>, "
}
```