### PR TITLE
Adds filter as request for  #33

### DIFF
--- a/changelogs/fragments/310_win_disk_facts.yml
+++ b/changelogs/fragments/310_win_disk_facts.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - win_disk_facts - Added ``filter`` option to filter returned facts by type of disk information - https://github.com/ansible-collections/community.windows/pull/333
-  - win_disk_facts - Converted from ``#Requires -Module Ansible.ModuleUtils.Legacy`` to ``#AnsibleRequires -CSharpUtil Ansible.Basic`` - https://github.com/ansible-collections/community.windows/pull/333
+  - win_disk_facts - Added ``filter`` option to filter returned facts by type of disk information - https://github.com/ansible-collections/community.windows/issues/33
+  - win_disk_facts - Converted from ``#Requires -Module Ansible.ModuleUtils.Legacy`` to ``#AnsibleRequires -CSharpUtil Ansible.Basic``

--- a/changelogs/fragments/310_win_disk_facts.yml
+++ b/changelogs/fragments/310_win_disk_facts.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - win_disk_facts - Added ``filter`` option to filter returned facts by type of disk information - https://github.com/ansible-collections/community.windows/pull/333
+  - win_disk_facts - Converted from ``#Requires -Module Ansible.ModuleUtils.Legacy`` to ``#AnsibleRequires -CSharpUtil Ansible.Basic`` - https://github.com/ansible-collections/community.windows/pull/333

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -3,7 +3,6 @@
 # Copyright: (c) 2017, Marc Tschapek <marc.tschapek@itelligence.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -OSVersion 6.2
 
@@ -32,23 +31,20 @@ function Test-Admin {
 
 # Check admin rights
 if (-not (Test-Admin)) {
-    Fail-Json -obj @{} -message "Module was not started with elevated rights"
+    $module.FailJson("Module was not started with elevated rights")
 }
 
+
 # Create a new result object
-$result = @{
-    changed = $false
-    ansible_facts = @{
-        ansible_disks = @()
-    }
-}
+$module.Result.changed = $false
+$module.Result.ansible_facts = @{ansible_disks = @()}
 
 # Search disks
 try {
     $disks = Get-Disk
 }
 catch {
-    Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
+    $module.FailJson("Failed to search the disks on the target: $($_.Exception.Message)", $_)
 }
 
 foreach ($disk in $disks) {
@@ -274,11 +270,11 @@ foreach ($disk in $disks) {
             }
         }
     }
-    $result.ansible_facts.ansible_disks += $disk_info
+    $module.Result.ansible_facts.ansible_disks += $disk_info
 }
 
 # Sort by disk number property
-$result.ansible_facts.ansible_disks = @() + ($result.ansible_facts.ansible_disks | Sort-Object -Property { $_.Number })
+$module.Result.ansible_facts.ansible_disks = @() + ($module.Result.ansible_facts.ansible_disks | Sort-Object -Property { $_.Number })
 
 # Return result
-Exit-Json -obj $result
+$module.ExitJson()

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -4,16 +4,29 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -OSVersion 6.2
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
 
+$spec = @{
+    options = @{
+        filter = @{
+            type = "list";
+            elements = "str";
+            choices = "physical_disk", "virtual_disk", "win32_disk_drive", "partitions", "volumes";
+            default = "physical_disk", "virtual_disk", "win32_disk_drive", "partitions", "volumes";
+        }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
 # Functions
 function Test-Admin {
     $CurrentUser = New-Object Security.Principal.WindowsPrincipal $([Security.Principal.WindowsIdentity]::GetCurrent())
     $IsAdmin = $CurrentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
-
     return $IsAdmin
 }
 
@@ -33,144 +46,148 @@ $result = @{
 # Search disks
 try {
     $disks = Get-Disk
-}
-catch {
+} catch {
     Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
 }
 foreach ($disk in $disks) {
     $disk_info = @{}
-    $pdisk = Get-PhysicalDisk -ErrorAction SilentlyContinue | Where-Object {
-        $_.DeviceId -eq $disk.Number
-    }
-    if ($pdisk) {
-        $disk_info["physical_disk"] += @{
-            size = $pdisk.Size
-            allocated_size = $pdisk.AllocatedSize
-            device_id = $pdisk.DeviceId
-            friendly_name = $pdisk.FriendlyName
-            operational_status = $pdisk.OperationalStatus
-            health_status = $pdisk.HealthStatus
-            bus_type = $pdisk.BusType
-            usage_type = $pdisk.Usage
-            supported_usages = $pdisk.SupportedUsages
-            spindle_speed = $pdisk.SpindleSpeed
-            firmware_version = $pdisk.FirmwareVersion
-            physical_location = $pdisk.PhysicalLocation
-            manufacturer = $pdisk.Manufacturer
-            model = $pdisk.Model
-            can_pool = $pdisk.CanPool
-            indication_enabled = $pdisk.IsIndicationEnabled
-            partial = $pdisk.IsPartial
-            serial_number = $pdisk.SerialNumber
-            object_id = $pdisk.ObjectId
-            unique_id = $pdisk.UniqueId
+    if ("physical_disk" -in $module.Params.filter) {
+        $pdisk = Get-PhysicalDisk -ErrorAction SilentlyContinue | Where-Object {
+            $_.DeviceId -eq $disk.Number
         }
-        if ([single]"$([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor)" -ge 6.3) {
-            $disk_info.physical_disk.media_type = $pdisk.MediaType
+        if ($pdisk) {
+            $disk_info["physical_disk"] += @{
+                size = $pdisk.Size
+                allocated_size = $pdisk.AllocatedSize
+                device_id = $pdisk.DeviceId
+                friendly_name = $pdisk.FriendlyName
+                operational_status = $pdisk.OperationalStatus
+                health_status = $pdisk.HealthStatus
+                bus_type = $pdisk.BusType
+                usage_type = $pdisk.Usage
+                supported_usages = $pdisk.SupportedUsages
+                spindle_speed = $pdisk.SpindleSpeed
+                firmware_version = $pdisk.FirmwareVersion
+                physical_location = $pdisk.PhysicalLocation
+                manufacturer = $pdisk.Manufacturer
+                model = $pdisk.Model
+                can_pool = $pdisk.CanPool
+                indication_enabled = $pdisk.IsIndicationEnabled
+                partial = $pdisk.IsPartial
+                serial_number = $pdisk.SerialNumber
+                object_id = $pdisk.ObjectId
+                unique_id = $pdisk.UniqueId
+            }
+            if ([single]"$([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor)" -ge 6.3) {
+                $disk_info.physical_disk.media_type = $pdisk.MediaType
+            }
+            if (-not $pdisk.CanPool) {
+                $disk_info.physical_disk.cannot_pool_reason = $pdisk.CannotPoolReason
+            }
         }
-        if (-not $pdisk.CanPool) {
-            $disk_info.physical_disk.cannot_pool_reason = $pdisk.CannotPoolReason
-        }
-        $vdisk = Get-VirtualDisk -PhysicalDisk $pdisk -ErrorAction SilentlyContinue
-        if ($vdisk) {
-            $disk_info["virtual_disk"] += @{
-                size = $vdisk.Size
-                allocated_size = $vdisk.AllocatedSize
-                footprint_on_pool = $vdisk.FootprintOnPool
-                name = $vdisk.name
-                friendly_name = $vdisk.FriendlyName
-                operational_status = $vdisk.OperationalStatus
-                health_status = $vdisk.HealthStatus
-                provisioning_type = $vdisk.ProvisioningType
-                allocation_unit_size = $vdisk.AllocationUnitSize
-                media_type = $vdisk.MediaType
-                parity_layout = $vdisk.ParityLayout
-                access = $vdisk.Access
-                detached_reason = $vdisk.DetachedReason
-                write_cache_size = $vdisk.WriteCacheSize
-                fault_domain_awareness = $vdisk.FaultDomainAwareness
-                inter_leave = $vdisk.InterLeave
-                deduplication_enabled = $vdisk.IsDeduplicationEnabled
-                enclosure_aware = $vdisk.IsEnclosureAware
-                manual_attach = $vdisk.IsManualAttach
-                snapshot = $vdisk.IsSnapshot
-                tiered = $vdisk.IsTiered
-                physical_sector_size = $vdisk.PhysicalSectorSize
-                logical_sector_size = $vdisk.LogicalSectorSize
-                available_copies = $vdisk.NumberOfAvailableCopies
-                columns = $vdisk.NumberOfColumns
-                groups = $vdisk.NumberOfGroups
-                physical_disk_redundancy = $vdisk.PhysicalDiskRedundancy
-                read_cache_size = $vdisk.ReadCacheSize
-                request_no_spof = $vdisk.RequestNoSinglePointOfFailure
-                resiliency_setting_name = $vdisk.ResiliencySettingName
-                object_id = $vdisk.ObjectId
-                unique_id_format = $vdisk.UniqueIdFormat
-                unique_id = $vdisk.UniqueId
+        if ("virtual_disk" -in $module.Params.filter) {
+            $vdisk = Get-VirtualDisk -PhysicalDisk $pdisk -ErrorAction SilentlyContinue
+            if ($vdisk) {
+                $disk_info["virtual_disk"] += @{
+                    size = $vdisk.Size
+                    allocated_size = $vdisk.AllocatedSize
+                    footprint_on_pool = $vdisk.FootprintOnPool
+                    name = $vdisk.name
+                    friendly_name = $vdisk.FriendlyName
+                    operational_status = $vdisk.OperationalStatus
+                    health_status = $vdisk.HealthStatus
+                    provisioning_type = $vdisk.ProvisioningType
+                    allocation_unit_size = $vdisk.AllocationUnitSize
+                    media_type = $vdisk.MediaType
+                    parity_layout = $vdisk.ParityLayout
+                    access = $vdisk.Access
+                    detached_reason = $vdisk.DetachedReason
+                    write_cache_size = $vdisk.WriteCacheSize
+                    fault_domain_awareness = $vdisk.FaultDomainAwareness
+                    inter_leave = $vdisk.InterLeave
+                    deduplication_enabled = $vdisk.IsDeduplicationEnabled
+                    enclosure_aware = $vdisk.IsEnclosureAware
+                    manual_attach = $vdisk.IsManualAttach
+                    snapshot = $vdisk.IsSnapshot
+                    tiered = $vdisk.IsTiered
+                    physical_sector_size = $vdisk.PhysicalSectorSize
+                    logical_sector_size = $vdisk.LogicalSectorSize
+                    available_copies = $vdisk.NumberOfAvailableCopies
+                    columns = $vdisk.NumberOfColumns
+                    groups = $vdisk.NumberOfGroups
+                    physical_disk_redundancy = $vdisk.PhysicalDiskRedundancy
+                    read_cache_size = $vdisk.ReadCacheSize
+                    request_no_spof = $vdisk.RequestNoSinglePointOfFailure
+                    resiliency_setting_name = $vdisk.ResiliencySettingName
+                    object_id = $vdisk.ObjectId
+                    unique_id_format = $vdisk.UniqueIdFormat
+                    unique_id = $vdisk.UniqueId
+                }
             }
         }
     }
-    $win32_disk_drive = Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction SilentlyContinue | Where-Object {
-        if ($_.SerialNumber) {
-            $_.SerialNumber -eq $disk.SerialNumber
+    if ("win32_disk_drive" -in $module.Params.filter) {
+        $win32_disk_drive = Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction SilentlyContinue | Where-Object {
+            if ($_.SerialNumber) {
+                $_.SerialNumber -eq $disk.SerialNumber
+            } elseif ($disk.UniqueIdFormat -eq 'Vendor Specific') {
+                $_.PNPDeviceID -eq $disk.UniqueId.split(':')[0]
+            }
         }
-        elseif ($disk.UniqueIdFormat -eq 'Vendor Specific') {
-            $_.PNPDeviceID -eq $disk.UniqueId.split(':')[0]
-        }
-    }
-    if ($win32_disk_drive) {
-        $disk_info["win32_disk_drive"] += @{
-            availability = $win32_disk_drive.Availability
-            bytes_per_sector = $win32_disk_drive.BytesPerSector
-            capabilities = $win32_disk_drive.Capabilities
-            capability_descriptions = $win32_disk_drive.CapabilityDescriptions
-            caption = $win32_disk_drive.Caption
-            compression_method = $win32_disk_drive.CompressionMethod
-            config_manager_error_code = $win32_disk_drive.ConfigManagerErrorCode
-            config_manager_user_config = $win32_disk_drive.ConfigManagerUserConfig
-            creation_class_name = $win32_disk_drive.CreationClassName
-            default_block_size = $win32_disk_drive.DefaultBlockSize
-            description = $win32_disk_drive.Description
-            device_id = $win32_disk_drive.DeviceID
-            error_cleared = $win32_disk_drive.ErrorCleared
-            error_description = $win32_disk_drive.ErrorDescription
-            error_methodology = $win32_disk_drive.ErrorMethodology
-            firmware_revision = $win32_disk_drive.FirmwareRevision
-            index = $win32_disk_drive.Index
-            install_date = $win32_disk_drive.InstallDate
-            interface_type = $win32_disk_drive.InterfaceType
-            last_error_code = $win32_disk_drive.LastErrorCode
-            manufacturer = $win32_disk_drive.Manufacturer
-            max_block_size = $win32_disk_drive.MaxBlockSize
-            max_media_size = $win32_disk_drive.MaxMediaSize
-            media_loaded = $win32_disk_drive.MediaLoaded
-            media_type = $win32_disk_drive.MediaType
-            min_block_size = $win32_disk_drive.MinBlockSize
-            model = $win32_disk_drive.Model
-            name = $win32_disk_drive.Name
-            needs_cleaning = $win32_disk_drive.NeedsCleaning
-            number_of_media_supported = $win32_disk_drive.NumberOfMediaSupported
-            partitions = $win32_disk_drive.Partitions
-            pnp_device_id = $win32_disk_drive.PNPDeviceID
-            power_management_capabilities = $win32_disk_drive.PowerManagementCapabilities
-            power_management_supported = $win32_disk_drive.PowerManagementSupported
-            scsi_bus = $win32_disk_drive.SCSIBus
-            scsi_logical_unit = $win32_disk_drive.SCSILogicalUnit
-            scsi_port = $win32_disk_drive.SCSIPort
-            scsi_target_id = $win32_disk_drive.SCSITargetId
-            sectors_per_track = $win32_disk_drive.SectorsPerTrack
-            serial_number = $win32_disk_drive.SerialNumber
-            signature = $win32_disk_drive.Signature
-            size = $win32_disk_drive.Size
-            status = $win32_disk_drive.status
-            status_info = $win32_disk_drive.StatusInfo
-            system_creation_class_name = $win32_disk_drive.SystemCreationClassName
-            system_name = $win32_disk_drive.SystemName
-            total_cylinders = $win32_disk_drive.TotalCylinders
-            total_heads = $win32_disk_drive.TotalHeads
-            total_sectors = $win32_disk_drive.TotalSectors
-            total_tracks = $win32_disk_drive.TotalTracks
-            tracks_per_cylinder = $win32_disk_drive.TracksPerCylinder
+        if ($win32_disk_drive) {
+            $disk_info["win32_disk_drive"] += @{
+                availability = $win32_disk_drive.Availability
+                bytes_per_sector = $win32_disk_drive.BytesPerSector
+                capabilities = $win32_disk_drive.Capabilities
+                capability_descriptions = $win32_disk_drive.CapabilityDescriptions
+                caption = $win32_disk_drive.Caption
+                compression_method = $win32_disk_drive.CompressionMethod
+                config_manager_error_code = $win32_disk_drive.ConfigManagerErrorCode
+                config_manager_user_config = $win32_disk_drive.ConfigManagerUserConfig
+                creation_class_name = $win32_disk_drive.CreationClassName
+                default_block_size = $win32_disk_drive.DefaultBlockSize
+                description = $win32_disk_drive.Description
+                device_id = $win32_disk_drive.DeviceID
+                error_cleared = $win32_disk_drive.ErrorCleared
+                error_description = $win32_disk_drive.ErrorDescription
+                error_methodology = $win32_disk_drive.ErrorMethodology
+                firmware_revision = $win32_disk_drive.FirmwareRevision
+                index = $win32_disk_drive.Index
+                install_date = $win32_disk_drive.InstallDate
+                interface_type = $win32_disk_drive.InterfaceType
+                last_error_code = $win32_disk_drive.LastErrorCode
+                manufacturer = $win32_disk_drive.Manufacturer
+                max_block_size = $win32_disk_drive.MaxBlockSize
+                max_media_size = $win32_disk_drive.MaxMediaSize
+                media_loaded = $win32_disk_drive.MediaLoaded
+                media_type = $win32_disk_drive.MediaType
+                min_block_size = $win32_disk_drive.MinBlockSize
+                model = $win32_disk_drive.Model
+                name = $win32_disk_drive.Name
+                needs_cleaning = $win32_disk_drive.NeedsCleaning
+                number_of_media_supported = $win32_disk_drive.NumberOfMediaSupported
+                partitions = $win32_disk_drive.Partitions
+                pnp_device_id = $win32_disk_drive.PNPDeviceID
+                power_management_capabilities = $win32_disk_drive.PowerManagementCapabilities
+                power_management_supported = $win32_disk_drive.PowerManagementSupported
+                scsi_bus = $win32_disk_drive.SCSIBus
+                scsi_logical_unit = $win32_disk_drive.SCSILogicalUnit
+                scsi_port = $win32_disk_drive.SCSIPort
+                scsi_target_id = $win32_disk_drive.SCSITargetId
+                sectors_per_track = $win32_disk_drive.SectorsPerTrack
+                serial_number = $win32_disk_drive.SerialNumber
+                signature = $win32_disk_drive.Signature
+                size = $win32_disk_drive.Size
+                status = $win32_disk_drive.status
+                status_info = $win32_disk_drive.StatusInfo
+                system_creation_class_name = $win32_disk_drive.SystemCreationClassName
+                system_name = $win32_disk_drive.SystemName
+                total_cylinders = $win32_disk_drive.TotalCylinders
+                total_heads = $win32_disk_drive.TotalHeads
+                total_sectors = $win32_disk_drive.TotalSectors
+                total_tracks = $win32_disk_drive.TotalTracks
+                tracks_per_cylinder = $win32_disk_drive.TracksPerCylinder
+            }
         }
     }
     $disk_info.number = $disk.Number
@@ -193,57 +210,60 @@ foreach ($disk in $disks) {
     $disk_info.unique_id = $disk.UniqueId
     $disk_info.guid = $disk.Guid
     $disk_info.path = $disk.Path
-    $parts = Get-Partition -DiskNumber $($disk.Number) -ErrorAction SilentlyContinue
-    if ($parts) {
-        $disk_info["partitions"] += @()
-        foreach ($part in $parts) {
-            $partition_info = @{
-                number = $part.PartitionNumber
-                size = $part.Size
-                type = $part.Type
-                drive_letter = $part.DriveLetter
-                transition_state = $part.TransitionState
-                offset = $part.Offset
-                hidden = $part.IsHidden
-                shadow_copy = $part.IsShadowCopy
-                guid = $part.Guid
-                access_paths = $part.AccessPaths
-            }
-            if ($disks.PartitionStyle -eq "GPT") {
-                $partition_info.gpt_type = $part.GptType
-                $partition_info.no_default_driveletter = $part.NoDefaultDriveLetter
-            }
-            elseif ($disks.PartitionStyle -eq "MBR") {
-                $partition_info.mbr_type = $part.MbrType
-                $partition_info.active = $part.IsActive
-            }
-            $vols = Get-Volume -Partition $part -ErrorAction SilentlyContinue
-            if ($vols) {
-                $partition_info["volumes"] += @()
-                foreach ($vol in $vols) {
-                    $volume_info = @{
-                        size = $vol.Size
-                        size_remaining = $vol.SizeRemaining
-                        type = $vol.FileSystem
-                        label = $vol.FileSystemLabel
-                        health_status = $vol.HealthStatus
-                        drive_type = $vol.DriveType
-                        object_id = $vol.ObjectId
-                        path = $vol.Path
-                    }
-                    if ([System.Environment]::OSVersion.Version.Major -ge 10) {
-                        $volume_info.allocation_unit_size = $vol.AllocationUnitSize
-                    }
-                    else {
-                        $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
-                        $diskQuery = "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'"
-                        $BlockSize = (Get-CimInstance -Query $diskQuery -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
-                        $volume_info.allocation_unit_size = $BlockSize
-                    }
-                    $partition_info.volumes += $volume_info
+    if ("partitions" -in $module.Params.filter -or "volumes" -in $module.Params.filter) {
+        $parts = Get-Partition -DiskNumber $($disk.Number) -ErrorAction SilentlyContinue
+        if ($parts) {
+            $disk_info["partitions"]  += @()
+            foreach ($part in $parts) {
+                $partition_info  = @{
+                    number = $part.PartitionNumber
+                    size = $part.Size
+                    type = $part.Type
+                    drive_letter = $part.DriveLetter
+                    transition_state = $part.TransitionState
+                    offset = $part.Offset
+                    hidden = $part.IsHidden
+                    shadow_copy = $part.IsShadowCopy
+                    guid = $part.Guid
+                    access_paths = $part.AccessPaths
                 }
+                if ($disks.PartitionStyle -eq "GPT") {
+                    $partition_info.gpt_type = $part.GptType
+                    $partition_info.no_default_driveletter = $part.NoDefaultDriveLetter
+                } elseif ($disks.PartitionStyle -eq "MBR") {
+                    $partition_info.mbr_type = $part.MbrType
+                    $partition_info.active = $part.IsActive
+                }
+                if ("volumes" -in $module.Params.filter) {
+                    $vols = Get-Volume -Partition $part -ErrorAction SilentlyContinue
+                    if ($vols) {
+                        $partition_info["volumes"]  += @()
+                        foreach ($vol in $vols) {
+                            $volume_info  = @{
+                                size = $vol.Size
+                                size_remaining = $vol.SizeRemaining
+                                type = $vol.FileSystem
+                                label = $vol.FileSystemLabel
+                                health_status = $vol.HealthStatus
+                                drive_type = $vol.DriveType
+                                object_id = $vol.ObjectId
+                                path = $vol.Path
+                            }
+                            if ([System.Environment]::OSVersion.Version.Major -ge 10) {
+                                $volume_info.allocation_unit_size = $vol.AllocationUnitSize
+                            } else {
+                                $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
+                                $BlockSize = (
+                                    Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue
+                                    | Select-Object BlockSize).BlockSize
+                                $volume_info.allocation_unit_size = $BlockSize
+                            }
+                            $partition_info.volumes  += $volume_info
+                        }
+                    }
+                }
+                $disk_info.partitions += $partition_info
             }
-            $disk_info.partitions += $partition_info
         }
     }
     $result.ansible_facts.ansible_disks += $disk_info

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -262,9 +262,9 @@ foreach ($disk in $disks) {
                                 $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
                                 $BlockSize = (
                                     Get-CimInstance `
-                                    -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" `
-                                    -ErrorAction SilentlyContinue `
-                                    | Select-Object BlockSize).BlockSize
+                                        -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" `
+                                        -ErrorAction SilentlyContinue `
+                                        | Select-Object BlockSize).BlockSize
                                 $volume_info.allocation_unit_size = $BlockSize
                             }
                             $partition_info.volumes += $volume_info

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -263,8 +263,7 @@ foreach ($disk in $disks) {
                                 $BlockSize = (
                                     Get-CimInstance `
                                         -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" `
-                                        -ErrorAction SilentlyContinue `
-                                        | Select-Object BlockSize).BlockSize
+                                        -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
                                 $volume_info.allocation_unit_size = $BlockSize
                             }
                             $partition_info.volumes += $volume_info

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -37,7 +37,7 @@ if (-not (Test-Admin)) {
 
 # Create a new result object
 $module.Result.changed = $false
-$module.Result.ansible_facts = @{ansible_disks = @()}
+$module.Result.ansible_facts = @{ ansible_disks = @() }
 
 # Search disks
 try {

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -257,8 +257,7 @@ foreach ($disk in $disks) {
                             } else {
                                 $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
                                 $BlockSize = (
-                                    Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" `
-                                    -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
+                                    Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
                                 $volume_info.allocation_unit_size = $BlockSize
                             }
                             $partition_info.volumes += $volume_info

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -49,11 +49,14 @@ try {
 } catch {
     Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
 }
+
 foreach ($disk in $disks) {
     $disk_info = @{}
     if ("physical_disk" -in $module.Params.filter) {
+
         $pdisk = Get-PhysicalDisk -ErrorAction SilentlyContinue | Where-Object {
             $_.DeviceId -eq $disk.Number
+
         }
         if ($pdisk) {
             $disk_info["physical_disk"] += @{
@@ -213,9 +216,9 @@ foreach ($disk in $disks) {
     if ("partitions" -in $module.Params.filter -or "volumes" -in $module.Params.filter) {
         $parts = Get-Partition -DiskNumber $($disk.Number) -ErrorAction SilentlyContinue
         if ($parts) {
-            $disk_info["partitions"]  += @()
+            $disk_info["partitions"] += @()
             foreach ($part in $parts) {
-                $partition_info  = @{
+                $partition_info = @{
                     number = $part.PartitionNumber
                     size = $part.Size
                     type = $part.Type
@@ -237,9 +240,9 @@ foreach ($disk in $disks) {
                 if ("volumes" -in $module.Params.filter) {
                     $vols = Get-Volume -Partition $part -ErrorAction SilentlyContinue
                     if ($vols) {
-                        $partition_info["volumes"]  += @()
+                        $partition_info["volumes"] += @()
                         foreach ($vol in $vols) {
-                            $volume_info  = @{
+                            $volume_info = @{
                                 size = $vol.Size
                                 size_remaining = $vol.SizeRemaining
                                 type = $vol.FileSystem
@@ -254,11 +257,11 @@ foreach ($disk in $disks) {
                             } else {
                                 $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
                                 $BlockSize = (
-                                    Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue
-                                    | Select-Object BlockSize).BlockSize
+                                    Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" `
+                                    -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
                                 $volume_info.allocation_unit_size = $BlockSize
                             }
-                            $partition_info.volumes  += $volume_info
+                            $partition_info.volumes += $volume_info
                         }
                     }
                 }

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -46,7 +46,8 @@ $result = @{
 # Search disks
 try {
     $disks = Get-Disk
-} catch {
+}
+catch {
     Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
 }
 
@@ -133,7 +134,8 @@ foreach ($disk in $disks) {
         $win32_disk_drive = Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction SilentlyContinue | Where-Object {
             if ($_.SerialNumber) {
                 $_.SerialNumber -eq $disk.SerialNumber
-            } elseif ($disk.UniqueIdFormat -eq 'Vendor Specific') {
+            }
+            elseif ($disk.UniqueIdFormat -eq 'Vendor Specific') {
                 $_.PNPDeviceID -eq $disk.UniqueId.split(':')[0]
             }
         }
@@ -233,7 +235,8 @@ foreach ($disk in $disks) {
                 if ($disks.PartitionStyle -eq "GPT") {
                     $partition_info.gpt_type = $part.GptType
                     $partition_info.no_default_driveletter = $part.NoDefaultDriveLetter
-                } elseif ($disks.PartitionStyle -eq "MBR") {
+                }
+                elseif ($disks.PartitionStyle -eq "MBR") {
                     $partition_info.mbr_type = $part.MbrType
                     $partition_info.active = $part.IsActive
                 }
@@ -254,7 +257,8 @@ foreach ($disk in $disks) {
                             }
                             if ([System.Environment]::OSVersion.Version.Major -ge 10) {
                                 $volume_info.allocation_unit_size = $vol.AllocationUnitSize
-                            } else {
+                            }
+                            else {
                                 $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
                                 $BlockSize = (
                                     Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize

--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -261,7 +261,10 @@ foreach ($disk in $disks) {
                             else {
                                 $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
                                 $BlockSize = (
-                                    Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
+                                    Get-CimInstance `
+                                    -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" `
+                                    -ErrorAction SilentlyContinue `
+                                    | Select-Object BlockSize).BlockSize
                                 $volume_info.allocation_unit_size = $BlockSize
                             }
                             $partition_info.volumes += $volume_info

--- a/plugins/modules/win_disk_facts.py
+++ b/plugins/modules/win_disk_facts.py
@@ -18,6 +18,15 @@ notes:
     U(https://msdn.microsoft.com/en-us/library/windows/desktop/hh830612.aspx)
 author:
   - Marc Tschapek (@marqelme)
+options:
+  filter:
+    description:
+      - Allows to filter returned facts by type of disk information.
+      - If volumes are selected partitions will be returned as well.
+    type: list
+    elements: str
+    choices: [ physical_disk, virtual_disk, win32_disk_drive, partitions, volumes ]
+    default: [ physical_disk, virtual_disk, win32_disk_drive, partitions, volumes ]
 '''
 
 EXAMPLES = r'''
@@ -46,6 +55,12 @@ EXAMPLES = r'''
 - name: Output second disk serial number
   debug:
     var: ansible_facts.disks[1].serial_number
+
+- name: get disk physical_disk and partition facts on the target
+  win_disk_facts:
+    filter:
+      - physical_disk
+      - partitions
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_disk_facts.py
+++ b/plugins/modules/win_disk_facts.py
@@ -27,6 +27,7 @@ options:
     elements: str
     choices: [ physical_disk, virtual_disk, win32_disk_drive, partitions, volumes ]
     default: [ physical_disk, virtual_disk, win32_disk_drive, partitions, volumes ]
+    version_added: 1.9.0
 '''
 
 EXAMPLES = r'''

--- a/tests/integration/targets/win_disk_facts/tasks/tests.yml
+++ b/tests/integration/targets/win_disk_facts/tasks/tests.yml
@@ -16,3 +16,74 @@
     - disks_found.ansible_facts.ansible_disks[0].physical_disk.size is defined
     - disks_found.ansible_facts.ansible_disks[0].physical_disk.operational_status is defined
     - disks_found.ansible_facts.ansible_disks[0].win32_disk_drive is defined
+    - disks_found.ansible_facts.ansible_disks[0].partitions is defined
+    - disks_found.ansible_facts.ansible_disks[0].partitions[0].volumes is defined
+
+- name: get disk partition facts on the target
+  win_disk_facts:
+    filter:
+      - partitions
+  register: disks_partitions_found
+
+- name: assert partitions disk facts
+  assert:
+    that:
+    - disks_partitions_found.changed == false
+    - disks_partitions_found.ansible_facts.ansible_disks[0].partitions is defined
+
+- name: get disk volume and partition facts on the target
+  win_disk_facts:
+    filter:
+      - volumes
+  register: disks_volumes_found
+
+- name: assert volume and partition disk facts
+  assert:
+    that:
+    - disks_volumes_found.changed == false
+    - disks_volumes_found.ansible_facts.ansible_disks[0].partitions is defined
+    - disks_volumes_found.ansible_facts.ansible_disks[0].partitions[0].volumes is defined
+
+
+- name: get disk physical_disk facts on the target
+  win_disk_facts:
+    filter:
+      - physical_disk
+  register: physical_disk_found
+
+- name: assert physical_disk disk facts
+  assert:
+    that:
+    - physical_disk_found.changed == false
+    - physical_disk_found.ansible_facts.ansible_disks[0].physical_disk is defined
+
+- name: get disk virtual_disk facts on the target
+  win_disk_facts:
+    filter:
+      - virtual_disk
+  register: virtual_disk_found
+
+- name: check if virtual_disk should be found
+  ansible.windows.win_shell: |
+    if (Get-VirtualDisk){$true}else{$false}
+  register: virtual_available
+  changed_when: false
+
+- name: assert virtual_disk disk facts
+  assert:
+    that:
+    - virtual_disk_found.changed == false
+    - virtual_disk_found.ansible_facts.ansible_disks[0].virtual_disk is defined
+  when: virtual_available.stdout == "True"
+
+- name: get disk win32_disk_drive facts on the target
+  win_disk_facts:
+    filter:
+      - win32_disk_drive
+  register: win32_disk_drive_found
+
+- name: assert win32_disk_drive disk facts
+  assert:
+    that:
+    - win32_disk_drive_found.changed == false
+    - win32_disk_drive_found.ansible_facts.ansible_disks[0].win32_disk_drive is defined


### PR DESCRIPTION
##### SUMMARY

This allows for selecting 1 or more filter option from the following choices
``` physical_disk, virtual_disk, win32_disk_drive, partitions, volumes ```

Filter is option and by default selects all choices which gives same behavior as original module.

fixes #33 



##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_disk_facts

##### ADDITIONAL INFORMATION
Adds filter option to win_disk_facts

```
- name: get disk physical_disk facts on the target
  community.windows.win_disk_facts:
    filter:
      - partitions

```
before change output
```
{"ansible_facts": {"ansible_disks": [{"bootable": true, "bus_type": "SAS", "clustered": false, "firmware_version": "1.0 ", "friendly_name": "VMware, VMware Virtual S", "guid": null, "location": "SCSI0", "manufacturer": "VMware, ", "model": "VMware Virtual S", "number": 0, "operational_status": "Online", "partition_count": 1, "partition_style": "MBR", "partitions": [{"access_paths": ["C:\\", "\\\\?\\Volume{7aa64acc-0000-0000-0000-100000000000}\\"], "active": true, "drive_letter": "C", "guid": null, "hidden": false, "mbr_type": 7, "number": 1, "offset": 1048576, "shadow_copy": false, "size": 107372085248, "transition_state": 1, "type": "IFS", "volumes": [{"allocation_unit_size": 4096, "drive_type": "Fixed", "health_status": "Healthy", "label": "OS", "object_id": "{1}\\\\THDTHE-7HGCMSJE\\root/Microsoft/Windows/Storage/Providers_v2\\WSP_Volume.ObjectId=\"{944bfc4d-16a7-11ec-aeb2-806e6f6e6963}:VO:\\\\?\\Volume{7aa64acc-0000-0000-0000-100000000000}\\\"", "path": "\\\\?\\Volume{7aa64acc-0000-0000-0000-100000000000}\\", "size": 107372081152, "size_remaining": 94551818240, "type": "NTFS"}]}], "path": "\\\\?\\scsi#disk&ven_vmware_&prod_vmware_virtual_s#000000#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}", "physical_disk": {"allocated_size": 107374182400, "bus_type": "SAS", "can_pool": false, "cannot_pool_reason": "Insufficient Capacity", "device_id": "0", "firmware_version": "1.0", "friendly_name": "VMware, VMware Virtual S", "health_status": "Healthy", "indication_enabled": null, "manufacturer": "VMware,", "media_type": "SSD", "model": "VMware Virtual S", "object_id": "{1}\\\\THDTHE-7HGCMSJE\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_PhysicalDisk.ObjectId=\"{944bfc4d-16a7-11ec-aeb2-806e6f6e6963}:PD:{25d8018f-59b6-c8c8-a34a-315de3c3865e}\"", "operational_status": "OK", "partial": true, "physical_location": "SCSI0", "serial_number": "6000c29ebffbb2bb9b1a16a3643a7932", "size": 107374182400, "spindle_speed": 0, "supported_usages": {"Count": 5, "value": ["Auto-Select", "Manual-Select", "Hot Spare", "Retired", "Journal"]}, "unique_id": "6000C29EBFFBB2BB9B1A16A3643A7932", "usage_type": "Auto-Select"}, "read_only": false, "sector_size": 512, "serial_number": "6000c29ebffbb2bb9b1a16a3643a7932", "size": 107374182400, "system_disk": true, "unique_id": "6000C29EBFFBB2BB9B1A16A3643A7932", "win32_disk_drive": {"availability": null, "bytes_per_sector": 512, "capabilities": [3, 4], "capability_descriptions": ["Random Access", "Supports Writing"], "caption": "VMware, VMware Virtual S SCSI Disk Device", "compression_method": null, "config_manager_error_code": 0, "config_manager_user_config": false, "creation_class_name": "Win32_DiskDrive", "default_block_size": null, "description": "Disk drive", "device_id": "\\\\.\\PHYSICALDRIVE0", "error_cleared": null, "error_description": null, "error_methodology": null, "firmware_revision": "1.0 ", "index": 0, "install_date": null, "interface_type": "SCSI", "last_error_code": null, "manufacturer": "(Standard disk drives)", "max_block_size": null, "max_media_size": null, "media_loaded": true, "media_type": "Fixed hard disk media", "min_block_size": null, "model": "VMware, VMware Virtual S SCSI Disk Device", "name": "\\\\.\\PHYSICALDRIVE0", "needs_cleaning": null, "number_of_media_supported": null, "partitions": 1, "pnp_device_id": "SCSI\\DISK&VEN_VMWARE_&PROD_VMWARE_VIRTUAL_S\\000000", "power_management_capabilities": null, "power_management_supported": null, "scsi_bus": 0, "scsi_logical_unit": 0, "scsi_port": 2, "scsi_target_id": 0, "sectors_per_track": 63, "serial_number": "6000c29ebffbb2bb9b1a16a3643a7932", "signature": 2057718476, "size": 107372805120, "status": "OK", "status_info": null, "system_creation_class_name": "Win32_ComputerSystem", "system_name": "THDTHE-7HGCMSJE", "total_cylinders": 13054, "total_heads": 255, "total_sectors": 209712510, "total_tracks": 3328770, "tracks_per_cylinder": 255}}]}, "changed": false}
```

after change output
```
{"ansible_facts": {"ansible_disks": [{"bootable": true, "bus_type": "SAS", "clustered": false, "firmware_version": "1.0 ", "friendly_name": "VMware, VMware Virtual S", "guid": null, "location": "SCSI0", "manufacturer": "VMware, ", "model": "VMware Virtual S", "number": 0, "operational_status": "Online", "partition_count": 1, "partition_style": "MBR", "partitions": [{"access_paths": ["C:\\", "\\\\?\\Volume{7aa64acc-0000-0000-0000-100000000000}\\"], "active": true, "drive_letter": "C", "guid": null, "hidden": false, "mbr_type": 7, "number": 1, "offset": 1048576, "shadow_copy": false, "size": 107372085248, "transition_state": 1, "type": "IFS"}], "path": "\\\\?\\scsi#disk&ven_vmware_&prod_vmware_virtual_s#000000#{53f56307-b6bf-11d0-94f2-00a0c91efb8b}", "read_only": false, "sector_size": 512, "serial_number": "6000c29ebffbb2bb9b1a16a3643a7932", "size": 107374182400, "system_disk": true, "unique_id": "6000C29EBFFBB2BB9B1A16A3643A7932"}]}, "changed": false}
```
