### PR TITLE
Encode URL in win_defrag_module

### DIFF
--- a/plugins/modules/win_defrag.py
+++ b/plugins/modules/win_defrag.py
@@ -10,7 +10,7 @@ module: win_defrag
 short_description: Consolidate fragmented files on local volumes
 description:
 - Locates and consolidates fragmented files on local volumes to improve system performance.
-- 'More information regarding C(win_defrag) is available from: U(https://technet.microsoft.com/en-us/library/cc731650(v=ws.11).aspx)'
+- 'More information regarding C(win_defrag) is available from: U(https://technet.microsoft.com/en-us/library/cc731650%28v%3Dws.11.aspx%29)'
 requirements:
 - defrag.exe
 options:


### PR DESCRIPTION
##### SUMMARY
The original URL contains parentheses and an equal sign which were parsed incorrectly, resulting in a broken link (see https://docs.ansible.com/ansible/latest/collections/community/windows/win_defrag_module.html).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`win_defrag_module`

##### ADDITIONAL INFORMATION
N/A
