### PR TITLE
Fix Physical Path changing on modules/win_iis_webapplication.ps1

### DIFF
--- a/changelogs/fragments/win_iis_webapplication-missing-path.yml
+++ b/changelogs/fragments/win_iis_webapplication-missing-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_iis_webapplication - Fix physical path check for broken configurations - https://github.com/ansible-collections/community.windows/pull/385

--- a/plugins/modules/win_iis_webapplication.ps1
+++ b/plugins/modules/win_iis_webapplication.ps1
@@ -78,9 +78,8 @@ try {
                 Fail-Json $result "specified folder must already exist: path"
             }
 
-            $app_folder = Get-Item -LiteralPath $application.PhysicalPath
             $folder = Get-Item -LiteralPath $physical_path
-            if ($folder.FullName -ne $app_folder.FullName) {
+            if ($folder.FullName -ne $application.PhysicalPath) {
                 Set-ItemProperty -LiteralPath "IIS:\Sites\$($site)\$($name)" -name physicalPath -value $physical_path -WhatIf:$check_mode
                 $result.changed = $true
             }


### PR DESCRIPTION
Remove Get-Item for current application physical path to prevent errors if current path does not exist. Update comparison to use the physical path value already stored in the `$application` variable.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using **win_iis_webapplication** under certain conditions the underliying powershell code will produce an irrecoverable error. Premise: If the currently set physicalPath does not exist, the execution of the module will fail with the error `Cannot find path '$path' because it does not exist`. 

The existing path should not be validated, as this module may be run exactly to update a webApp that is broken due to a missing/modified PhysicalPath. The only path that should be validated (and it is) is the new physical path to be set.

This PR aims to improve the way the module behaves by removing the implicit check that is induced by using Get-Item to evaluate the currently set physicalPath, which is then treated as a LiteralPath to be compared as a string with the value of the new path to be set.

With this change, the paths are still compared and only changed if they differ, but the implicit validation for the currently set path is removed, preventing the module from throwing and error when it has been modified or does no longer exist. The path to be set is already validated on Line 77
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- modules/win_iis_webapplication.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
How to reproduce the issue:
- Create a folder, point webApp to use as PhysicalPath
- Delete created folder, validate that webApp is still using that deleted folder path as PhysicalPath. webApp may be broken, but the PhysicalPath is still used and returned. 
- Execute `win_iis_webapplication` to change the PhysicalPath with a new one, execution will throw error `Cannot find path '$pathToDeletedFolder' because it does not exist`
   - (Can also be validated by just running the powershell code this module uses to change the physical Path. It will fail when performing the action on Line 81)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
