### PR TITLE
[Work inprogress]Changes to be compatible with Pester v5 as well.

### DIFF
--- a/plugins/modules/win_pester.ps1
+++ b/plugins/modules/win_pester.ps1
@@ -75,7 +75,7 @@ $Configuration = @{
     Output = @{}
     TestResult = @{}
     Filter = @{}
- }
+}
 If ($module.Result.pester_version -ge "4.0.0") {
     $Parameters.show = "none"
 }

--- a/plugins/modules/win_pester.ps1
+++ b/plugins/modules/win_pester.ps1
@@ -70,7 +70,7 @@ If ((-not (Get-Module -Name $Pester -ErrorAction SilentlyContinue | Where-Object
 #Prepare Invoke-Pester parameters depending of the Pester's version.
 #Invoke-Pester output deactivation behave differently depending on the Pester's version
 $Parameters = $Configuration = @{ }
-elseIf ($module.Result.pester_version -ge "4.0.0") {
+If ($module.Result.pester_version -ge "4.0.0") {
     $Parameters.show = "none"
 }
 else {

--- a/plugins/modules/win_pester.ps1
+++ b/plugins/modules/win_pester.ps1
@@ -69,7 +69,10 @@ If ((-not (Get-Module -Name $Pester -ErrorAction SilentlyContinue | Where-Object
 
 #Prepare Invoke-Pester parameters depending of the Pester's version.
 #Invoke-Pester output deactivation behave differently depending on the Pester's version
-If ($module.Result.pester_version -ge "4.0.0") {
+if($module.Result.pester_version -ge "5.0.0"){
+    # TODO: pester conffiguration object
+}
+elseIf ($module.Result.pester_version -ge "4.0.0") {
     $Parameters = @{
         "show" = "none"
         "PassThru" = $True

--- a/plugins/modules/win_pester.ps1
+++ b/plugins/modules/win_pester.ps1
@@ -74,7 +74,7 @@ elseIf ($module.Result.pester_version -ge "4.0.0") {
     $Parameters.show = "none"
 }
 else {
-    $Parameters.quiet = $True 
+    $Parameters.quiet = $True
 }
 
 $Configuration.Run.PassThru = $Parameters.PassThru = $True
@@ -113,16 +113,15 @@ else {
 }
 
 $InvokeParams = $Parameters
-if($module.Result.pester_version -ge "5.0.0"){
+if ($module.Result.pester_version -ge "5.0.0") {
     #Use pester Advanced conffiguration object as legacy parameters will be deprecated/removed soon.
     $Configuration.Run.Path = $Path
-    $InvokeParams = @{ Configuration = New-PesterConfiguration $Configuration }    
+    $InvokeParams = @{ Configuration = New-PesterConfiguration $Configuration }
 }
 
-if(-not $module.CheckMode){
+if (-not $module.CheckMode) {
     $module.Result.output = Invoke-Pester @InvokeParams
     $module.Result.changed = $true
 }
-
 
 $module.ExitJson()

--- a/plugins/modules/win_pester.ps1
+++ b/plugins/modules/win_pester.ps1
@@ -69,7 +69,13 @@ If ((-not (Get-Module -Name $Pester -ErrorAction SilentlyContinue | Where-Object
 
 #Prepare Invoke-Pester parameters depending of the Pester's version.
 #Invoke-Pester output deactivation behave differently depending on the Pester's version
-$Parameters = $Configuration = @{ }
+$Parameters = @{ }
+$Configuration = @{
+    Run = @{}
+    Output = @{}
+    TestResult = @{}
+    Filter = @{}
+ }
 If ($module.Result.pester_version -ge "4.0.0") {
     $Parameters.show = "none"
 }

--- a/plugins/modules/win_pester.ps1
+++ b/plugins/modules/win_pester.ps1
@@ -69,16 +69,12 @@ If ((-not (Get-Module -Name $Pester -ErrorAction SilentlyContinue | Where-Object
 
 #Prepare Invoke-Pester parameters depending of the Pester's version.
 #Invoke-Pester output deactivation behave differently depending on the Pester's version
-$Configuration = @{ }
+$Parameters = $Configuration = @{ }
 elseIf ($module.Result.pester_version -ge "4.0.0") {
-    $Parameters = @{
-        "show" = "none"
-    }
+    $Parameters.show = "none"
 }
 else {
-    $Parameters = @{
-        "quiet" = $True
-    }
+    $Parameters.quiet = $True 
 }
 
 $Configuration.Run.PassThru = $Parameters.PassThru = $True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Pester version 5+ has lots of changes w.r.t parameter deprecation. This PR has changes which will adopt new pester advanced configuration instead of long individual parameters. It also helps in getting rid of using deprecated parameters when version 5 or greater is used.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.windows.win_pester

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
