### PR TITLE
win_xml: Hide warnings on element operation, unless debug or count is set

### DIFF
--- a/changelogs/fragments/205-win_xml-warning.yml
+++ b/changelogs/fragments/205-win_xml-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_xml - Do not show warnings for normal operations - https://github.com/ansible-collections/community.windows/issues/205

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -181,8 +181,6 @@ if ($type -eq "element") {
             $elements = $node.get_ChildNodes()
             [bool]$present = $false
             [bool]$changed = $false
-            $element_count = $elements.get_Count()
-            }
             if ($elements.get_Count()) {
                 if ($debug) {
                     $err = @()

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -182,9 +182,6 @@ if ($type -eq "element") {
             [bool]$present = $false
             [bool]$changed = $false
             $element_count = $elements.get_Count()
-            if (($debug) -or ($count)) {
-                $nstatus = "node: " + $node.get_Value() + " element: " + $elements.get_OuterXml() + " Element count is $element_count"
-                Add-Warning $result $nstatus
             }
             if ($elements.get_Count()) {
                 if ($debug) {
@@ -192,10 +189,6 @@ if ($type -eq "element") {
                     $result.err = {$err}.Invoke()
                 }
                 foreach ($element in $elements) {
-                    if ($debug){
-                        $estatus = "element is " + $element.get_OuterXml()
-                        Add-Warning $result $estatus
-                    }
                     try {
                         Compare-XmlDocs $candidate $element
                         $present = $true

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -182,16 +182,20 @@ if ($type -eq "element") {
             [bool]$present = $false
             [bool]$changed = $false
             $element_count = $elements.get_Count()
-            $nstatus = "node: " + $node.get_Value() + " element: " + $elements.get_OuterXml() + " Element count is $element_count"
-            Add-Warning $result $nstatus
+            if ($debug) {
+                $nstatus = "node: " + $node.get_Value() + " element: " + $elements.get_OuterXml() + " Element count is $element_count"
+                Add-Warning $result $nstatus
+            }
             if ($elements.get_Count()) {
                 if ($debug) {
                     $err = @()
                     $result.err = {$err}.Invoke()
                 }
                 foreach ($element in $elements) {
-                    $estatus = "element is " + $element.get_OuterXml()
-                    Add-Warning $result $estatus
+                    if ($debug){
+                        $estatus = "element is " + $element.get_OuterXml()
+                        Add-Warning $result $estatus
+                    }
                     try {
                         Compare-XmlDocs $candidate $element
                         $present = $true

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -182,7 +182,7 @@ if ($type -eq "element") {
             [bool]$present = $false
             [bool]$changed = $false
             $element_count = $elements.get_Count()
-            if ($debug) {
+            if (($debug) -or ($count)) {
                 $nstatus = "node: " + $node.get_Value() + " element: " + $elements.get_OuterXml() + " Element count is $element_count"
                 Add-Warning $result $nstatus
             }


### PR DESCRIPTION
##### SUMMARY
When running win_xml to add an element, it will display warnings in the output as it enumerates the multiple children in the element you've selected. This hides those behind the debug flag, as the warnings are simply displaying names of the element currently being looked at, and the count of total elements. 

Fixes #205.
Partially addresses #210.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_xml

##### ADDITIONAL INFORMATION
This is my first contribution here, please let me know if this needs improvement. Thanks!
