### PR TITLE
win_iis_virtualdirectory: Add credential support and integration test

### DIFF
--- a/changelogs/fragments/347_win_iis_virtualdirectory.yml
+++ b/changelogs/fragments/347_win_iis_virtualdirectory.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - win_iis_virtualdirectory - Added the ``connect_as``, ``username``, and ``password`` options to control the virtual directory authentication - https://github.com/ansible-collections/community.windows/issues/346
+
+bugfixes:
+  - win_iis_virtualdirectory - Fixed an issue where virtual directory information could not be obtained correctly when the parameter ``application`` was set

--- a/plugins/modules/win_iis_virtualdirectory.py
+++ b/plugins/modules/win_iis_virtualdirectory.py
@@ -37,6 +37,23 @@ options:
       - The physical path to the folder in which the new virtual directory is created.
       - The specified folder must already exist.
     type: str
+  connect_as:
+    description:
+    - The type of authentication to use for the virtual directory. Either C(pass_through) or C(specific_user)
+    - If C(pass_through), IIS will use the identity of the user or application pool identity to access the physical path.
+    - If C(specific_user), IIS will use the credentials provided in I(username) and I(password) to access the physical path.
+    type: str
+    choices: [pass_through, specific_user]
+  username:
+    description:
+    - Specifies the user name of an account that can access configuration files and content for the virtual directory.
+    - Required when I(connect_as) is set to C(specific_user).
+    type: str
+  password:
+    description:
+    - The password associated with I(username).
+    - Required when I(connect_as) is set to C(specific_user).
+    type: str
 seealso:
 - module: community.windows.win_iis_webapplication
 - module: community.windows.win_iis_webapppool

--- a/plugins/modules/win_iis_virtualdirectory.py
+++ b/plugins/modules/win_iis_virtualdirectory.py
@@ -44,16 +44,19 @@ options:
     - If C(specific_user), IIS will use the credentials provided in I(username) and I(password) to access the physical path.
     type: str
     choices: [pass_through, specific_user]
+    version_added: 1.9.0
   username:
     description:
     - Specifies the user name of an account that can access configuration files and content for the virtual directory.
     - Required when I(connect_as) is set to C(specific_user).
     type: str
+    version_added: 1.9.0
   password:
     description:
     - The password associated with I(username).
     - Required when I(connect_as) is set to C(specific_user).
     type: str
+    version_added: 1.9.0
 seealso:
 - module: community.windows.win_iis_webapplication
 - module: community.windows.win_iis_webapppool

--- a/tests/integration/targets/win_iis_virtualdirectory/aliases
+++ b/tests/integration/targets/win_iis_virtualdirectory/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group4

--- a/tests/integration/targets/win_iis_virtualdirectory/defaults/main.yml
+++ b/tests/integration/targets/win_iis_virtualdirectory/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+test_vdir_name: testvdir
+test_physical_path: "{{ remote_tmp_dir }}"
+
+test_site_name: 'Test Site'
+test_app_name: 'testapp'
+
+test_user: testuser
+test_password: testpass

--- a/tests/integration/targets/win_iis_virtualdirectory/meta/main.yml
+++ b/tests/integration/targets/win_iis_virtualdirectory/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- setup_remote_tmp_dir

--- a/tests/integration/targets/win_iis_virtualdirectory/tasks/main.yml
+++ b/tests/integration/targets/win_iis_virtualdirectory/tasks/main.yml
@@ -1,0 +1,90 @@
+---
+- name: check if we can run the tests
+  ansible.windows.win_shell: |
+    $osVersion = [Version](Get-Item -LiteralPath "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
+    $osVersion -ge [Version]"6.2"
+  register: run_test
+  changed_when: False
+
+- name: Run on Server 2012 and higher
+  when: run_test.stdout | trim | bool
+  block:
+  - name: ensure IIS features are installed
+    ansible.windows.win_feature:
+      name: Web-Server
+      state: present
+      include_management_tools: True
+    register: feature_install
+
+  - name: reboot after feature install
+    ansible.windows.win_reboot:
+    when: feature_install.reboot_required
+
+    # may be possible that copy corrupts the file
+  - name: Get iis configuration checksum
+    ansible.windows.win_stat:
+      path: C:\Windows\System32\inetsrv\config\applicationHost.config
+      checksum_algorithm: sha1
+    register: stat_result
+
+  - name: take a copy of the original iis configuration
+    ansible.windows.win_copy:
+      src: C:\Windows\System32\inetsrv\config\applicationHost.config
+      dest: '{{ remote_tmp_dir }}\applicationHost.config'
+      remote_src: yes
+    register: copy_result
+
+  - assert:
+      that:
+        - "stat_result.stat.checksum == copy_result.checksum"
+
+  # Tests
+  - name: run tests on hosts that support it
+    include_tasks: tests.yml
+
+  always:
+  # Cleanup
+  - name: remove test virtual directory
+    win_iis_virtualdirectory:
+      state: absent
+      site: "{{ test_site_name }}"
+      name: "{{ test_vdir_name }}"
+
+  - name: remove test application
+    win_iis_webapplication:
+      name: "{{ test_app_name }}"
+      site: "{{ test_site_name }}"
+      state: absent
+
+  - name: remove test site
+    win_iis_website:
+      name: "{{ test_site_name }}"
+      state: absent
+
+  - name: delete test application temporary directory
+    win_file:
+      path: "{{ test_app_tmp_dir.path }}"
+      state: absent
+
+  - name: restore iis configuration
+    ansible.windows.win_copy:
+      src: '{{ remote_tmp_dir }}\applicationHost.config'
+      dest: C:\Windows\System32\inetsrv\config\applicationHost.config
+      remote_src: yes
+    register: copy_result
+
+  - assert:
+      that:
+        - "stat_result.stat.checksum == copy_result.checksum"
+
+  - name: remove IIS feature if it was installed
+    ansible.windows.win_feature:
+      name: Web-Server
+      state: absent
+      include_management_tools: True
+    when: feature_install is changed
+    register: feature_uninstall
+
+  - name: reboot after removing IIS features
+    ansible.windows.win_reboot:
+    when: feature_uninstall.reboot_required | default(False)

--- a/tests/integration/targets/win_iis_virtualdirectory/tasks/tests.yml
+++ b/tests/integration/targets/win_iis_virtualdirectory/tasks/tests.yml
@@ -1,0 +1,111 @@
+---
+- name: test site exists, but stopped in case of duplicate web binding
+  win_iis_website:
+    name: "{{ test_site_name }}"
+    state: stopped
+    physical_path: 'C:\inetpub\wwwroot'
+
+- name: test virtual directory is absent (baseline)
+  win_iis_virtualdirectory:
+    state: absent
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+
+- name: create test virtual directory
+  win_iis_virtualdirectory:
+    state: present
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+    physical_path: "{{ test_physical_path }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == true'
+    - 'result.directory.PhysicalPath == test_physical_path'
+
+- name: create test virtual directory (idempotent)
+  win_iis_virtualdirectory:
+    state: present
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+    physical_path: "{{ test_physical_path }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == false'
+    - 'result.directory.PhysicalPath == test_physical_path'
+
+- name: set test virtual directory credentials
+  win_iis_virtualdirectory:
+    state: present
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+    connect_as: specific_user
+    username: "{{ test_user }}"
+    password: "{{ test_password }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == true'
+    - 'result.directory.PhysicalPath == test_physical_path'
+
+- name: set test virtual directory credentials (idempotent)
+  win_iis_virtualdirectory:
+    state: present
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+    connect_as: specific_user
+    username: "{{ test_user }}"
+    password: "{{ test_password }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == false'
+    - 'result.directory.PhysicalPath == test_physical_path'
+
+- name: create test application temporary directory
+  ansible.windows.win_tempfile:
+    suffix: ".{{ test_app_name }}"
+    state: directory
+  register: test_app_tmp_dir
+
+- name: create new test application
+  win_iis_webapplication:
+    name: "{{ test_app_name }}"
+    site: "{{ test_site_name }}"
+    physical_path: "{{ test_app_tmp_dir.path }}"
+    state: present
+
+- name: create virtual directory and use pass through authentication
+  win_iis_virtualdirectory:
+    state: present
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+    physical_path: "{{ test_physical_path }}"
+    connect_as: pass_through
+    application: "{{ test_app_name }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == true'
+    - 'result.directory.PhysicalPath == test_physical_path'
+
+- name: create virtual directory and use pass through authentication (idempotent)
+  win_iis_virtualdirectory:
+    state: present
+    site: "{{ test_site_name }}"
+    name: "{{ test_vdir_name }}"
+    physical_path: "{{ test_physical_path }}"
+    connect_as: pass_through
+    application: "{{ test_app_name }}"
+  register: result
+
+- assert:
+    that:
+    - 'result.changed == false'
+    - 'result.directory.PhysicalPath == test_physical_path'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #346 

- Added parameters ('connect_as', 'username', 'password') so that credentials can be set when creating a virtual directory.
- Added integration tests.
- Fixed the method of getting virtual directory information when the parameter 'application' is set.

I found a bug by adding integration tests.
I've included the bug fix in this PR.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

<!--- Write the short name of the module, plugin, task or feature below -->
win_iis_virtualdirectory

##### ADDITIONAL INFORMATION

n/a