### PR TITLE
Fix CNAME creation in win_dns_record

### DIFF
--- a/changelogs/fragments/452-win_dns_record-cname.yml
+++ b/changelogs/fragments/452-win_dns_record-cname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_dns_record - Fix CNAME creation in subdomains - https://github.com/ansible-collections/community.windows/issues/429

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -32,6 +32,7 @@ $values = $module.Params.value
 $weight = $module.Params.weight
 $zone = $module.Params.zone
 $dns_computer_name = $module.Params.computer_name
+# If you add additional arguments, check that they are supported by all modules (Add-DnsServerResourceRecordCName and Add-DnsServerResourceRecord).
 $extra_args = @{}
 if ($null -ne $dns_computer_name) {
     $extra_args.ComputerName = $dns_computer_name
@@ -156,7 +157,7 @@ if ($null -ne $values -and $values.Count -gt 0) {
                 Add-DnsServerResourceRecord -TXT -Name $name -DescriptiveText $value -ZoneName $zone -TimeToLive $ttl @extra_args -WhatIf:$module.CheckMode
             }
             elseif ($type -eq 'CNAME') {
-                Add-DnsServerResourceRecordCName -Name $name -HostNameAlias $value -ZoneName $zone -TimeToLive $ttl -WhatIf:$module.CheckMode
+                Add-DnsServerResourceRecordCName -Name $name -HostNameAlias $value -ZoneName $zone -TimeToLive $ttl @extra_args -WhatIf:$module.CheckMode
             }
             else {
                 Add-DnsServerResourceRecord -Name $name -AllowUpdateAny -ZoneName $zone -TimeToLive $ttl @splat_args -WhatIf:$module.CheckMode @extra_args

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -150,10 +150,13 @@ if ($null -ne $values -and $values.Count -gt 0) {
         }
         try {
             if ($type -eq 'SRV') {
-                Add-DnsServerResourceRecord -SRV -Name $name  -ZoneName $zone @srv_args @extra_args -WhatIf:$module.CheckMode
+                Add-DnsServerResourceRecord -SRV -Name $name -ZoneName $zone @srv_args @extra_args -WhatIf:$module.CheckMode
             }
             elseif ($type -eq 'TXT') {
                 Add-DnsServerResourceRecord -TXT -Name $name -DescriptiveText $value -ZoneName $zone -TimeToLive $ttl @extra_args -WhatIf:$module.CheckMode
+            }
+            elseif ($type -eq 'CNAME') {
+                Add-DnsServerResourceRecordCName -Name $name -HostNameAlias $value -ZoneName $zone -TimeToLive $ttl -WhatIf:$module.CheckMode
             }
             else {
                 Add-DnsServerResourceRecord -Name $name -AllowUpdateAny -ZoneName $zone -TimeToLive $ttl @splat_args -WhatIf:$module.CheckMode @extra_args


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As suggested in https://github.com/ansible-collections/community.windows/issues/429, I have added a case to handle CNAME creation when the cname is part of a subdomain.
This is my first contribution and I am not used to the contribution process, so I am sorry if this is not the right way to submit fixes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #429

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_dns_record

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If this fix is accepted, the documentation should be updated with instructions for creating aliases in subdomains.
Unfortunately, I didn't find where I could update the documentation in this repository.
The following task could be included in the examples on the documentation page :
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create the alias helloworld.test.example.com pointing to myserver.example.com
    community.windows.win_dns_record:
      name: "helloworld.test"
      type: "CNAME"
      value: "myserver.example.com"
      zone: "example.com"
```
