### PR TITLE
Add GUID mapping to fix AuditPol localization issue

### DIFF
--- a/plugins/modules/win_audit_policy_system.ps1
+++ b/plugins/modules/win_audit_policy_system.ps1
@@ -23,7 +23,8 @@ $categories_rc = run-command -command 'auditpol /list /category /r'
 $subcategories_rc = run-command -command 'auditpol /list /subcategory:* /r'
 
 If ($categories_rc.item('rc') -eq 0) {
-    $categories = ConvertFrom-Csv $categories_rc.item('stdout') | Select-Object -expand Category*
+    $categories_guid = ConvertFrom-Csv $categories_rc.item('stdout') | Select-Object -expand GUID
+    $categories_guid = $categories_guid.Trim('{', '}')
 }
 Else {
     Fail-Json -obj $results -message "Failed to retrive audit policy categories. Please make sure the auditpol command is functional on
@@ -31,13 +32,100 @@ Else {
 }
 
 If ($subcategories_rc.item('rc') -eq 0) {
-    $subcategories = ConvertFrom-Csv $subcategories_rc.item('stdout') | Select-Object -expand Category* |
-        Where-Object { $_ -notin $categories }
+    $subcategories_guid = ConvertFrom-Csv $subcategories_rc.item('stdout') | Select-Object -expand GUID |
+        Where-Object { $_ -notin $categories_guid }
+    $subcategories_guid = $subcategories_guid.Trim('{', '}')
 }
 Else {
     Fail-Json -obj $results -message "Failed to retrive audit policy subcategories. Please make sure the auditpol command is functional on
     the system and that the account ansible is running under is able to retrieve them. $($_.Exception.Message)"
 }
+
+####################################
+### GUID -> English name mapping ###
+####################################
+# Based off of DSC Community AuditPolicyDsc file
+$category_to_guid_hash = @{
+    ######Category/Subcategory                  GUID
+    #Category
+    "System" = "69979848-797A-11D9-BED3-505054503030";
+    "Logon/Logoff" = "69979849-797A-11D9-BED3-505054503030";
+    "Object Access" = "6997984A-797A-11D9-BED3-505054503030";
+    "Privilege Use" = "6997984B-797A-11D9-BED3-505054503030";
+    "Detailed Tracking" = "6997984C-797A-11D9-BED3-505054503030";
+    "Policy Change" = "6997984D-797A-11D9-BED3-505054503030";
+    "Account Management" = "6997984E-797A-11D9-BED3-505054503030";
+    "DS Access" = "6997984F-797A-11D9-BED3-505054503030";
+    "Account Logon" = "69979850-797A-11D9-BED3-505054503030";
+    # Subcategory
+    "Security State Change" = "0CCE9210-69AE-11D9-BED3-505054503030";
+    "Security System Extension" = "0CCE9211-69AE-11D9-BED3-505054503030";
+    "System Integrity" = "0CCE9212-69AE-11D9-BED3-505054503030";
+    "IPsec Driver" = "0CCE9213-69AE-11D9-BED3-505054503030";
+    "Other System Events" = "0CCE9214-69AE-11D9-BED3-505054503030";
+    "Logon" = "0CCE9215-69AE-11D9-BED3-505054503030";
+    "Logoff" = "0CCE9216-69AE-11D9-BED3-505054503030";
+    "Account Lockout" = "0CCE9217-69AE-11D9-BED3-505054503030";
+    "IPsec Main Mode" = "0CCE9218-69AE-11D9-BED3-505054503030";
+    "IPsec Quick Mode" = "0CCE9219-69AE-11D9-BED3-505054503030";
+    "IPsec Extended Mode" = "0CCE921A-69AE-11D9-BED3-505054503030";
+    "Special Logon" = "0CCE921B-69AE-11D9-BED3-505054503030";
+    "Other Logon/Logoff Events" = "0CCE921C-69AE-11D9-BED3-505054503030";
+    "Network Policy Server" = "0CCE9243-69AE-11D9-BED3-505054503030";
+    "User / Device Claims" = "0CCE9247-69AE-11D9-BED3-505054503030";
+    "Group Membership" = "0CCE9249-69AE-11D9-BED3-505054503030";
+    "File System" = "0CCE921D-69AE-11D9-BED3-505054503030";
+    "Registry" = "0CCE921E-69AE-11D9-BED3-505054503030";
+    "Kernel Object" = "0CCE921F-69AE-11D9-BED3-505054503030";
+    "SAM" = "0CCE9220-69AE-11D9-BED3-505054503030";
+    "Certification Services" = "0CCE9221-69AE-11D9-BED3-505054503030";
+    "Application Generated" = "0CCE9222-69AE-11D9-BED3-505054503030";
+    "Handle Manipulation" = "0CCE9223-69AE-11D9-BED3-505054503030";
+    "File Share" = "0CCE9224-69AE-11D9-BED3-505054503030";
+    "Filtering Platform Packet Drop" = "0CCE9225-69AE-11D9-BED3-505054503030";
+    "Filtering Platform Connection" = "0CCE9226-69AE-11D9-BED3-505054503030";
+    "Other Object Access Events" = "0CCE9227-69AE-11D9-BED3-505054503030";
+    "Detailed File Share" = "0CCE9244-69AE-11D9-BED3-505054503030";
+    "Removable Storage" = "0CCE9245-69AE-11D9-BED3-505054503030";
+    "Central Policy Staging" = "0CCE9246-69AE-11D9-BED3-505054503030";
+    "Sensitive Privilege Use" = "0CCE9228-69AE-11D9-BED3-505054503030";
+    "Non Sensitive Privilege Use" = "0CCE9229-69AE-11D9-BED3-505054503030";
+    "Other Privilege Use Events" = "0CCE922A-69AE-11D9-BED3-505054503030";
+    "Process Creation" = "0CCE922B-69AE-11D9-BED3-505054503030";
+    "Process Termination" = "0CCE922C-69AE-11D9-BED3-505054503030";
+    "DPAPI Activity" = "0CCE922D-69AE-11D9-BED3-505054503030";
+    "RPC Events" = "0CCE922E-69AE-11D9-BED3-505054503030";
+    "Plug and Play Events" = "0CCE9248-69AE-11D9-BED3-505054503030";
+    "Token Right Adjusted Events" = "0CCE924A-69AE-11D9-BED3-505054503030";
+    "Audit Policy Change" = "0CCE922F-69AE-11D9-BED3-505054503030";
+    "Authentication Policy Change" = "0CCE9230-69AE-11D9-BED3-505054503030";
+    "Authorization Policy Change" = "0CCE9231-69AE-11D9-BED3-505054503030";
+    "MPSSVC Rule-Level Policy Change" = "0CCE9232-69AE-11D9-BED3-505054503030";
+    "Filtering Platform Policy Change" = "0CCE9233-69AE-11D9-BED3-505054503030";
+    "Other Policy Change Events" = "0CCE9234-69AE-11D9-BED3-505054503030";
+    "User Account Management" = "0CCE9235-69AE-11D9-BED3-505054503030";
+    "Computer Account Management" = "0CCE9236-69AE-11D9-BED3-505054503030";
+    "Security Group Management" = "0CCE9237-69AE-11D9-BED3-505054503030";
+    "Distribution Group Management" = "0CCE9238-69AE-11D9-BED3-505054503030";
+    "Application Group Management" = "0CCE9239-69AE-11D9-BED3-505054503030";
+    "Other Account Management Events" = "0CCE923A-69AE-11D9-BED3-505054503030";
+    "Directory Service Access" = "0CCE923B-69AE-11D9-BED3-505054503030";
+    "Directory Service Changes" = "0CCE923C-69AE-11D9-BED3-505054503030";
+    "Directory Service Replication" = "0CCE923D-69AE-11D9-BED3-505054503030";
+    "Detailed Directory Service Replication" = "0CCE923E-69AE-11D9-BED3-505054503030";
+    "Credential Validation" = "0CCE923F-69AE-11D9-BED3-505054503030";
+    "Kerberos Service Ticket Operations" = "0CCE9240-69AE-11D9-BED3-505054503030";
+    "Other Account Logon Events" = "0CCE9241-69AE-11D9-BED3-505054503030";
+    "Kerberos Authentication Service" = "0CCE9242-69AE-11D9-BED3-505054503030";
+}
+
+$guid_to_category_hash = @{}
+$category_to_guid_hash.Keys | ForEach-Object {
+    $guid_to_category_hash.Add($category_to_guid_hash[$_], $_)
+}
+
+$categories = $categories_guid | Foreach-Object { $guid_to_category_hash[$_] }
+$subcategories = $subcategories_guid | Foreach-Object { $guid_to_category_hash[$_] }
 
 ######################
 ### ansible params ###


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a static GUID - English Name mapping for the outputs from auditpol.exe, to get around an issue caused by auditpol's outputs are localized. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #14

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_audit_policy_system


##### ADDITIONAL INFORMATION
This is the same method used to fix the same localization problem is the AuditPolicyDSC DSC resource:
https://github.com/dsccommunity/AuditPolicyDsc/blob/03bd14a560be01a50222f1dfad739c914043b124/DSCResources/AuditPolicyResourceHelper/AuditPolicyResourceHelper.psm1#L249