### PR TITLE
Default $identity to $sam_account_name if it's set, $name if it isn't

### DIFF
--- a/changelogs/fragments/345_win_domain_user.yml
+++ b/changelogs/fragments/345_win_domain_user.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - win_domain_user - The AD user's existing identity is searched using their sAMAccountName name preferentially and falls back to the provided name property instead - https://github.com/ansible-collections/community.windows/issues/344

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -87,7 +87,6 @@ $domain_server = Get-AnsibleParam -obj $params -name "domain_server" -type "str"
 
 # User account parameters
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
-$identity = Get-AnsibleParam -obj $params -name "identity" -type "str" -default $name
 $description = Get-AnsibleParam -obj $params -name "description" -type "str"
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $password_expired = Get-AnsibleParam -obj $params -name "password_expired" -type "bool"
@@ -99,6 +98,9 @@ $enabled = Get-AnsibleParam -obj $params -name "enabled" -type "bool" -default $
 $path = Get-AnsibleParam -obj $params -name "path" -type "str"
 $upn = Get-AnsibleParam -obj $params -name "upn" -type "str"
 $sam_account_name = Get-AnsibleParam -obj $params -name "sam_account_name" -type "str"
+$identity = Get-AnsibleParam -obj $params -name "identity" -type "str" -default $sam_account_name
+
+if ($null -eq $identity) { $identity = $name }
 
 # User informational parameters
 $user_info = @{


### PR DESCRIPTION
##### SUMMARY
Fixes an issue where the user's prior existence is checked based on the `name` parameter which is used as the display name of the user. 

Currently, if both `sam_account_name` and `name` parameters are provided but no `identity` parameter is provided during runtime, the user will be created but later will cause errors since the `New-ADUser` cmdlet runs when the user already exists, causing an `ADException`. This is because the `Get-ADUser` cmdlet is run with the `identity` parameter set as _it's_ `-Identity` parameter. `identity` defaults to the `name` parameter which would equate to the user's display name. 

The current `New-ADUser` cmdlet creates users with the `Name` of the user as the `SamAccountName` and `Name` Property of the user. If you pass a separate `SamAccountName` property, the `Name` parameter is instead only set to the given `Name` parameter.

Here's an example showing how the PowerShell process works currently:

```
PS C:\Windows\system32> New-ADUser "Test User 2"
PS C:\Windows\system32> Get-ADUSer "Test User 2"


DistinguishedName : CN=Test User 2,CN=Users,DC=domain,DC=com
Enabled           : False
GivenName         :
Name              : Test User 2
ObjectClass       : user
ObjectGUID        : e4f36d2a-4d10-47d2-8bae-a7b6bf5eab97
SamAccountName    : Test User 2
SID               : S-1-5-21-370554974-2125117728-3394474177-1186
Surname           :
UserPrincipalName :



PS C:\Windows\system32> New-ADUser "Test User 3" -SamAccountName "test.user.3"
PS C:\Windows\system32> Get-ADUser "Test User 3"
Get-ADUser : Cannot find an object with identity: 'Test User 3' under: 'DC=domain,DC=com'.
At line:1 char:1
+ Get-ADUser "Test User 3"
+ ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Test User 3:ADUser) [Get-ADUser], ADIdentityNotFoundException
    + FullyQualifiedErrorId : ActiveDirectoryCmdlet:Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException,M
   icrosoft.ActiveDirectory.Management.Commands.GetADUser

PS C:\Windows\system32> Get-ADUser "test.user.3"


DistinguishedName : CN=Test User 3,CN=Users,DC=domain,DC=com
Enabled           : False
GivenName         :
Name              : Test User 3
ObjectClass       : user
ObjectGUID        : 6107d492-c4ee-46a8-ae20-905948904991
SamAccountName    : test.user.3
SID               : S-1-5-21-370554974-2125117728-3394474177-1187
Surname           :
UserPrincipalName :
```

The fix sets the `identity` module parameter to the `sam_account_name` provided preferentially, otherwise the `name` is used. This should mean that users updating the collection will be unaffected since if they were using just the name previously, the handling of the rest of the module is exactly the same.

Fixes #344 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.windows/win_domain_user