### PR TITLE
win_region - fix junk output

### DIFF
--- a/changelogs/fragments/win_region-output.yml
+++ b/changelogs/fragments/win_region-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_region - Fix junk output when copying settings across users

--- a/plugins/modules/win_region.ps1
+++ b/plugins/modules/win_region.ps1
@@ -416,7 +416,7 @@ if ($null -ne $unicode_language) {
 
 if ($copy_settings -eq $true -and $module.Result.changed -eq $true) {
     if (-not $check_mode) {
-        New-PSDrive -Name HKU -PSProvider Registry -Root Registry::HKEY_USERS
+        $null = New-PSDrive -Name HKU -PSProvider Registry -Root Registry::HKEY_USERS
 
         if (Test-Path -LiteralPath HKU:\ANSIBLE) {
             $module.Warn("hive already loaded at HKU:\ANSIBLE, had to unload hive for win_region to continue")


### PR DESCRIPTION
##### SUMMARY
The `New-PSDrive` cmdlet outputs data when called but wasn't captured in the module. To avoid impacting the normal module output result this should be redirected to null.

Fixes https://github.com/ansible-collections/community.windows/issues/381

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_region