### PR TITLE
win_dns_record: CNAME: remove unneeded special case

### DIFF
--- a/changelogs/fragments/452-win_dns_record-cname.yml
+++ b/changelogs/fragments/452-win_dns_record-cname.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - win_dns_record - Fix CNAME creation in subdomains - https://github.com/ansible-collections/community.windows/issues/429

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -32,7 +32,6 @@ $values = $module.Params.value
 $weight = $module.Params.weight
 $zone = $module.Params.zone
 $dns_computer_name = $module.Params.computer_name
-# If you add additional arguments, check that they are supported by all modules (Add-DnsServerResourceRecordCName and Add-DnsServerResourceRecord).
 $extra_args = @{}
 if ($null -ne $dns_computer_name) {
     $extra_args.ComputerName = $dns_computer_name
@@ -155,9 +154,6 @@ if ($null -ne $values -and $values.Count -gt 0) {
             }
             elseif ($type -eq 'TXT') {
                 Add-DnsServerResourceRecord -TXT -Name $name -DescriptiveText $value -ZoneName $zone -TimeToLive $ttl @extra_args -WhatIf:$module.CheckMode
-            }
-            elseif ($type -eq 'CNAME') {
-                Add-DnsServerResourceRecordCName -Name $name -HostNameAlias $value -ZoneName $zone -TimeToLive $ttl @extra_args -WhatIf:$module.CheckMode
             }
             else {
                 Add-DnsServerResourceRecord -Name $name -AllowUpdateAny -ZoneName $zone -TimeToLive $ttl @splat_args -WhatIf:$module.CheckMode @extra_args

--- a/tests/integration/targets/win_dns_record/tasks/tests-CNAME.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-CNAME.yml
@@ -184,3 +184,22 @@
     that:
       - cmd_result is not changed
       - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: Issue 429 - creation
+  win_dns_record:
+    name: helloworld.test
+    type: CNAME
+    value: myserver.example.com
+    zone: "{{ win_dns_record_zone }}"
+  register: cmd_result
+
+- name: Issue 429 - get results
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'helloworld.test' -RRType CNAME -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: Issue 429 - creation check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'myserver.example.com.\r\n'


### PR DESCRIPTION
The special case for CNAME records added in #452 is not needed.