### PR TITLE
win_scoop_bucket - handle output better

### DIFF
--- a/changelogs/fragments/win_scoop_bucket-error.yml
+++ b/changelogs/fragments/win_scoop_bucket-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_scoop_bucket - Fix handling of output and errors from each scoop command

--- a/plugins/modules/win_scoop_bucket.py
+++ b/plugins/modules/win_scoop_bucket.py
@@ -58,3 +58,16 @@ EXAMPLES = r'''
     name: my-bucket
     repo: https://github.com/example/my-bucket
 '''
+
+RETURN = r'''
+rc:
+    description: The result code of the scoop action
+    returned: always
+    type: int
+    sample: 0
+stdout:
+    description: The raw output from the scoop action
+    returned: on failure or when verbosity is greater than 1
+    type: str
+    sample: The test bucket was added successfully.
+'''


### PR DESCRIPTION
##### SUMMARY
Instead of calling scoop through a new process and trying to read the raw output as a string, call scoop in process and deal with the objects it outputs back natively. Also documents the return values that could be set from before.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scoop_bucket