### PR TITLE
RST edit notification

### DIFF
--- a/.github/workflows/rst-pr.yml
+++ b/.github/workflows/rst-pr.yml
@@ -1,0 +1,35 @@
+name: RST PR
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docs/*.rst"
+
+jobs:
+  notify:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Look for an existing comment
+      id: fc
+      uses: peter-evans/find-comment@v1
+      with:
+        issue-number: ${{ github.event.number }}
+        body-includes: '### Generated Docs Modified'
+        comment-author: 'github-actions[bot]'
+
+    - name: Notify the author
+      id: comment
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.number }}
+        edit-mode: replace
+        body: |
+          ### Generated Docs Modified
+
+          This PR with commit ${{ github.event.pull_request.head.sha }} is directly editing an RST file.
+          These files are auto-generated and will be overwritten on release.
+
+          To update documentation, please edit the appropriate `.py` file(s) used to generate the documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Generated Documentation
+The `docs/` directory contains **automatically generated** documentation from the plugins and modules in this collection.
+
+**Please do not submit pull requests to edit this documentation directly.** Instead, open a pull request to the `.py` file that contains the content these files are generated from.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After the WWG meeting, got inspired and whipped up this workflow that should notify PR authors that they modified the RST files directly and should edit the `.py` files instead.

Because this uses `pull_request_target`, it will need to be merged in `main` before it can be "tested" with a dummy PR.

This also doesn't remove the comment if the edits are removed; that would need a separate but similar workflow with the `paths:` inverted I think, or maybe some conditional stuff.

Also threw in a README in that docs dir, in case that deters someone from submitting the wrong PR in the first place.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
github workflows

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The RST files in `docs/` are auto-generated but people try to put up PRs for them sometimes to update the documentation.
