### PR TITLE
Support for client identifiers other than just simple mac addresses

### DIFF
--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -142,6 +142,7 @@ if ($mac) {
     } else {
         $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
     }
+    
 }
 
 # Did we find a lease/reservation

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -233,8 +233,8 @@ if ($state -eq "present") {
 
                 if ($reservation_name) {
                     $params.Name = $reservation_name
-                } 
-                else { 
+                }
+                else {
                     $params.Name = "reservation-" + $params.ClientId
                 }
 

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -139,6 +139,8 @@ if ($mac) {
 
     if ($mac -eq $false) {
         $module.FailJson("The MAC Address is not properly formatted")
+    } else {
+        $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
     }
 }
 

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -139,7 +139,8 @@ if ($mac) {
 
     if ($mac -eq $false) {
         $module.FailJson("The MAC Address is not properly formatted")
-    } else {
+    } 
+    else {
         $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
     }
 
@@ -232,8 +233,8 @@ if ($state -eq "present") {
 
                 if ($reservation_name) {
                     $params.Name = $reservation_name
-                }
-                else {
+                } 
+                else { 
                     $params.Name = "reservation-" + $params.ClientId
                 }
 

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -71,8 +71,7 @@ Function Convert-MacAddress {
         }
         return $str
     }
-    else
-    {
+    else {
         return $false
     }
 }

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -129,16 +129,13 @@ if ($ip) {
 # MacAddress was specified
 if ($mac) {
     
-    if ($mac -like "*-*") {
-        $mac_original = $mac
-        $mac = Convert-MacAddress -mac $mac
-    }
+    $mac = Convert-MacAddress -mac $mac
 
     if ($mac -eq $false) {
         $module.FailJson("The MAC Address is not properly formatted")
     }
     else {
-        $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac_original
+        $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
     }
 }
 
@@ -430,7 +427,7 @@ if ($state -eq "present") {
                 Try {
                     if ($check_mode) {
                         # In check mode, a lease won't exist for conversion, make one manually
-                        Add-DhcpServerv4Reservation -ScopeId $scope_id -ClientId $mac_original -IPAddress $ip -WhatIf:$check_mode
+                        Add-DhcpServerv4Reservation -ScopeId $scope_id -ClientId $mac -IPAddress $ip -WhatIf:$check_mode
                     }
                     else {
                         # Convert to Reservation
@@ -444,7 +441,7 @@ if ($state -eq "present") {
 
                 if (-not $check_mode) {
                     # Get DHCP reservation object
-                    $new_lease = Get-DhcpServerv4Reservation -ClientId $mac_original -ScopeId $scope_id
+                    $new_lease = Get-DhcpServerv4Reservation -ClientId $mac -ScopeId $scope_id
                     $module.Result.lease = Convert-ReturnValue -Object $new_lease
                 }
 

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -47,14 +47,14 @@ Function Convert-MacAddress {
     # Remove dashes and colons
     $mac = $mac -replace ':'
     $mac = $mac -replace '-'
-    
+
     # These are valid characters for a mac address or a client identifier
     $pat = "^[a-fA-F0-9]+$"
-    
+
     # Get the length of the provided identifier
     $mac_length = $mac.length
 
-    # Evaluate the identifier. The maximum length of a client identifier is 510 characters, otherwise the DHCP server crashes. 
+    # Evaluate the identifier. The maximum length of a client identifier is 510 characters, otherwise the DHCP server crashes.
     # The number of characters should be an even number, as the DHCP server otherwise shortens the string. The minimum
     # number of characters is 2 (regardless if such a short identifier makes sense). Allowed characters are 0-9 and A-F,
     # allthough the RFC allows any characters, Microsoft does not.
@@ -71,7 +71,8 @@ Function Convert-MacAddress {
         }
         return $str
     }
-    else {
+    else
+    {
         return $false
     }
 }
@@ -134,15 +135,12 @@ if ($ip) {
 
 # MacAddress was specified
 if ($mac) {
-    
+
     $mac = Convert-MacAddress -mac $mac
 
     if ($mac -eq $false) {
         $module.FailJson("The MAC Address is not properly formatted")
     }
-   # elseif ($current_lease -and $current_lease.ClientId -eq $mac ) {
-   #     $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
-   # }
 }
 
 # Did we find a lease/reservation
@@ -150,7 +148,6 @@ if ($current_lease) {
     $current_lease_exists = $true
     $original_lease = $current_lease
     $module.Diff.before = Convert-ReturnValue -Object $original_lease
-    #$module.FailJson("Current: " + $current_lease.ClientId + ", Original: " + $original_lease.ClientId + ", MAC: " + $mac )
 }
 else {
     $current_lease_exists = $false

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -142,7 +142,7 @@ if ($mac) {
     } else {
         $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
     }
-    
+
 }
 
 # Did we find a lease/reservation


### PR DESCRIPTION
##### SUMMARY
Added support for client identifiers other than a simple mac address

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_dhcp_lease.ps1

##### ADDITIONAL INFORMATION
As stated in RFC2131, "the 'client identifier' is an opaque key, not to be interpreted by the server; for example, the 'client identifier' may contain a hardware address, identical to the contents of the 'chaddr' field, or it may contain another type of identifier, such as a DNS name.  The 'client identifier' chosen by a DHCP client MUST be unique to that client within the subnet to which the client is attached."

A Windows DHCP server supports client identifiers with at least 2 characters (shorter identifiers will be prefixed with a 0) and allows a maximum length of 510 characters (this seems to be a bug in at least Windows Server 2016 Standard, as the server becomes unstable and crashes, when adding reservations with identifiers longer than 510 characters (without dashes)). Also the number of characters of an identifier has to be an even number, as otherwise Windows truncates the string automatically.

Windows only supports characters from a-f, A-F and 0-9, which imho conflicts with RFC2131, which makes no restrictions regarding the character set.

Currently, the module only supports client identifiers which are 12 or 17 characters long and there is not charset validation implemented. I added support for client identifiers from 2-510 characters long and with a validated charset a-f, A-F and 0-9. I also sanitize strings like MAC addresse (*:*:*...) and notations like (*-*-*...). I convert any strings into the format Windows uses (*-*-*...). 