### PR TITLE
win_nssm - undeprecate options and tidy up

### DIFF
--- a/changelogs/fragments/win_nssm-username.yml
+++ b/changelogs/fragments/win_nssm-username.yml
@@ -1,0 +1,7 @@
+minor_changes:
+- win_nssm - Support gMSA accounts for ``user``
+- win_nssm - Remove deprecation for ``state``, ``dependencies``, ``user``, ``password``, ``start_mode``
+- win_nssm - Added ``username`` as an alias for ``user``
+
+bugfixes:
+- win_nssm - Perform better user comparison checks for idempotency

--- a/plugins/modules/win_nssm.py
+++ b/plugins/modules/win_nssm.py
@@ -22,8 +22,6 @@ options:
   state:
     description:
       - State of the service on the system.
-      - Values C(started), C(stopped), and C(restarted) are deprecated and will be removed on a major release after
-        C(2021-07-01). Please use the M(ansible.windows.win_service) module instead to start, stop or restart the service.
     type: str
     choices: [ absent, present, started, stopped, restarted ]
     default: present
@@ -74,20 +72,19 @@ options:
   dependencies:
     description:
       - Service dependencies that has to be started to trigger startup, separated by comma.
-      - DEPRECATED, will be removed in a major release after C(2021-07-01), please use the
-        M(ansible.windows.win_service) module instead.
     type: list
-  user:
+  username:
     description:
       - User to be used for service startup.
-      - DEPRECATED, will be removed in a major release after C(2021-07-01), please use the
-        M(ansible.windows.win_service) module instead.
+      - Group managed service accounts must end with C($).
+      - Before C(1.8.0), this parameter was just C(user).
     type: str
+    aliases:
+    - user
   password:
     description:
       - Password to be used for service startup.
-      - DEPRECATED, will be removed in a major release after C(2021-07-01), please use the
-        M(ansible.windows.win_service) module instead.
+      - This is not required for the well known service accounts and group managed service accounts.
     type: str
   start_mode:
     description:
@@ -95,8 +92,6 @@ options:
       - C(delayed) causes a delayed but automatic start after boot.
       - C(manual) means that the service will start only when another service needs it.
       - C(disabled) means that the service will stay off, regardless if it is needed or not.
-      - DEPRECATED, will be removed in a major release after C(2021-07-01), please use the
-        M(ansible.windows.win_service) module instead.
     type: str
     choices: [ auto, delayed, disabled, manual ]
     default: auto

--- a/tests/integration/targets/win_nssm/tasks/main.yml
+++ b/tests/integration/targets/win_nssm/tasks/main.yml
@@ -14,11 +14,28 @@
     name: '{{test_win_nssm_username}}'
     password: '{{test_win_nssm_password}}'
     state: present
+    groups_action: add
     groups:
     - Users
+  register: user_info
 
 # Run actual tests
 - block:
+  - name: normalise test account name
+    ansible.windows.win_powershell:
+      parameters:
+        SID: '{{ user_info.sid }}'
+      script: |
+        [CmdletBinding()]
+        param ([String]$SID)
+
+        $Ansible.Changed = $false
+        ([System.Security.Principal.SecurityIdentifier]$SID).Translate([System.Security.Principal.NTAccount]).Value
+    register: test_win_nssm_normalised_username
+
+  - set_fact:
+      test_win_nssm_normalised_username: '{{ test_win_nssm_normalised_username.output[0] }}'
+
   - include_tasks: tests.yml
 
   always:

--- a/tests/integration/targets/win_nssm/tasks/tests.yml
+++ b/tests/integration/targets/win_nssm/tasks/tests.yml
@@ -6,6 +6,42 @@
       $srvobj = Get-WmiObject Win32_Service -Filter "Name=""$service""" | Select Name,DisplayName,Description,PathName,StartMode,StartName,State
       if ($srvobj) {
         $srvobj | Get-Member -MemberType *Property | % { $res.($_.name) = $srvobj.($_.name) }
+
+        $startName = $res.StartName
+        $candidates = @(if ($startName -eq "LocalSystem") {
+          "NT AUTHORITY\SYSTEM"
+        }
+        elseif ($startName.Contains('\')) {
+          $nameSplit = $startName.Split('\', 2)
+
+          if ($nameSplit[0] -eq '.') {
+            ,@($env:COMPUTERNAME, $nameSplit[1])
+            $nameSplit[1]
+          } else {
+            ,$nameSplit
+          }
+        }
+        else {
+          $startName
+        })
+
+        $sid = for ($i = 0; $i -lt $candidates.Length; $i++) {
+          $candidate = $candidates[$i]
+          $ntAccount = New-Object -TypeName System.Security.Principal.NTAccount -ArgumentList $candidate
+          try {
+              $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
+              break
+          }
+          catch [System.Security.Principal.IdentityNotMappedException] {
+            if ($i -eq ($candidates.Length - 1)) {
+              throw
+            }
+            continue
+          }
+        }
+
+        $res.StartName = $sid.Translate([System.Security.Principal.NTAccount]).Value
+
         $res.Exists = $true
         $res.Dependencies = @(Get-WmiObject -Query "Associators of {Win32_Service.Name=""$service""} Where AssocClass=Win32_DependentService" | select -ExpandProperty Name)
         $res.Parameters = @{}
@@ -106,7 +142,7 @@
     start_mode: manual
     working_directory: '{{ test_win_nssm_path }}'
     dependencies: 'tcpip,dnscache'
-    user: '{{ test_win_nssm_username }}'
+    username: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
     stdout_file: '{{ test_win_nssm_path }}\log.txt'
     stderr_file: '{{ test_win_nssm_path }}\error.txt'
@@ -126,7 +162,7 @@
     - (install_service_complex_check_actual.stdout|from_json).DisplayName == '{{ test_service_name }}'
     - (install_service_complex_check_actual.stdout|from_json).Description is none
     - (install_service_complex_check_actual.stdout|from_json).StartMode != 'Manual'
-    - (install_service_complex_check_actual.stdout|from_json).StartName != '.\\' + test_win_nssm_username
+    - (install_service_complex_check_actual.stdout|from_json).StartName != test_win_nssm_normalised_username
     - (install_service_complex_check_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     - (install_service_complex_check_actual.stdout|from_json).Parameters.AppDirectory == "C:\Windows\System32"
     - '"AppStdout" not in (install_service_complex_check_actual.stdout|from_json).Parameters'
@@ -142,7 +178,7 @@
     start_mode: manual
     working_directory: '{{ test_win_nssm_path }}'
     dependencies: 'tcpip,dnscache'
-    user: '{{ test_win_nssm_username }}'
+    username: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
     stdout_file: '{{ test_win_nssm_path }}\log.txt'
     stderr_file: '{{ test_win_nssm_path }}\error.txt'
@@ -162,7 +198,7 @@
     - (install_service_complex_actual.stdout|from_json).Description == 'win_nssm test service'
     - (install_service_complex_actual.stdout|from_json).State == 'Running'
     - (install_service_complex_actual.stdout|from_json).StartMode == 'Manual'
-    - (install_service_complex_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
+    - (install_service_complex_actual.stdout|from_json).StartName == test_win_nssm_normalised_username
     - (install_service_complex_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     - (install_service_complex_actual.stdout|from_json).Parameters.AppDirectory == test_win_nssm_path
     - (install_service_complex_actual.stdout|from_json).Parameters.AppStdout == test_win_nssm_path + '\\log.txt'
@@ -181,7 +217,7 @@
     working_directory: '{{ test_win_nssm_path }}'
     # Dependencies order should not trigger a change
     dependencies: 'dnscache,tcpip'
-    user: '{{ test_win_nssm_username }}'
+    username: '{{ test_win_nssm_username }}'
     password: '{{ test_win_nssm_password }}'
     stdout_file: '{{ test_win_nssm_path }}\log.txt'
     stderr_file: '{{ test_win_nssm_path }}\error.txt'
@@ -201,7 +237,7 @@
     - (install_service_complex_again_actual.stdout|from_json).Description == 'win_nssm test service'
     - (install_service_complex_again_actual.stdout|from_json).State == 'Running'
     - (install_service_complex_again_actual.stdout|from_json).StartMode == 'Manual'
-    - (install_service_complex_again_actual.stdout|from_json).StartName == '.\\' + test_win_nssm_username
+    - (install_service_complex_again_actual.stdout|from_json).StartName == test_win_nssm_normalised_username
     - (install_service_complex_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     - (install_service_complex_again_actual.stdout|from_json).Parameters.AppDirectory == test_win_nssm_path
     - (install_service_complex_again_actual.stdout|from_json).Parameters.AppStdout == test_win_nssm_path + '\\log.txt'
@@ -268,9 +304,9 @@
   ansible.windows.win_shell: nssm.exe get '{{ test_service_name }}' AppEnvironmentExtra
   register: install_service_appenv_check_actual
 
-  ## note: this could fail (in theory) when the service is not yet 
-  ##   installed (diff mode), but because of side effects of earlier 
-  ##   tests this will actually not fail in practice, however, it is 
+  ## note: this could fail (in theory) when the service is not yet
+  ##   installed (diff mode), but because of side effects of earlier
+  ##   tests this will actually not fail in practice, however, it is
   ##   not a real issue in any case
   failed_when: false
 
@@ -468,6 +504,66 @@
     - (list_params_again_actual.stdout|from_json).Parameters.Application == "C:\Windows\System32\cmd.exe"
     # Expected value: -foo=bar -day 14 -file.out "C:\with space\output.bat" -str "test\"quotes\\" (backslashes doubled for jinja)
     - (list_params_again_actual.stdout|from_json).Parameters.AppParameters == '-foo=bar -day 14 -file.out "C:\\with space\\output.bat" -str "test\\"quotes\\\\"'
+
+- name: set service username to SYSTEM
+  win_nssm:
+    name: '{{ test_service_name }}'
+    username: LocalSystem
+    application: C:\Windows\System32\cmd.exe
+  register: service_system
+
+- name: get service account for SYSTEM
+  ansible.windows.win_service_info:
+    name: '{{ test_service_name }}'
+  register: service_system_actual
+
+- name: assert set service username to SYSTEM
+  assert:
+    that:
+    - service_system is changed
+    - service_system_actual.services[0].username == 'NT AUTHORITY\\SYSTEM'
+
+- name: set service username to SYSTEM (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    username: SYSTEM
+    application: C:\Windows\System32\cmd.exe
+  register: service_system_again
+
+- name: assert set service username to SYSTEM (idempotent)
+  assert:
+    that:
+    - not service_system_again is changed
+
+- name: set service username to NETWORK SERVICE
+  win_nssm:
+    name: '{{ test_service_name }}'
+    username: NETWORK SERVICE
+    application: C:\Windows\System32\cmd.exe
+  register: service_network
+
+- name: get service account for NETWORK SERVICE
+  ansible.windows.win_service_info:
+    name: '{{ test_service_name }}'
+  register: service_network_actual
+
+- name: assert set service username to NETWORK SERVICE
+  assert:
+    that:
+    - service_network is changed
+    - service_network_actual.services[0].username == 'NT Authority\\NetworkService'
+
+- name: set service username to NETWORK SERVICE (idempotent)
+  win_nssm:
+    name: '{{ test_service_name }}'
+    username: NT AUTHORITY\NETWORK SERVICE
+    application: C:\Windows\System32\cmd.exe
+  register: service_network_again
+
+- name: assert set service username to NETWORK SERVICE (idempotent)
+  assert:
+    that:
+    - not service_network_again is changed
 
 - name: remove service (check mode)
   win_nssm:


### PR DESCRIPTION
##### SUMMARY
This undeprecated options that probably should just stay with the module. There's little benefit forcing people to use 2 modules when NSSM can do the same thing at the same time. In reality it may be easier to use than `win_service` as it will grant the log on as a service right for the user specified whereas `win_service` is a manual step. It also tried to normalize the user accounts specified for better comparisons and fixes the password logic for accounts without a password.

The tests added by https://github.com/ansible-collections/community.windows/pull/299 are affecting `win_nssm`. This fixes the tests to work with any environment changes `win_domain_ou` has made.

Fixes https://github.com/ansible-collections/community.windows/issues/227

##### ISSUE TYPE
- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME
win_nssm