### PR TITLE
win_scheduled_task - fix run_on_last_week_of_month trigger

### DIFF
--- a/changelogs/fragments/win_scheduled_task_week-trigger.yml
+++ b/changelogs/fragments/win_scheduled_task_week-trigger.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_scheduled_task - Fix the Monthly DOW trigger value ``run_on_last_week_of_month`` when ``weeks_of_month`` is also set - https://github.com/ansible-collections/community.windows/issues/414

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -633,8 +633,10 @@ Function Compare-Trigger($task_definition) {
         }
         [TASK_TRIGGER_TYPE2]::TASK_TRIGGER_MONTHLYDOW = @{
             mandatory = @('start_boundary')
-            optional = @('days_of_week', 'enabled', 'end_boundary', 'execution_time_limit', 'months_of_year', 'random_delay', 'run_on_last_week_of_month',
-                'weeks_of_month', 'repetition')
+            # Make sure run_on_last_week_of_month comes after weeks_of_month
+            # https://github.com/ansible-collections/community.windows/issues/414
+            optional = @('days_of_week', 'enabled', 'end_boundary', 'execution_time_limit', 'months_of_year', 'random_delay', 'weeks_of_month',
+                'run_on_last_week_of_month', 'repetition')
         }
         [TASK_TRIGGER_TYPE2]::TASK_TRIGGER_MONTHLY = @{
             mandatory = @('days_of_month', 'start_boundary')

--- a/tests/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -217,6 +217,7 @@
     - type: monthlydow
       start_boundary: '2000-01-01T00:00:01'
       weeks_of_month: 1,2
+      run_on_last_week_of_month: true
       days_of_week: [ "monday", "wednesday" ]
   register: trigger_monthlydow_check
   check_mode: yes
@@ -248,6 +249,7 @@
     - type: monthlydow
       start_boundary: '2000-01-01T00:00:01+03:00'
       weeks_of_month: 1,2
+      run_on_last_week_of_month: true
       days_of_week: [ "monday", "wednesday" ]
   register: trigger_monthlydow
 
@@ -272,6 +274,7 @@
     - trigger_monthlydow_result.triggers[0].start_boundary == trigger_monthlydow_date.stdout|trim
     - trigger_monthlydow_result.triggers[0].end_boundary == None
     - trigger_monthlydow_result.triggers[0].weeks_of_month == "1,2"
+    - trigger_monthlydow_result.triggers[0].run_on_last_week_of_month == True
     - trigger_monthlydow_result.triggers[0].days_of_week == "monday,wednesday"
 
 - name: create monthly dow trigger (idempotent)
@@ -284,6 +287,7 @@
     - type: monthlydow
       start_boundary: '2000-01-01T00:00:01+03:00'
       weeks_of_month: 1,2
+      run_on_last_week_of_month: true
       days_of_week: [ "monday", "wednesday" ]
   register: trigger_monthlydow_again
 
@@ -328,6 +332,7 @@
     - create_trigger_repetition_result_check.triggers[0].start_boundary == trigger_monthlydow_date.stdout|trim
     - create_trigger_repetition_result_check.triggers[0].end_boundary == None
     - create_trigger_repetition_result_check.triggers[0].weeks_of_month == "1,2"
+    - create_trigger_repetition_result_check.triggers[0].run_on_last_week_of_month == True
     - create_trigger_repetition_result_check.triggers[0].days_of_week == "monday,wednesday"
     - create_trigger_repetition_result_check.triggers[0].repetition.interval == None
     - create_trigger_repetition_result_check.triggers[0].repetition.duration == None


### PR DESCRIPTION
##### SUMMARY
The `run_on_last_week_of_month` property needs to be set after `weeks_of_month` as the latter unsets the formers value internally.

Fixes: https://github.com/ansible-collections/community.windows/issues/414

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scheduled_task