### PR TITLE
Add `accept_license` option to `win_psmodule`

### DIFF
--- a/changelogs/fragments/340-win_psmodule-accept_license-option.yml
+++ b/changelogs/fragments/340-win_psmodule-accept_license-option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - win_psmodule module - add ``accept_license`` option to allow for installing modules that require license acceptance (https://github.com/ansible-collections/community.windows/issues/340).

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -25,9 +25,9 @@ $skip_publisher_check = Get-AnsibleParam -obj $params -name "skip_publisher_chec
 $allow_prerelease = Get-AnsibleParam -obj $params -name "allow_prerelease" -type "bool" -default $false
 $accept_license = Get-AnsibleParam -obj $params -name "accept_license" -type "bool" -default $false
 
-$result = @{changed    = $false
-    output             = ""
-    nuget_changed      = $false
+$result = @{changed = $false
+    output = ""
+    nuget_changed = $false
     repository_changed = $false
 }
 
@@ -72,7 +72,7 @@ Function Install-PrereqModule {
     # Those are minimum required versions of modules.
     $PrereqModules = @{
         PackageManagement = '1.1.7'
-        PowerShellGet     = '1.6.0'
+        PowerShellGet = '1.6.0'
     }
 
     [Bool]$PrereqModulesInstalled = $true
@@ -88,11 +88,11 @@ Function Install-PrereqModule {
             else {
                 try {
                     $install_params = @{
-                        Name           = $Name
+                        Name = $Name
                         MinimumVersion = $PrereqModules[$Name]
-                        Force          = $true
-                        WhatIf         = $CheckMode
-                        AcceptLicense  = $AcceptLicense
+                        Force = $true
+                        WhatIf = $CheckMode
+                        AcceptLicense = $AcceptLicense
                     }
                     $installCmd = Get-Command -Name Install-Module
                     if ($installCmd.Parameters.ContainsKey('SkipPublisherCheck')) {
@@ -135,7 +135,7 @@ Function Get-PsModule {
     )
 
     $ExistingModule = @{
-        Exists  = $false
+        Exists = $false
         Version = ""
     }
 
@@ -164,8 +164,8 @@ Function Get-PsModule {
         }
         elseif ( $MinimumVersion -and $MaximumVersion ) {
             $ReturnedModule = $ExistingModules |
-            Where-Object -FilterScript { $MinimumVersion -le $_.Version -and $MaximumVersion -ge $_.Version } |
-            Select-Object -First 1
+                Where-Object -FilterScript { $MinimumVersion -le $_.Version -and $MaximumVersion -ge $_.Version } |
+                Select-Object -First 1
         }
         elseif ( $MinimumVersion ) {
             $ReturnedModule = $ExistingModules | Where-Object -FilterScript { $MinimumVersion -le $_.Version } | Select-Object -First 1
@@ -220,10 +220,10 @@ Function Install-PsModule {
     )
 
     $getParams = @{
-        Name            = $Name
+        Name = $Name
         RequiredVersion = $RequiredVersion
-        MinimumVersion  = $MinimumVersion
-        MaximumVersion  = $MaximumVersion
+        MinimumVersion = $MinimumVersion
+        MaximumVersion = $MaximumVersion
     }
     $ExistingModuleBefore = Get-PsModule @getParams
 
@@ -233,9 +233,9 @@ Function Install-PsModule {
             Install-NugetProvider -CheckMode $CheckMode
 
             $ht = @{
-                Name          = $Name
-                WhatIf        = $CheckMode
-                Force         = $true
+                Name = $Name
+                WhatIf = $CheckMode
+                Force = $true
                 AcceptLicense = $AcceptLicense
             }
 
@@ -272,9 +272,9 @@ Function Remove-PsModule {
     if (Get-Module -Listavailable | Where-Object { $_.name -eq $Name }) {
         try {
             $ht = @{
-                Name    = $Name
+                Name = $Name
                 Confirm = $false
-                Force   = $true
+                Force = $true
             }
 
             $ExistingModuleBefore = Get-PsModule -Name $Name -RequiredVersion $RequiredVersion -MinimumVersion $MinimumVersion -MaximumVersion $MaximumVersion
@@ -353,8 +353,8 @@ Function Install-Repository {
         "Use community.windows.win_psrepository to manage repos"
     )
     $result.deprecations += @{
-        msg             = $msg
-        date            = "2021-07-01"
+        msg = $msg
+        date = "2021-07-01"
         collection_name = "community.windows"
     }
     # Install NuGet provider if needed.
@@ -389,8 +389,8 @@ Function Remove-Repository {
         $result.deprecations = @()
     }
     $result.deprecations += @{
-        msg             = "Removing a repo with this module is deprecated, use community.windows.win_psrepository to manage repos"
-        date            = "2021-07-01"
+        msg = "Removing a repo with this module is deprecated, use community.windows.win_psrepository to manage repos"
+        date = "2021-07-01"
         collection_name = "community.windows"
     }
 
@@ -478,17 +478,17 @@ if ($state -eq "present") {
 
     if ($name) {
         $ht = @{
-            Name               = $name
-            RequiredVersion    = $required_version
-            MinimumVersion     = $minimum_version
-            MaximumVersion     = $maximum_version
-            Repository         = $repo
-            AllowClobber       = $allow_clobber
+            Name = $name
+            RequiredVersion = $required_version
+            MinimumVersion = $minimum_version
+            MaximumVersion = $maximum_version
+            Repository = $repo
+            AllowClobber = $allow_clobber
             SkipPublisherCheck = $skip_publisher_check
-            AllowPrerelease    = $allow_prerelease
-            CheckMode          = $check_mode
-            Credential         = $repo_credential
-            AcceptLicense      = $accept_license
+            AllowPrerelease = $allow_prerelease
+            CheckMode = $check_mode
+            Credential = $repo_credential
+            AcceptLicense = $accept_license
         }
         Install-PsModule @ht
     }
@@ -500,11 +500,11 @@ elseif ($state -eq "absent") {
 
     if ($name) {
         $ht = @{
-            Name            = $Name
-            CheckMode       = $check_mode
+            Name = $Name
+            CheckMode = $check_mode
             RequiredVersion = $required_version
-            MinimumVersion  = $minimum_version
-            MaximumVersion  = $maximum_version
+            MinimumVersion = $minimum_version
+            MaximumVersion = $maximum_version
         }
         Remove-PsModule @ht
     }
@@ -512,11 +512,11 @@ elseif ($state -eq "absent") {
 elseif ( $state -eq "latest") {
 
     $ht = @{
-        Name            = $Name
+        Name = $Name
         AllowPrerelease = $allow_prerelease
-        Repository      = $repo
-        CheckMode       = $check_mode
-        Credential      = $repo_credential
+        Repository = $repo
+        CheckMode = $check_mode
+        Credential = $repo_credential
     }
 
     $LatestVersion = Find-LatestPsModule @ht
@@ -526,15 +526,15 @@ elseif ( $state -eq "latest") {
     if ( $LatestVersion.Version -ne $ExistingModule.Version ) {
 
         $ht = @{
-            Name               = $Name
-            RequiredVersion    = $LatestVersion
-            Repository         = $repo
-            AllowClobber       = $allow_clobber
+            Name = $Name
+            RequiredVersion = $LatestVersion
+            Repository = $repo
+            AllowClobber = $allow_clobber
             SkipPublisherCheck = $skip_publisher_check
-            AllowPrerelease    = $allow_prerelease
-            CheckMode          = $check_mode
-            Credential         = $repo_credential
-            AcceptLicense      = $accept_license
+            AllowPrerelease = $allow_prerelease
+            CheckMode = $check_mode
+            Credential = $repo_credential
+            AcceptLicense = $accept_license
         }
         Install-PsModule @ht
     }

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -23,10 +23,11 @@ $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "prese
 $allow_clobber = Get-AnsibleParam -obj $params -name "allow_clobber" -type "bool" -default $false
 $skip_publisher_check = Get-AnsibleParam -obj $params -name "skip_publisher_check" -type "bool" -default $false
 $allow_prerelease = Get-AnsibleParam -obj $params -name "allow_prerelease" -type "bool" -default $false
+$accept_license = Get-AnsibleParam -obj $params -name "accept_license" -type "bool" -default $false
 
-$result = @{changed = $false
-    output = ""
-    nuget_changed = $false
+$result = @{changed    = $false
+    output             = ""
+    nuget_changed      = $false
     repository_changed = $false
 }
 
@@ -64,13 +65,14 @@ Function Install-PrereqModule {
     Param(
         [Switch]$TestInstallationOnly,
         [bool]$AllowClobber,
-        [Bool]$CheckMode
+        [Bool]$CheckMode,
+        [bool]$AcceptLicense
     )
 
     # Those are minimum required versions of modules.
     $PrereqModules = @{
         PackageManagement = '1.1.7'
-        PowerShellGet = '1.6.0'
+        PowerShellGet     = '1.6.0'
     }
 
     [Bool]$PrereqModulesInstalled = $true
@@ -86,10 +88,11 @@ Function Install-PrereqModule {
             else {
                 try {
                     $install_params = @{
-                        Name = $Name
+                        Name           = $Name
                         MinimumVersion = $PrereqModules[$Name]
-                        Force = $true
-                        WhatIf = $CheckMode
+                        Force          = $true
+                        WhatIf         = $CheckMode
+                        AcceptLicense  = $AcceptLicense
                     }
                     $installCmd = Get-Command -Name Install-Module
                     if ($installCmd.Parameters.ContainsKey('SkipPublisherCheck')) {
@@ -132,7 +135,7 @@ Function Get-PsModule {
     )
 
     $ExistingModule = @{
-        Exists = $false
+        Exists  = $false
         Version = ""
     }
 
@@ -161,8 +164,8 @@ Function Get-PsModule {
         }
         elseif ( $MinimumVersion -and $MaximumVersion ) {
             $ReturnedModule = $ExistingModules |
-                Where-Object -FilterScript { $MinimumVersion -le $_.Version -and $MaximumVersion -ge $_.Version } |
-                Select-Object -First 1
+            Where-Object -FilterScript { $MinimumVersion -le $_.Version -and $MaximumVersion -ge $_.Version } |
+            Select-Object -First 1
         }
         elseif ( $MinimumVersion ) {
             $ReturnedModule = $ExistingModules | Where-Object -FilterScript { $MinimumVersion -le $_.Version } | Select-Object -First 1
@@ -212,14 +215,15 @@ Function Install-PsModule {
         [Bool]$AllowClobber,
         [Bool]$SkipPublisherCheck,
         [Bool]$AllowPrerelease,
-        [Bool]$CheckMode
+        [Bool]$CheckMode,
+        [Bool]$AcceptLicense
     )
 
     $getParams = @{
-        Name = $Name
+        Name            = $Name
         RequiredVersion = $RequiredVersion
-        MinimumVersion = $MinimumVersion
-        MaximumVersion = $MaximumVersion
+        MinimumVersion  = $MinimumVersion
+        MaximumVersion  = $MaximumVersion
     }
     $ExistingModuleBefore = Get-PsModule @getParams
 
@@ -229,9 +233,10 @@ Function Install-PsModule {
             Install-NugetProvider -CheckMode $CheckMode
 
             $ht = @{
-                Name = $Name
-                WhatIf = $CheckMode
-                Force = $true
+                Name          = $Name
+                WhatIf        = $CheckMode
+                Force         = $true
+                AcceptLicense = $AcceptLicense
             }
 
             [String[]]$ParametersNames = @("RequiredVersion", "MinimumVersion", "MaximumVersion", "AllowPrerelease",
@@ -267,9 +272,9 @@ Function Remove-PsModule {
     if (Get-Module -Listavailable | Where-Object { $_.name -eq $Name }) {
         try {
             $ht = @{
-                Name = $Name
+                Name    = $Name
                 Confirm = $false
-                Force = $true
+                Force   = $true
             }
 
             $ExistingModuleBefore = Get-PsModule -Name $Name -RequiredVersion $RequiredVersion -MinimumVersion $MinimumVersion -MaximumVersion $MaximumVersion
@@ -348,8 +353,8 @@ Function Install-Repository {
         "Use community.windows.win_psrepository to manage repos"
     )
     $result.deprecations += @{
-        msg = $msg
-        date = "2021-07-01"
+        msg             = $msg
+        date            = "2021-07-01"
         collection_name = "community.windows"
     }
     # Install NuGet provider if needed.
@@ -384,8 +389,8 @@ Function Remove-Repository {
         $result.deprecations = @()
     }
     $result.deprecations += @{
-        msg = "Removing a repo with this module is deprecated, use community.windows.win_psrepository to manage repos"
-        date = "2021-07-01"
+        msg             = "Removing a repo with this module is deprecated, use community.windows.win_psrepository to manage repos"
+        date            = "2021-07-01"
         collection_name = "community.windows"
     }
 
@@ -458,7 +463,7 @@ if ( ($allow_clobber -or $allow_prerelease -or $skip_publisher_check -or
         $required_version -or $minimum_version -or $maximum_version) ) {
     # Update the PowerShellGet and PackageManagement modules.
     # It's required to support AllowClobber, AllowPrerelease parameters.
-    Install-PrereqModule -AllowClobber $allow_clobber -CheckMode $check_mode
+    Install-PrereqModule -AllowClobber $allow_clobber -CheckMode $check_mode -AcceptLicense $accept_license
 }
 
 Import-Module -Name PackageManagement, PowerShellGet
@@ -473,16 +478,17 @@ if ($state -eq "present") {
 
     if ($name) {
         $ht = @{
-            Name = $name
-            RequiredVersion = $required_version
-            MinimumVersion = $minimum_version
-            MaximumVersion = $maximum_version
-            Repository = $repo
-            AllowClobber = $allow_clobber
+            Name               = $name
+            RequiredVersion    = $required_version
+            MinimumVersion     = $minimum_version
+            MaximumVersion     = $maximum_version
+            Repository         = $repo
+            AllowClobber       = $allow_clobber
             SkipPublisherCheck = $skip_publisher_check
-            AllowPrerelease = $allow_prerelease
-            CheckMode = $check_mode
-            Credential = $repo_credential
+            AllowPrerelease    = $allow_prerelease
+            CheckMode          = $check_mode
+            Credential         = $repo_credential
+            AcceptLicense      = $accept_license
         }
         Install-PsModule @ht
     }
@@ -494,11 +500,11 @@ elseif ($state -eq "absent") {
 
     if ($name) {
         $ht = @{
-            Name = $Name
-            CheckMode = $check_mode
+            Name            = $Name
+            CheckMode       = $check_mode
             RequiredVersion = $required_version
-            MinimumVersion = $minimum_version
-            MaximumVersion = $maximum_version
+            MinimumVersion  = $minimum_version
+            MaximumVersion  = $maximum_version
         }
         Remove-PsModule @ht
     }
@@ -506,11 +512,11 @@ elseif ($state -eq "absent") {
 elseif ( $state -eq "latest") {
 
     $ht = @{
-        Name = $Name
+        Name            = $Name
         AllowPrerelease = $allow_prerelease
-        Repository = $repo
-        CheckMode = $check_mode
-        Credential = $repo_credential
+        Repository      = $repo
+        CheckMode       = $check_mode
+        Credential      = $repo_credential
     }
 
     $LatestVersion = Find-LatestPsModule @ht
@@ -520,14 +526,15 @@ elseif ( $state -eq "latest") {
     if ( $LatestVersion.Version -ne $ExistingModule.Version ) {
 
         $ht = @{
-            Name = $Name
-            RequiredVersion = $LatestVersion
-            Repository = $repo
-            AllowClobber = $allow_clobber
+            Name               = $Name
+            RequiredVersion    = $LatestVersion
+            Repository         = $repo
+            AllowClobber       = $allow_clobber
             SkipPublisherCheck = $skip_publisher_check
-            AllowPrerelease = $allow_prerelease
-            CheckMode = $check_mode
-            Credential = $repo_credential
+            AllowPrerelease    = $allow_prerelease
+            CheckMode          = $check_mode
+            Credential         = $repo_credential
+            AcceptLicense      = $accept_license
         }
         Install-PsModule @ht
     }

--- a/plugins/modules/win_psmodule.py
+++ b/plugins/modules/win_psmodule.py
@@ -76,6 +76,9 @@ options:
       - Accepts the module's license.
       - Required for modules that require license acceptance, since interactively answering the prompt is not possible.
       - Corresponds to the C(-AcceptLicense) parameter of C(Install-Module).
+      - >-
+        Installation of a module or a dependency that requires license acceptance cannot be detected in check mode,
+        but will cause a failure at runtime unless I(accept_license=true).
     type: bool
     required: no
     default: false

--- a/plugins/modules/win_psmodule.py
+++ b/plugins/modules/win_psmodule.py
@@ -71,6 +71,15 @@ options:
     type: str
     required: no
     version_added: '1.10.0'
+  accept_license:
+    description:
+      - Accepts the module's license.
+      - Required for modules that require license acceptance, since interactively answering the prompt is not possible.
+      - Corresponds to the C(-AcceptLicense) parameter of C(Install-Module).
+    type: bool
+    required: no
+    default: false
+    version_added: '1.11.0'
   url:
     description:
       - URL of the custom repository to register.

--- a/tests/integration/targets/win_psmodule/files/module/license.txt
+++ b/tests/integration/targets/win_psmodule/files/module/license.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Ansible
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/integration/targets/win_psmodule/files/module/template.nuspec
+++ b/tests/integration/targets/win_psmodule/files/module/template.nuspec
@@ -5,7 +5,7 @@
     <version>--- VERSION ---</version>
     <authors>Ansible</authors>
     <owners>Ansible</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <requireLicenseAcceptance>--- LICACC ---</requireLicenseAcceptance>
     <description>Test for Ansible win_ps* modules</description>
     <releaseNotes></releaseNotes>
     <copyright>Copyright (c) 2019 Ansible, licensed under MIT.</copyright>

--- a/tests/integration/targets/win_psmodule/files/module/template.nuspec
+++ b/tests/integration/targets/win_psmodule/files/module/template.nuspec
@@ -6,6 +6,7 @@
     <authors>Ansible</authors>
     <owners>Ansible</owners>
     <requireLicenseAcceptance>--- LICACC ---</requireLicenseAcceptance>
+    <licenseUrl>https://choosealicense.com/licenses/mit/</licenseUrl>
     <description>Test for Ansible win_ps* modules</description>
     <releaseNotes></releaseNotes>
     <copyright>Copyright (c) 2019 Ansible, licensed under MIT.</copyright>

--- a/tests/integration/targets/win_psmodule/files/module/template.nuspec
+++ b/tests/integration/targets/win_psmodule/files/module/template.nuspec
@@ -10,6 +10,6 @@
     <description>Test for Ansible win_ps* modules</description>
     <releaseNotes></releaseNotes>
     <copyright>Copyright (c) 2019 Ansible, licensed under MIT.</copyright>
-    <tags>PSModule PSIncludes_Function PSFunction_--- FUNCTION --- PSCommand_--- FUNCTION ---</tags>
+    <tags>PowerShellGetFormatVersion_2.0 PSModule PSIncludes_Function PSFunction_--- FUNCTION --- PSCommand_--- FUNCTION ---</tags>
   </metadata>
 </package>

--- a/tests/integration/targets/win_psmodule/files/module/template.nuspec
+++ b/tests/integration/targets/win_psmodule/files/module/template.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>--- NAME ---</id>
     <version>--- VERSION ---</version>

--- a/tests/integration/targets/win_psmodule/files/setup_modules.ps1
+++ b/tests/integration/targets/win_psmodule/files/setup_modules.ps1
@@ -4,6 +4,7 @@ $template_path = $args[0]
 $template_manifest = Join-Path -Path $template_path -ChildPath template.psd1
 $template_script = Join-Path -Path $template_path -ChildPath template.psm1
 $template_nuspec = Join-Path -Path $template_path -ChildPath template.nuspec
+$template_license = Join-Path -Path $template_path -ChildPath license.txt
 $nuget_exe = Join-Path -Path $template_path -ChildPath nuget.exe
 $sign_cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList @(
     (Join-Path -Path $template_path -ChildPath sign.pfx),
@@ -32,8 +33,10 @@ foreach ($package in $packages) {
     }
     New-Item -Path $tmp_dir -ItemType Directory > $null
 
+    Copy-Item -LiteralPath $template_license -Destination $tmp_dir -Force
+
     try {
-        $ps_data = @()
+        $ps_data = @("LicenseUri = 'https://choosealicense.com/licenses/mit/'")
         $nuget_version = $package.version
         if ($package.ContainsKey("prerelease")) {
             $ps_data += "Prerelease = '$($package.prerelease)'"

--- a/tests/integration/targets/win_psmodule/files/setup_modules.ps1
+++ b/tests/integration/targets/win_psmodule/files/setup_modules.ps1
@@ -23,7 +23,7 @@ $packages = @(
     @{ name = "ansible-test2"; version = "1.0.1"; repo = "PSRepo 1"; function = "Get-AnsibleTest2"; signed = $false }
     @{ name = "ansible-test2"; version = "1.1.0"; prerelease = "beta1"; repo = "PSRepo 1"; function = "Get-AnsibleTest2" }
     @{ name = "ansible-clobber"; version = "0.1.0"; repo = "PSRepo 1"; function = "Enable-PSTrace" }
-    @{ name = "ansible-licensed" ; version = "1.1.1"; repo = "PSRepo 1" ; require_license = $true; function = "Get-AnsibleTest1" }
+    @{ name = "ansible-licensed" ; version = "1.1.1"; repo = "PSRepo 1" ; require_license = $true; function = "Get-AnsibleLicensed" }
 )
 
 foreach ($package in $packages) {

--- a/tests/integration/targets/win_psmodule/files/setup_modules.ps1
+++ b/tests/integration/targets/win_psmodule/files/setup_modules.ps1
@@ -40,7 +40,7 @@ foreach ($package in $packages) {
             $nuget_version = "$($package.version)-$($package.prerelease)"
         }
         if ($package.ContainsKey("require_license")) {
-            $ps_data += "RequireLicenseAcceptance = `$$($package['require_license'])"
+            $ps_data += "RequireLicenseAcceptance = `$$($package.require_license)"
         }
 
         $manifest = [System.IO.File]::ReadAllText($template_manifest)
@@ -70,6 +70,7 @@ foreach ($package in $packages) {
         $nuspec = [System.IO.File]::ReadAllText($template_nuspec)
         $nuspec = $nuspec.Replace('--- NAME ---', $package.name).Replace('--- VERSION ---', $nuget_version)
         $nuspec = $nuspec.Replace('--- FUNCTION ---', $package.function)
+        $nuspec = $nuspec.Replace('--- LICACC ---', ($package.require_license -as [bool]).ToString().ToLower())
         Set-Content -Path (Join-Path -Path $tmp_dir -ChildPath "$($package.name).nuspec") -Value $nuspec
 
         &$nuget_exe pack "$tmp_dir\$($package.name).nuspec" -outputdirectory $tmp_dir

--- a/tests/integration/targets/win_psmodule/tasks/main.yml
+++ b/tests/integration/targets/win_psmodule/tasks/main.yml
@@ -38,7 +38,7 @@
   ignore_errors: yes
 
 - name: get result of install package
-  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
+  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-licensed | Measure-Object).Count
   register: install_actual_check
 
 - name: assert install package (failure)
@@ -56,7 +56,7 @@
   register: install_licensed
 
 - name: get result of install package
-  ansible.windows.win_shell: Import-Module -Name ansible-test1; Get-AnsibleTest1 | ConvertTo-Json
+  ansible.windows.win_shell: Import-Module -Name ansible-licensed; Get-AnsibleLicensed | ConvertTo-Json
   register: install_actual
 
 - name: assert install package
@@ -73,7 +73,7 @@
   register: install_licensed
 
 - name: get result of install package (idempotence)
-  ansible.windows.win_shell: Import-Module -Name ansible-test1; Get-AnsibleTest1 | ConvertTo-Json
+  ansible.windows.win_shell: Import-Module -Name ansible-licensed; Get-AnsibleLicensed | ConvertTo-Json
   register: install_actual
 
 - name: assert install package (idempotence)

--- a/tests/integration/targets/win_psmodule/tasks/main.yml
+++ b/tests/integration/targets/win_psmodule/tasks/main.yml
@@ -45,7 +45,7 @@
   assert:
     that:
     - install_licensed is failed
-      #TODO (this PR): check for specific failure message
+    - '"License Acceptance is required for module" in install_licensed.msg'
     - install_actual_check.stdout | trim | int == 0
 
 - name: install module requiring license acceptance

--- a/tests/integration/targets/win_psmodule/tasks/main.yml
+++ b/tests/integration/targets/win_psmodule/tasks/main.yml
@@ -25,6 +25,99 @@
     - dep_repo_add.deprecations[0].msg == 'Adding a repo with this module is deprecated, the repository parameter should only be used to select a repo. Use community.windows.win_psrepository to manage repos'
     - dep_repo_add.deprecations[0].date == '2021-07-01'
 
+### licensed module checks
+
+- name: install module requiring license acceptance (no param, check mode)
+  win_psmodule:
+    name: ansible-licensed
+    state: present
+  register: install_licensed
+  check_mode: yes
+  ignore_errors: yes
+
+- name: get result of install package (check mode)
+  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
+  register: install_actual_check
+
+- name: assert install package (failure, check mode)
+  assert:
+    that:
+    - install_licensed is failed
+      #TODO (this PR): check for specific failure message
+    - install_actual_check.stdout | trim | int == 0
+
+- name: install module requiring license acceptance (no param)
+  win_psmodule:
+    name: ansible-licensed
+    state: present
+  register: install_licensed
+  ignore_errors: yes
+
+- name: get result of install package (check mode)
+  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
+  register: install_actual_check
+
+- name: assert install package (failure, check mode)
+  assert:
+    that:
+    - install_licensed is failed
+      #TODO (this PR): check for specific failure message
+    - install_actual_check.stdout | trim | int == 0
+
+- name: install module requiring license acceptance (check mode)
+  win_psmodule:
+    name: ansible-licensed
+    state: present
+    accept_license: true
+  register: install_licensed
+  check_mode: yes
+
+- name: get result of install package (check mode)
+  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
+  register: install_actual_check
+
+- name: assert install package (check mode)
+  assert:
+    that:
+    - install_licensed is changed
+    - install_actual_check.stdout | trim | int == 0
+
+- name: install module requiring license acceptance
+  win_psmodule:
+    name: ansible-licensed
+    state: present
+    accept_license: true
+  register: install_licensed
+
+- name: get result of install package
+  ansible.windows.win_shell: Import-Module -Name ansible-test1; Get-AnsibleTest1 | ConvertTo-Json
+  register: install_actual
+
+- name: assert install package
+  assert:
+    that:
+    - install_licensed is changed
+    - install_actual.stdout | from_json == {"Name":"ansible-licensed","Version":"1.1.1","Repo":"PSRepo 1"}
+
+- name: install module requiring license acceptance (idempotence)
+  win_psmodule:
+    name: ansible-licensed
+    state: present
+    accept_license: true
+  register: install_licensed
+
+- name: get result of install package (idempotence)
+  ansible.windows.win_shell: Import-Module -Name ansible-test1; Get-AnsibleTest1 | ConvertTo-Json
+  register: install_actual
+
+- name: assert install package (idempotence)
+  assert:
+    that:
+    - install_licensed is not changed
+    - install_actual.stdout | from_json == {"Name":"ansible-licensed","Version":"1.1.1","Repo":"PSRepo 1"}
+
+### end licensed module checks
+
 - name: install package (check mode)
   win_psmodule:
     name: ansible-test1

--- a/tests/integration/targets/win_psmodule/tasks/main.yml
+++ b/tests/integration/targets/win_psmodule/tasks/main.yml
@@ -26,25 +26,9 @@
     - dep_repo_add.deprecations[0].date == '2021-07-01'
 
 ### licensed module checks
-
-- name: install module requiring license acceptance (no param, check mode)
-  win_psmodule:
-    name: ansible-licensed
-    state: present
-  register: install_licensed
-  check_mode: yes
-  ignore_errors: yes
-
-- name: get result of install package (check mode)
-  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
-  register: install_actual_check
-
-- name: assert install package (failure, check mode)
-  assert:
-    that:
-    - install_licensed is failed
-      #TODO (this PR): check for specific failure message
-    - install_actual_check.stdout | trim | int == 0
+# it is not known in check mode that a module requires
+# license acceptance, so we don't do check mode tests
+# for that scenario
 
 - name: install module requiring license acceptance (no param)
   win_psmodule:
@@ -53,33 +37,15 @@
   register: install_licensed
   ignore_errors: yes
 
-- name: get result of install package (check mode)
+- name: get result of install package
   ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
   register: install_actual_check
 
-- name: assert install package (failure, check mode)
+- name: assert install package (failure)
   assert:
     that:
     - install_licensed is failed
       #TODO (this PR): check for specific failure message
-    - install_actual_check.stdout | trim | int == 0
-
-- name: install module requiring license acceptance (check mode)
-  win_psmodule:
-    name: ansible-licensed
-    state: present
-    accept_license: true
-  register: install_licensed
-  check_mode: yes
-
-- name: get result of install package (check mode)
-  ansible.windows.win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
-  register: install_actual_check
-
-- name: assert install package (check mode)
-  assert:
-    that:
-    - install_licensed is changed
     - install_actual_check.stdout | trim | int == 0
 
 - name: install module requiring license acceptance

--- a/tests/integration/targets/win_psmodule/tasks/setup.yml
+++ b/tests/integration/targets/win_psmodule/tasks/setup.yml
@@ -8,7 +8,7 @@
 #     ansible-test2 - 1.0.1 (Not signed for skip_publisher tests)
 #     ansible-test2 - 1.1.0-beta1
 #     ansible-clobber - 0.1.0
-#
+#     ansible-licensed - 1.1.1 (requires license acceptance)
 # PSRepo 2 contains
 #     ansible-test2 - 1.0.0
 #


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #340 

Adds `accept_license` option to `win_psmodule` so that modules requiring license acceptance can be installed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_psmodule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A
<!--- Paste verbatim command output below, e.g. before and after your change -->
