### PR TITLE
Added vscode configuration and simplify unit test running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,6 +391,3 @@ changelogs/.plugin-cache.yaml
 
 # ansible-test ignores
 tests/integration/inventory*
-
-# VSCode
-.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-vscode.powershell",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+    "python.testing.pytestArgs": [
+        "tests/unit",
+        "-vv"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.analysis.extraPaths": [
+        "${workspaceFolder}/../../../",
+    ],
+
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "powershell.codeFormatting.alignPropertyValuePairs": false,
+    "powershell.codeFormatting.autoCorrectAliases": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": true,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.newLineAfterOpenBrace": true,
+    "powershell.codeFormatting.openBraceOnSameLine": true,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceBetweenParameters": true,
+    "powershell.codeFormatting.whitespaceInsideBrace": true,
+    "powershell.scriptAnalysis.enable": true,
+    "[powershell]": {
+        "editor.formatOnSave": true,
+    },
+}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,43 @@
+"""Enable unit testing of Ansible collections. PYTEST_DONT_REWRITE"""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import os.path
+
+from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
+
+
+ANSIBLE_COLLECTIONS_PATH = os.path.abspath(os.path.join(__file__, '..', '..', '..', '..', '..'))
+
+
+# this monkeypatch to _pytest.pathlib.resolve_package_path fixes PEP420 resolution for collections in pytest >= 6.0.0
+def collection_resolve_package_path(path):
+    """Configure the Python package path so that pytest can find our collections."""
+    for parent in path.parents:
+        if str(parent) == ANSIBLE_COLLECTIONS_PATH:
+            return parent
+
+    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
+
+
+def pytest_configure():
+    """Configure this pytest plugin."""
+
+    try:
+        if pytest_configure.executed:
+            return
+    except AttributeError:
+        pytest_configure.executed = True
+
+    # allow unit tests to import code from collections
+
+    # noinspection PyProtectedMember
+    _AnsibleCollectionFinder(paths=[os.path.dirname(ANSIBLE_COLLECTIONS_PATH)])._install()  # pylint: disable=protected-access
+
+    # noinspection PyProtectedMember
+    from _pytest import pathlib as pytest_pathlib
+    pytest_pathlib.resolve_package_path = collection_resolve_package_path
+
+
+pytest_configure()


### PR DESCRIPTION
##### SUMMARY
Now that Ansible from a source checkout can be installed with `pip install -e .` we can simplify the logic in the collection loader plugin used in vscode.

Also adds PowerShell auto formatting to help make it easier to fix sanity problems.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test unit