### PR TITLE
Fix scoop idempotency and Chocolatey issues

### DIFF
--- a/changelogs/fragments/scoop-export.yml
+++ b/changelogs/fragments/scoop-export.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_scoop - Fix idempotency checks with Scoop ``v0.2.3`` and newer.

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -73,7 +73,9 @@ fi
 # TODO: put this in a requirements file
 # Install the depss of this collection
 sudo chown "$(whoami)" "${PWD}/../../"
-retry ansible-galaxy collection install 'ansible.windows' 'chocolatey.chocolatey'
+# Chocolatey 1.3.0 broke compatibiltiy wtih WinPS 3 and 4 so we are stuck with 1.2.0
+# https://github.com/chocolatey/chocolatey-ansible/issues/96
+retry ansible-galaxy collection install 'ansible.windows' 'chocolatey.chocolatey:1.2.0'
 
 export PYTHONIOENCODING='utf-8'
 


### PR DESCRIPTION
##### SUMMARY
Fixes an idempotency issue where `scoop export` now outputs JSON and not the string value it had before. This was a change in v0.2.3 through https://github.com/ScoopInstaller/Scoop/commit/c4d1b9c22f943a810bed7f9f74d7d4d5c42d9a74. The change tries to parse by JSON used by newer versions with the fallback to the old code if it's not JSON.

Also pinned `chocolatey.chocolatey` to `1.2.0` for compatibility with PowerShell 3, and 4 - https://github.com/chocolatey/chocolatey-ansible/issues/96. This can be removed if Chocolatey update their codebase and bring back compatibility to these versions or we drop Server 2012 and 2012 R2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_scoop
