### PR TITLE
Add note about new module contributions not being accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ collections:
 
 ## Contributing to this collection
 
-We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against the [Community Windows collection repository](https://github.com/ansible-collections/community.windows). See [Contributing to Ansible-maintained collections](https://docs.ansible.com/ansible/devel/community/contributing_maintained_collections.html#contributing-maintained-collections) for details.
+Currently we welcome bugfixes or feature requests to plugins in this collection but no new modules or plugins will be accepted in this collection. If you find problems, please open an issue or create a PR against the [Community Windows collection repository](https://github.com/ansible-collections/community.windows). See [Contributing to Ansible-maintained collections](https://docs.ansible.com/ansible/devel/community/contributing_maintained_collections.html#contributing-maintained-collections) for details.
 
 See [Developing modules for Windows](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general_windows.html#developing-modules-general-windows) for specifics on Windows modules.
 


### PR DESCRIPTION
##### SUMMARY
To avoid bloating this collection further and also time constraints new module and plugin submissions won't be accepted into this collection. PRs for bugfixes or new features in existing modules will still be accepted the exclusion is just for new modules and other plugins.

These submissions should go into other collections that are either for a more specific set of components or maintained individually. The `community.windows` shouldn't continue to be a catch all for Windows modules but rather a way to continue distributing modules originally shipped with Ansible until they themselves are moved to a collection where they can be maintained better.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.windows