### PR TITLE
new module: win_pending_reboot_info

### DIFF
--- a/plugins/modules/win_pending_reboot_info.ps1
+++ b/plugins/modules/win_pending_reboot_info.ps1
@@ -74,8 +74,14 @@ function Test-WindowsUpdatePR {
         }
     }
 
-    $pending_services = Get-ChildItem -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending'
-    if ($pending_services) {
+    try {
+        $pending_services = Get-ChildItem -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending' -ErrorAction Stop
+    }
+    catch {
+        $pending_services = $null
+    }
+
+    if ($null -ne $pending_services) {
         return $true
     }
 

--- a/plugins/modules/win_pending_reboot_info.ps1
+++ b/plugins/modules/win_pending_reboot_info.ps1
@@ -1,0 +1,209 @@
+#!powershell
+
+# Copyright: (c) 2022, Oleg Galushko (@inorangestylee)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+Set-StrictMode -Version 3.0
+
+$spec = @{
+    options             = @{
+        skip = @{ type = 'list'; elements = 'str'; required = $false; choices = @(
+                'cbs', 'ccm_client', 'computer_rename', 'dsc_lcm', 'dvd_reboot_signal',
+                'file_rename', 'join_domain', 'server_manager', 'windows_update'
+            )
+        }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$skip_list = $module.Params.skip
+
+$module.Result.changed = $false
+
+$checks = @('cbs', 'ccm_client', 'computer_rename', 'dsc_lcm', 'dvd_reboot_signal', 'file_rename', 'join_domain', 'server_manager', 'windows_update')
+
+function Test-ComponentBasedServicingPR {
+    [OutputType([System.Boolean])]
+
+    $test_registry_keys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootInProgress'
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\PackagesPending'
+    )
+
+    forEach ($rk in $test_registry_keys) {
+        if (Test-Path -LiteralPath $rk) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-DscLcmPR {
+    [OutputType([System.Boolean])]
+
+    $result = $false
+    try {
+        $result = (Get-DscLocalConfigurationManager).LcmState -eq 'PendingReboot'
+    }
+    catch [System.Management.Automation.CommandNotFoundException] {
+        $module.Warn('DSC LCM is not available on this system. Check will be skipped')
+    }
+    catch {
+        $module.Warn("Unable to query DSC LCM state: $_")
+    }
+
+    return $result
+}
+function Test-WindowsUpdatePR {
+    [OutputType([System.Boolean])]
+
+    $test_registry_keys = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\PostRebootReporting'
+    )
+
+    forEach ($rk in $test_registry_keys) {
+        $result = Test-Path -LiteralPath $rk
+        if ($result) {
+            return $true
+        }
+    }
+
+    $pending_services = Get-ChildItem -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending'
+    if ($pending_services) {
+        return $true
+    }
+
+    $update_exe_volatile = Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Updates' -Name 'UpdateExeVolatile' -ErrorAction SilentlyContinue
+    if ($null -ne $update_exe_volatile -and $update_exe_volatile.UpdateExeVolatile -gt 0) {
+        return $true
+    }
+
+    return $false
+}
+
+function Test-FileRenamePR {
+    [OutputType([System.Boolean])]
+    $properties = @('PendingFileRenameOperations', 'PendingFileRenameOperations2')
+
+    $file_rename_operations = Get-ItemProperty `
+        -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\' `
+        -Name $properties `
+        -ErrorAction SilentlyContinue
+
+    forEach ($p in $properties) {
+        try {
+            $check = $file_rename_operations.$p
+        }
+        catch {
+            $check = $null
+        }
+
+        if ($null -ne $check) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-ServerManagerPR {
+    [OutputType([System.Boolean])]
+    $result = Test-Path -LiteralPath 'HKLM:\SOFTWARE\Microsoft\ServerManager\CurrentRebootAttempts'
+
+    return $result
+}
+
+function Test-DVDRebootSignal {
+    [OutputType([System.Boolean])]
+    $check = Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' -Name 'DVDRebootSignal' -ErrorAction SilentlyContinue
+    try {
+        $result = $null -ne $check.DVDRebootSignal
+    }
+    catch {
+        return $false
+    }
+
+    return $result
+}
+
+function Test-ComputerRenamePR {
+    [OutputType([System.Boolean])]
+    $actual_computer_name = (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName').ComputerName
+    $pending_computer_name = (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'-Name 'ComputerName').ComputerName
+    $result = $actual_computer_name -ne $pending_computer_name
+
+    return $result
+}
+
+function Test-JoinDomainPR {
+    [OutputType([System.Boolean])]
+    $properties = @('JoinDomain', 'AvoidSpnSet')
+    $netlogon = Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon' -Name $properties -ErrorAction SilentlyContinue
+
+    forEach ($p in $properties) {
+        try {
+            $check = $netlogon.$p
+        }
+        catch {
+            $check = $null
+        }
+
+        if ($null -ne $check) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-CcmClientPR {
+    [OutputType([System.Boolean])]
+    $result = $false
+    try {
+        $cim_result = Invoke-CimMethod -Namespace 'ROOT\ccm\ClientSDK' -ClassName 'CCM_ClientUtilities' -Name 'DetermineIfRebootPending' -ErrorAction Stop
+    }
+    catch {
+        $module.Warn("Unable to query CIM Class CCM_ClientUtilities: $_")
+        $cim_result = $null
+    }
+
+    if ($cim_result) {
+        $result = ($cim_result.ReturnValue -eq 0) -and ($cim_result.IsHardRebootPending -or $cim_result.RebootPending)
+    }
+
+    return $result
+}
+
+$checks_results = [System.Collections.Generic.Dictionary[[System.String], [System.Boolean]]]::new()
+forEach ($c in $checks) {
+    if ($c -in $skip_list) {
+        $checks_results.Add($c, $false)
+        continue
+    }
+
+    switch ($c) {
+        'cbs' { $state = Test-ComponentBasedServicingPR }
+        'ccm_client' { $state = Test-CcmClientPR }
+        'computer_rename' { $state = Test-ComputerRenamePR }
+        'dsc_lcm' { $state = Test-DscLcmPR }
+        'dvd_reboot_signal' { $state = Test-DVDRebootSignal }
+        'file_rename' { $state = Test-FileRenamePR }
+        'join_domain' { $state = Test-JoinDomainPR }
+        'server_manager' { $state = Test-ServerManagerPR }
+        'windows_update' { $state = Test-WindowsUpdatePR }
+    }
+
+    $checks_results.Add($c, $state)
+}
+
+$module.Result.checks = $checks_results
+$module.Result.reboot_required = $checks_results.Values -contains $true
+
+$module.ExitJson()

--- a/plugins/modules/win_pending_reboot_info.ps1
+++ b/plugins/modules/win_pending_reboot_info.ps1
@@ -134,9 +134,9 @@ function Test-DVDRebootSignal {
 
 function Test-ComputerRenamePR {
     [OutputType([System.Boolean])]
-    $actual_computer_name = Get-ItemPropertyValue -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName'
-    $pending_computer_name = Get-ItemPropertyValue -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'-Name 'ComputerName'
-    $result = $actual_computer_name -ne $pending_computer_name
+    $actual_computer_name = Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName'
+    $pending_computer_name = Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'-Name 'ComputerName'
+    $result = $actual_computer_name.ComputerName -ne $pending_computer_name.ComputerName
 
     return $result
 }

--- a/plugins/modules/win_pending_reboot_info.ps1
+++ b/plugins/modules/win_pending_reboot_info.ps1
@@ -8,10 +8,9 @@
 Set-StrictMode -Version 3.0
 
 $spec = @{
-    options             = @{
+    options = @{
         skip = @{ type = 'list'; elements = 'str'; required = $false; choices = @(
-                'cbs', 'ccm_client', 'computer_rename', 'dsc_lcm', 'dvd_reboot_signal',
-                'file_rename', 'join_domain', 'server_manager', 'windows_update'
+                'cbs', 'ccm_client', 'computer_rename', 'dsc_lcm', 'dvd_reboot_signal', 'file_rename', 'join_domain', 'server_manager', 'windows_update'
             )
         }
     }
@@ -135,8 +134,8 @@ function Test-DVDRebootSignal {
 
 function Test-ComputerRenamePR {
     [OutputType([System.Boolean])]
-    $actual_computer_name = (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName').ComputerName
-    $pending_computer_name = (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'-Name 'ComputerName').ComputerName
+    $actual_computer_name = Get-ItemPropertyValue -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName'
+    $pending_computer_name = Get-ItemPropertyValue -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'-Name 'ComputerName'
     $result = $actual_computer_name -ne $pending_computer_name
 
     return $result
@@ -181,7 +180,7 @@ function Test-CcmClientPR {
     return $result
 }
 
-$checks_results = [System.Collections.Generic.Dictionary[[System.String], [System.Boolean]]]::new()
+$checks_results = [ordered]@{}
 forEach ($c in $checks) {
     if ($c -in $skip_list) {
         $checks_results.Add($c, $false)

--- a/plugins/modules/win_pending_reboot_info.py
+++ b/plugins/modules/win_pending_reboot_info.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Oleg Galushko (@inorangestylee)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_pending_reboot_info
+short_description: Gather information about pending reboot state
+version_added: '1.12.0'
+description:
+- Gather information about pending reboot state.
+options:
+  skip:
+    description:
+    - List of checks that will be skipped during execution. Skipped check returns C(false)
+    type: list
+    elements: str
+    required: false
+    choices:
+    - cbs
+    - ccm_client
+    - computer_rename
+    - dsc_lcm
+    - dvd_reboot_signal
+    - file_rename
+    - join_domain
+    - server_manager
+    - windows_update
+seealso:
+- module: ansible.windows.win_reboot
+- name: Powershell PendingReboot module by Brian Wilhite
+  description: Powershell PendingReboot module by Brian Wilhite
+  link: https://github.com/bcwilhite/PendingReboot/
+- name: How to Check for a Pending Reboot in the Registry (Windows)
+  description: Article about pending reboot flags
+  link: https://adamtheautomator.com/pending-reboot-registry/
+notes:
+- C(file_rename) check can be a false positive, because this registry property is used by antivirus programs.
+  Recommended to add C(file_rename) to the C(skip) list to avoid false positives.
+- Using the C(ccm_client) check can only be successful if target host have the CCM client installed
+  in other cases it is recommended to add C(ccm_client) check to the C(skip) list.
+author:
+- Oleg Galushko (@inorangestylee)
+'''
+
+EXAMPLES = r'''
+- name: Get pending reboot state
+  community.windows.win_pending_reboot_info:
+  register: pending_reboot_info
+
+- name: Get pending reboot state (skip ccm client and file_rename)
+  community.windows.win_pending_reboot_info:
+    skip:
+    - ccm_client
+    - file_rename
+  register: pending_reboot_info2
+
+- name: Reboot server if pending
+  ansible.windows.win_reboot:
+  when: pending_reboot_info.reboot_required
+'''
+
+RETURN = r'''
+checks:
+    description:
+    - a dict of pending reboot checks.
+    returned: always
+    type: dict
+    sample:
+      cbs: false
+      ccm_client: false
+      computer_rename: false
+      dsc_lcm: false
+      dvd_reboot_signal: false
+      file_rename: true
+      join_domain: false
+      server_manager: true
+      windows_update: false
+reboot_required:
+    description:
+    - Overall result of checks. If one of checks is C(true) this value will also be C(true)
+    returned: always
+    type: bool
+    sample: false
+'''

--- a/tests/integration/targets/win_pending_reboot_info/aliases
+++ b/tests/integration/targets/win_pending_reboot_info/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group5

--- a/tests/integration/targets/win_pending_reboot_info/tasks/main.yml
+++ b/tests/integration/targets/win_pending_reboot_info/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- name: Get current pending reboot states
+  ansible.windows.win_powershell:
+    script: |
+      Set-StrictMode -Off
+      $cbs_state = (
+          (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') -or
+          (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootInProgress') -or
+          (Test-Path -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\PackagesPending')
+      )
+
+      $dsc_lcm_state = $false
+      try {
+          $dsc_lcm_state = (Get-DscLocalConfigurationManager).LcmState -eq 'PendingReboot'
+      }
+      catch {}
+
+      $wu_state = (
+          [bool](Get-ChildItem -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending') -or
+          (((Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Updates' -Name 'UpdateExeVolatile' -ErrorAction SilentlyContinue).UpdateExeVolatile) -gt 0)
+      )
+
+      $fro_state = (
+          ($null -ne (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\' -Name 'PendingFileRenameOperations' -ErrorAction SilentlyContinue).PendingFileRenameOperations) -or
+          ($null -ne (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\' -Name 'PendingFileRenameOperations2' -ErrorAction SilentlyContinue).PendingFileRenameOperations2)
+      )
+
+      $sm_state = Test-Path -LiteralPath 'HKLM:\SOFTWARE\Microsoft\ServerManager\CurrentRebootAttempts'
+
+      $dvd_state = $null -ne (Get-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce' -Name 'DVDRebootSignal' -ErrorAction SilentlyContinue).DVDRebootSignal
+
+      $rename_state = (
+          (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' -Name 'ComputerName').ComputerName -ne
+          (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'-Name 'ComputerName').ComputerName
+      )
+
+      $domjoin_state = (
+          ($null -ne (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon').JoinDomain) -or
+          ($null -ne (Get-ItemProperty -LiteralPath 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon').AvoidSpnSet)
+      )
+
+      $ccm_state = $(
+          $cim_req = Invoke-CimMethod -Namespace 'ROOT\ccm\ClientSDK' -ClassName 'CCM_ClientUtilities' -Name 'DetermineIfRebootPending' -ErrorAction SilentlyContinue
+          $(($cim_req.ReturnValue -eq 0) -and ($cim_req.IsHardRebootPending -or $cim_req.RebootPending))
+      )
+
+      $overall_state = $cbs_state -or $dsc_lcm_state -or $wu_state -or $fro_state -or $sm_state -or $dvd_state -or $rename_state -or $domjoin_state -or $ccm_state
+
+      $Ansible.Result = @{
+        cbs = $cbs_state
+        dsc_lcm = $dsc_lcm_state
+        windows_update = $wu_state
+        file_rename = $fro_state
+        server_manager = $sm_state
+        dvd_reboot_signal = $dvd_state
+        computer_rename = $rename_state
+        join_domain = $domjoin_state
+        ccm_client = $ccm_state
+        reboot_required = $overall_state
+      }
+  changed_when: false
+  register: actual_checks
+
+
+- name: Get current pending reboot with module
+  community.windows.win_pending_reboot_info:
+  register: module_checks
+
+- name: assetion
+  ansible.builtin.assert:
+    that:
+    - module_checks.checks.cbs == actual_checks.result.cbs
+    - module_checks.checks.dsc_lcm == actual_checks.result.dsc_lcm
+    - module_checks.checks.windows_update == actual_checks.result.windows_update
+    - module_checks.checks.file_rename == actual_checks.result.file_rename
+    - module_checks.checks.server_manager == actual_checks.result.server_manager
+    - module_checks.checks.dvd_reboot_signal == actual_checks.result.dvd_reboot_signal
+    - module_checks.checks.computer_rename == actual_checks.result.computer_rename
+    - module_checks.checks.join_domain == actual_checks.result.join_domain
+    - module_checks.checks.ccm_client == actual_checks.result.ccm_client
+    - module_checks.reboot_required == actual_checks.result.reboot_required


### PR DESCRIPTION
##### SUMMARY
Module for getting information about pending reboots. 

The idea is not fresh and exists in different implementations:
- [xPendingReboot](https://github.com/dsccommunity/xPendingReboot) DSC Resource
- [PendingReboot](https://github.com/bcwilhite/PendingReboot/) Powershell Module
- [Get-ServerRebootPending.ps1](https://github.com/microsoft/CSS-Exchange/blob/main/Shared/Get-ServerRebootPending.ps1) in Exchange server support scripts 

This implementation was made possible because I wanted something native to Ansible and the possibility of using it alongside the win_reboot module. This partially covers my case described in [ansible.windows/issues/182](https://github.com/ansible-collections/ansible.windows/issues/182)

How it works:
The module checks for well-known pending reboot flags and outputs the result.

The following checks are now supported:
- component-based maintenance
- CCM client
- pending computer renaming
- DSC LCM
- DVD reload signal
- pending file renaming
- pending domain join
- server manager
- windows update

By default all checks are enabled, but some of them can be disabled using the `skip` list.  For example you can disable the check of the CCM Client if it is not used in your environment. `skip` is only one option for this module.

The output is a dictionary with checks and their results (true/false) and a reboot_required key with the overall result (if at least one of the checks is true, the result is true)

Example:
```
test-host1 | SUCCESS => {
    "changed": false,
    "checks": {
        "cbs": false,
        "ccm_client": false,
        "computer_rename": false,
        "dsc_lcm": false,
        "dvd_reboot_signal": false,
        "file_rename": true,
        "join_domain": false,
        "server_manager": false,
        "windows_update": false
    },
    "reboot_required": true
}
```

You can register return value and use it later for `when` condition for `win_reboot` for example.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME
win_pending_reboot_info.ps1

##### ADDITIONAL INFORMATION
https://docs.microsoft.com/en-us/powershell/scripting/dsc/configurations/reboot-a-node?view=powershell-7.1
https://adamtheautomator.com/pending-reboot-registry-windows/