### PR TITLE
Fix LIB env var conflicts

### DIFF
--- a/changelogs/fragments/add-type-env.yml
+++ b/changelogs/fragments/add-type-env.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- win_region - Fix conflicts with existing ``LIB`` environment variable
+- win_scheduled_task_stat - Fix conflicts with existing ``LIB`` environment variable
+- win_scheduled_task - Fix conflicts with existing ``LIB`` environment variable

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -5,6 +5,7 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.SID
 
@@ -70,7 +71,7 @@ if ($diff_mode) {
     $result.diff = @{}
 }
 
-$task_enums = @"
+Add-CSharpType -TempPath $_remote_tmp -References @'
 public enum TASK_ACTION_TYPE // https://msdn.microsoft.com/en-us/library/windows/desktop/aa383553(v=vs.85).aspx
 {
     TASK_ACTION_EXEC          = 0,
@@ -132,12 +133,7 @@ public enum TASK_SESSION_STATE_CHANGE_TYPE // https://docs.microsoft.com/en-us/w
     TASK_SESSION_LOCK       = 7,
     TASK_SESSION_UNLOCK     = 8
 }
-"@
-
-$original_tmp = $env:TMP
-$env:TMP = $_remote_tmp
-Add-Type -TypeDefinition $task_enums
-$env:TMP = $original_tmp
+'@
 
 ########################
 ### HELPER FUNCTIONS ###

--- a/plugins/modules/win_scheduled_task_stat.ps1
+++ b/plugins/modules/win_scheduled_task_stat.ps1
@@ -380,6 +380,12 @@ if ($null -ne $name) {
     }
 }
 
-$module.Result = Convert-DictToSnakeCase -dict $module.Result
+# Convert-DictToSnakeCase returns a Hashtable but Ansible.Basic expect a Dictionary. This is a hack until the snake
+# conversion code has been moved to this collection and updated to handle this.
+$new_result = [System.Collections.Generic.Dictionary[[String], [Object]]]@{}
+foreach ($kvp in (Convert-DictToSnakeCase -dict $module.Result).GetEnumerator()) {
+    $new_result[$kvp.Name] = $kvp.Value
+}
+$module.Result = $new_result
 
 $module.ExitJson()


### PR DESCRIPTION
##### SUMMARY
Calling `Add-Type` with the env var `LIB` set to an invalid PATH breaks the compilation and thus fails the module. This PR changes modules to use `Add-CSharpType` which fixed this problem https://github.com/ansible/ansible/pull/75698.

It also converts `win_region` and `win_scheduled_task_stat` to the newer module wrapper util to reduce the amount of code shipped across.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_region
win_scheduled_task_stat
win_scheduled_task