### PR TITLE
fix win_partition auto assign next free letter

### DIFF
--- a/changelogs/fragments/463-fix_win_partition_auto_assign.yaml
+++ b/changelogs/fragments/463-fix_win_partition_auto_assign.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_partition - fix problem in auto assigning a drive letter should the user use either a, u, t or o as a drive letter

--- a/plugins/modules/win_partition.ps1
+++ b/plugins/modules/win_partition.ps1
@@ -98,7 +98,7 @@ if ($null -ne $disk_number -and $null -ne $partition_number) {
     $ansible_partition = Get-Partition -DiskNumber $disk_number -PartitionNumber $partition_number -ErrorAction SilentlyContinue
 }
 # Check if drive_letter is either auto-assigned or a character from A-Z
-elseif ($drive_letter -and $drive_letter -ne "auto" -and -not ($disk_number -and $partition_number)) { 
+elseif ($drive_letter -and $drive_letter -ne "auto" -and -not ($disk_number -and $partition_number)) {
     if ($drive_letter -match "^[a-zA-Z]$") {
         $ansible_partition = Get-Partition -DriveLetter $drive_letter -ErrorAction SilentlyContinue
     }

--- a/plugins/modules/win_partition.ps1
+++ b/plugins/modules/win_partition.ps1
@@ -98,8 +98,8 @@ if ($null -ne $disk_number -and $null -ne $partition_number) {
     $ansible_partition = Get-Partition -DiskNumber $disk_number -PartitionNumber $partition_number -ErrorAction SilentlyContinue
 }
 # Check if drive_letter is either auto-assigned or a character from A-Z
-elseif ($drive_letter -and -not ($disk_number -and $partition_number)) {
-    if ($drive_letter -eq "auto" -or $drive_letter -match "^[a-zA-Z]$") {
+elseif ($drive_letter -and $drive_letter -ne "auto" -and -not ($disk_number -and $partition_number)) { 
+    if ($drive_letter -match "^[a-zA-Z]$") {
         $ansible_partition = Get-Partition -DriveLetter $drive_letter -ErrorAction SilentlyContinue
     }
     else {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

According to the documentation you can automatically assign a drive letter when you specify the keyword "auto".
The code is a bit problematic in cases where your server or pc has a partition with an assigned drive letter of either a, u, t or o.

This fixes the problem.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module: win_partition.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
