### PR TITLE
Fix win_scoop bootstrapping

### DIFF
--- a/changelogs/fragments/win_scoop-install.yml
+++ b/changelogs/fragments/win_scoop-install.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_scoop - Fix bootstrapping process to properly work when running as admin


### PR DESCRIPTION
##### SUMMARY
The win_scoop module tries to check if the bootstrapping process worked
based on the return value but this will not work due to how the scoop
script is written. Instead it will use the presence of the scoop.ps1
script as an indicator of whether it worked or not and return the raw
output back on a failure for better debugging.

This exposed the other issue this commit fixes where the installer exits
early if running as admin but without the -RunAsAdmin switch. I'm not
sure how it worked in the past but this fixes that problem allowing CI
to run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scoop