### PR TITLE
add new stable branch and fix up 2.14 santiy ignores

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,19 @@ stages:
               test: sanity
             - name: Units
               test: units
+  - stage: Ansible_2_13
+    displayName: Ansible 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: '{0}'
+          testFormat: '2.13/{0}'
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_12
     displayName: Ansible 2.12
     dependsOn: []

--- a/changelogs/fragments/win_rds-sid.yml
+++ b/changelogs/fragments/win_rds-sid.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_rds_cap - Fix SID lookup with any account ending with the ``@builtin`` UPN suffix
+- win_rds_rap - Fix SID lookup with any account ending with the ``@builtin`` UPN suffix

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,15 @@
+plugins/modules/win_audit_rule.ps1 pslint:PSCustomUseLiteralPath
+plugins/modules/win_rabbitmq_plugin.ps1 pslint:PSAvoidUsingInvokeExpression
+plugins/modules/win_region.ps1 pslint:PSAvoidUsingEmptyCatchBlock # Keep
+plugins/modules/win_regmerge.ps1 pslint:PSCustomUseLiteralPath
+plugins/modules/win_robocopy.ps1 pslint:PSCustomUseLiteralPath
+tests/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 pslint:PSCustomUseLiteralPath
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings
+tests/integration/targets/win_psmodule/files/module/template.psd1 pslint!skip
+tests/integration/targets/win_psmodule/files/module/template.psm1 pslint!skip
+tests/integration/targets/win_psmodule/files/setup_modules.ps1 pslint:PSCustomUseLiteralPath
+tests/integration/targets/win_regmerge/templates/win_line_ending.j2 line-endings
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
Ansible has just bumped versions in the devel branch to 2.14 which requires a new sanity ignore file. This adds that file and ensures we still test with the newly created stable-2.13. Also fixes a bug in the RDS modules now that the controller provided util does SID lookups slightly differently when encountering a UPN formatted name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows