### PR TITLE
fix AppendChild to empty parent

### DIFF
--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -58,6 +58,7 @@ function Compare-XmlDocs($actual, $expected) {
         }
     }
 
+    <#
     ##children
     if ($expected.get_ChildNodes().Count -ne $actual.get_ChildNodes().Count)  {
         throw "child node mismatch. for actual=" + $actual.get_Name()
@@ -69,6 +70,7 @@ function Compare-XmlDocs($actual, $expected) {
         }
         Compare-XmlDocs $expected.get_ChildNodes()[$i] $actual.get_ChildNodes()[$i]
     }
+    #>
 
     if ($expected.get_InnerText()) {
         if ($expected.get_InnerText() -ne $actual.get_InnerText()) {
@@ -205,11 +207,11 @@ if ($type -eq "element") {
                         }
                     }
                 }
-                if (-Not $present -and ($state -eq "present")) {
-                    [void]$node.AppendChild($candidate)
-                    $result.msg = $result.msg + "xml added "
-                    $changed = $true
-                }
+            }
+            if (-Not $present -and ($state -eq "present")) {
+                [void]$node.AppendChild($candidate)
+                $result.msg = $result.msg + "xml added "
+                $changed = $true
             }
         }
     }


### PR DESCRIPTION
##### SUMMARY
The if statement to create a missing element was nested too high and not executing if the parent node has no children. Also, the Compare-XML function compared child nodes which causes a new node to be created if you were just trying to confirm the existence of said node.

Fixes #46 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- win_xml.ps1

##### ADDITIONAL INFORMATION
The if statement to create a missing element was nested too high and not executing if the parent node has no children. 
If the node exist and has children, it would create a new empty node which is undesirable.

ANSIBLE 
```
  - name: Ensure Rewrite node exists
    win_xml:
      path: '{{ iis_physical_path }}\web.config'
      xpath: '/configuration/system.webServer'
      fragment: '<rewrite></rewrite>'
```

BEFORE:
```
{
  "changed": false,
  "msg": "not changed",
  "_ansible_no_log": false
}
```

AFTER:
```
{
  "changed": true,
  "msg": "element added",
  "_ansible_no_log": false
}
```