### PR TITLE
Added ignore revs file for tracking commits with bulk sanity changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# Bulk PowerShell sanity fixes PSSA 1.20.0
+08257cb1863b0c61d80c4a407fef9a9e5d6a8e0b
+# Bulk PowerShell sanity fixes PSSA 1.21.0
+47d3207f1004b8b0023ab29ef23e0677bfa9405e


### PR DESCRIPTION
##### SUMMARY
The changes referenced in the file had some bulk sanity changes which we want to ignore from displaying in the blame. GitHub supports using this file in it's UI and it can also be used by the `git blame` CLI.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Git stuff