### PR TITLE
win_domain_user now has the option to ignore non-existent groups

### DIFF
--- a/changelogs/fragments/win_domain_user-groups-missing.yml
+++ b/changelogs/fragments/win_domain_user-groups-missing.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_domain_user - Added the ``groups_missing_behaviour`` option that controls the behaviour when a group specified does not exist - https://github.com/ansible-collections/community.windows/pull/375

--- a/docs/community.windows.win_domain_user_module.rst
+++ b/docs/community.windows.win_domain_user_module.rst
@@ -270,6 +270,26 @@ Parameters
                 </td>
             </tr>
             <tr>
+            <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>groups_ignore_nonexistent</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                    <li>no</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If <code>yes</code>, a warning message will occur if a group assignment is attempted on a group that does not exist.</div>
+                        <div>If <code>no</code>, the module will produce a fail condition if a group assignment is attempted on a group that does not exist.</div>
+                </td>
+            </tr>
+            <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>identity</b>

--- a/docs/community.windows.win_domain_user_module.rst
+++ b/docs/community.windows.win_domain_user_module.rst
@@ -275,7 +275,7 @@ Parameters
                     <b>groups_ignore_nonexistent</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">boolean</span>
                     </div>
                 </td>
                 <td>

--- a/docs/community.windows.win_domain_user_module.rst
+++ b/docs/community.windows.win_domain_user_module.rst
@@ -270,26 +270,6 @@ Parameters
                 </td>
             </tr>
             <tr>
-            <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>groups_ignore_nonexistent</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">boolean</span>
-                    </div>
-                </td>
-                <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
-                                    <li>no</li>
-                        </ul>
-                </td>
-                <td>
-                        <div>If <code>yes</code>, a warning message will occur if a group assignment is attempted on a group that does not exist.</div>
-                        <div>If <code>no</code>, the module will produce a fail condition if a group assignment is attempted on a group that does not exist.</div>
-                </td>
-            </tr>
-            <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>identity</b>

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -465,7 +465,7 @@ If ($state -eq 'present') {
                     if ($groups_missing_behaviour -eq "fail") {
                         $module.FailJson("Failed to locate group $($group): $($_.Exception.Message)", $_)
                     }
-                    elseif ($groups_action -eq "warn") {
+                    elseif ($groups_missing_behaviour -eq "warn") {
                         $module.Warn("Failed to locate group $($group) but continuing on: $($_.Exception.Message)")
                     }
                 }

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -472,7 +472,6 @@ If ($state -eq 'present') {
             }
         }
 
-
         $assigned_groups = Get-PrincipalGroup $user_guid $extra_args
 
         switch ($groups_action) {

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -88,7 +88,7 @@ $spec = @{
         user_cannot_change_password = @{ type = 'bool' }
         account_locked = @{ type = 'bool' }
         groups = @{ type = 'list'; elements = 'str' }
-        groups_ignore_nonexistent = @{ type = 'bool'; default = $true }
+        groups_missing_behaviour = @{ type = 'str'; choices = "fail", "ignore", "warn"; default = "fail" }
         enabled = @{ type = 'bool'; default = $true }
         path = @{ type = 'str' }
         upn = @{ type = 'str' }
@@ -152,7 +152,7 @@ $password_never_expires = $module.Params.password_never_expires
 $user_cannot_change_password = $module.Params.user_cannot_change_password
 $account_locked = $module.Params.account_locked
 $groups = $module.Params.groups
-$groups_ignore_nonexistent = module.Params.groups_ignore_nonexistent
+$groups_missing_behaviour = $module.Params.groups_missing_behaviour
 $enabled = $module.Params.enabled
 $path = $module.Params.path
 $upn = $module.Params.upn
@@ -456,21 +456,21 @@ If ($state -eq 'present') {
     if ($null -ne $groups) {
         $group_list = $groups
 
-        $groups = @()
-        If ($groups_ignore_nonexistent) {
+        $groups = @(
             Foreach ($group in $group_list) {
                 try {
-                    $groups += (Get-ADGroup -Identity $group @extra_args).DistinguishedName
-                } catch {
-                    Add-Warning -obj $result -message "Failed to locate group $($group) but continuing on.: $($_.Exception.Message)"
-                    Continue
+                    (Get-ADGroup -Identity $group @extra_args).DistinguishedName
+                }
+                catch {
+                    if ($groups_missing_behaviour -eq "fail") {
+                        $module.FailJson("Failed to locate group $($group): $($_.Exception.Message)", $_)
+                    }
+                    elseif ($groups_action -eq "warn") {
+                        $module.Warn("Failed to locate group $($group) but continuing on: $($_.Exception.Message)")
+                    }
                 }
             }
-        } else {
-            Foreach ($group in $group_list) {
-                $groups += (Get-ADGroup -Identity $group @extra_args).DistinguishedName
-            }
-        }
+        )
 
         $assigned_groups = Get-PrincipalGroup $user_guid $extra_args
 

--- a/plugins/modules/win_domain_user.py
+++ b/plugins/modules/win_domain_user.py
@@ -65,11 +65,19 @@ options:
     type: str
     choices: [ add, remove, replace ]
     default: replace
-  groups_ignore_nonexistent:
+  groups_missing_behaviour:
     description:
-      - C(yes) will issue warning if attempting to add an AD Security Group that does not exist.
-      - C(no) will cause failure if attempting to add an AD Security Group that does not exist.
-    type: bool
+    - Controls what happens when a group specified by C(groups) is an invalid group name.
+    - C(fail) is the default and will return an error any groups do not exist.
+    - C(ignore) will ignore any groups that does not exist.
+    - C(warn) will display a warning for any groups that do not exist but will continue without failing.
+    type: str
+    choices:
+    - fail
+    - ignore
+    - warn
+    default: fail
+    version_added: 1.10.0
   spn:
     description:
       - Specifies the service principal name(s) for the account. This parameter sets the

--- a/plugins/modules/win_domain_user.py
+++ b/plugins/modules/win_domain_user.py
@@ -65,6 +65,11 @@ options:
     type: str
     choices: [ add, remove, replace ]
     default: replace
+  groups_ignore_nonexistent:
+    description:
+      - C(yes) will issue warning if attempting to add an AD Security Group that does not exist.
+      - C(no) will cause failure if attempting to add an AD Security Group that does not exist.
+    type: bool
   spn:
     description:
       - Specifies the service principal name(s) for the account. This parameter sets the

--- a/tests/integration/targets/win_domain_user/tasks/test2.yml
+++ b/tests/integration/targets/win_domain_user/tasks/test2.yml
@@ -97,6 +97,35 @@
   register: remove_spn_test_idempotent
   failed_when: remove_spn_test_idempotent is changed
 
+- name: Katie | Add to groups that are missing - fail
+  win_domain_user:
+    name: katie
+    state: present
+    groups:
+    - Missing Group
+  register: add_invalid_group_fail
+  failed_when: add_invalid_group_fail is success
+
+- name: Katie | Add to groups that are missing - warn
+  win_domain_user:
+    name: katie
+    state: present
+    groups:
+    - Missing Group
+    groups_missing_behaviour: warn
+  register: add_invalid_group_warn
+  failed_when: not add_invalid_group_warn.warnings[0].startswith("Failed to locate group Missing Group but continuing on")
+
+- name: Katie | Add to groups that are missing - ignore
+  win_domain_user:
+    name: katie
+    state: present
+    groups:
+    - Missing Group
+    groups_missing_behaviour: ignore
+  register: add_invalid_group_ignore
+  failed_when: (add_invalid_group_ignore.warnings | default([]) | length) != 0
+
 - name: Hana | Remove User
   win_domain_user:
     name: hana


### PR DESCRIPTION
##### SUMMARY
During my automation I would often use groups with variables in them, e.g.:
DL {{ site_location }} All Users

Certain niche situations were brought up where there were inconsistencies across our sites and business units, and some AD groups didn't exist under the variables I had specified.

I was often trying to add a user to a group with a variable in it that doesn't exist, and previously the code would produce an error, and fail the automation completely. This addition gives users the ability to fail on non-existent groups, or produce a warning and proceed instead.

I've had this running in our environment for a few weeks now.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
New addition to win_domain_user.ps1:
groups_ignore_nonexistent

##### ADDITIONAL INFORMATION
Feel free to change the documentation I provided for the feature to your standard.

Feel free to set the default to No rather than Yes