### PR TITLE
Add vscode powershell format rule for semicolons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
     "python.analysis.extraPaths": [
         "${workspaceFolder}/../../../",
     ],
-
     "powershell.codeFormatting.addWhitespaceAroundPipe": true,
     "powershell.codeFormatting.alignPropertyValuePairs": false,
     "powershell.codeFormatting.autoCorrectAliases": true,
@@ -23,6 +22,7 @@
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": true,
     "powershell.codeFormatting.whitespaceInsideBrace": true,
+    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
     "powershell.scriptAnalysis.enable": true,
     "[powershell]": {
         "editor.formatOnSave": true,


### PR DESCRIPTION
##### SUMMARY
Have VSCode automatically remove semicolons at the end of the line in save. This aligns with the new rules added to PSScriptAnalyzer.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vscode