### PR TITLE
win_scoop_bucket - fix junk data output

### DIFF
--- a/changelogs/fragments/win_scoop_bucket-junk.yml
+++ b/changelogs/fragments/win_scoop_bucket-junk.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_scoop_bucket - Ensure no extra data is sent to the controller resulting in a junk output warning

--- a/plugins/modules/win_scoop_bucket.ps1
+++ b/plugins/modules/win_scoop_bucket.ps1
@@ -91,7 +91,7 @@ function Install-ScoopBucket {
     [Parameter(Mandatory = $true)] [String]$bucket,
     [String]$repo
   )
-  $arguments = [System.Collections.ArrayList]@("powershell.exe", $scoop_path, "bucket", "add")
+  $arguments = [System.Collections.Generic.List[String]]@("powershell.exe", $scoop_path, "bucket", "add")
   $arguments.Add($bucket)
   if ($repo) {
     $arguments.Add($repo)


### PR DESCRIPTION
##### SUMMARY
The `win_scoop_bucket` module calls` .Add()` on an `ArrayList` object which outputs the index that was added. This results in both the index values and the output json being parsed by Ansible causing a warning to be fired. Instead this will change the list type to a `Generic.List` which has a void `.Add()` method.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scoop_bucket