### PR TITLE
win_domain_user - fix broken warning message

### DIFF
--- a/changelogs/fragments/win_domain_user-add-warning.yml
+++ b/changelogs/fragments/win_domain_user-add-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_user - Fix broken warning call when failing to get group membership - https://github.com/ansible-collections/community.windows/issues/412

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -210,7 +210,7 @@ Function Get-PrincipalGroup {
             -ErrorAction Stop
     }
     catch {
-        Add-Warning -obj $result -message "Failed to enumerate user groups but continuing on.: $($_.Exception.Message)"
+        $module.Warn("Failed to enumerate user groups but continuing on: $($_.Exception.Message)")
         return @()
     }
 


### PR DESCRIPTION
##### SUMMARY
The PR https://github.com/ansible-collections/community.windows/pull/365 migrated `win_domain_user` to the new module style but missed the `Add-Warning` call. This PR changes it to use the newer mechanism to display a warning back to Ansible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user