### PR TITLE
win_iis_virtualdirectory: Amending Test-Path Format

### DIFF
--- a/plugins/modules/win_iis_virtualdirectory.ps1
+++ b/plugins/modules/win_iis_virtualdirectory.ps1
@@ -47,7 +47,7 @@ try {
         If (-not $physical_path) {
             Fail-Json -obj $result -message "missing required arguments: physical_path"
         }
-        If (-not (Test-Path -LiteralPath $physical_path)) {
+        If (![System.IO.File]::Exists($physical_path)) {
             Fail-Json -obj $result -message "specified folder must already exist: physical_path"
         }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The old version of the Test-Path command didn't work (exited with `Access is denied` error) with UNC paths when run through Ansible even though the same Test-Path function ran find locally on the target. This method works with these paths.

Fixes #342 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_iis_virtualdirectory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
