### PR TITLE
Update test container and bump min ansible version

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.9.0
+      image: quay.io/ansible/azure-pipelines-test-container:3.0.0
 
 pool: Standard
 
@@ -93,19 +93,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_10
-    displayName: Ansible 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: '{0}'
-          testFormat: '2.10/{0}'
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn: []
@@ -132,7 +119,6 @@ stages:
       - Ansible_devel
       - Ansible_2_12
       - Ansible_2_11
-      - Ansible_2_10
       - Windows
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `community.windows` collection includes the community plugins supported by A
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.10**.
+This collection has been tested against following Ansible versions: **>=2.11**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-version-bump.yml
+++ b/changelogs/fragments/ansible-version-bump.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Raise minimum Ansible version to ``2.11`` or newer

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: community
 name: windows
-version: 1.10.0
+version: 1.11.0
 readme: README.md
 authors:
 - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.10'
+requires_ansible: '>=2.11'


### PR DESCRIPTION
##### SUMMARY
Uses the latest test container and removes Ansible 2.10 from the test matrix as it is out of support.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.windows