### PR TITLE
✨ add display_name field to win_domain_user (#477)

### DIFF
--- a/changelogs/fragments/win_domain_user-display_name.yml
+++ b/changelogs/fragments/win_domain_user-display_name.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_domain_user - Added the ``display_name`` option to set the users display name attribute

--- a/plugins/modules/win_domain_user.ps1
+++ b/plugins/modules/win_domain_user.ps1
@@ -96,6 +96,7 @@ $spec = @{
         identity = @{ type = 'str' }
         firstname = @{ type = 'str' }
         surname = @{ type = 'str'; aliases = @('lastname') }
+        display_name = @{ type = 'str' }
         company = @{ type = 'str' }
         email = @{ type = 'str' }
         street = @{ type = 'str' }
@@ -170,6 +171,7 @@ if ($null -eq $identity) {
 $user_info = @{
     GivenName = $module.Params.firstname
     Surname = $module.Params.surname
+    DisplayName = $module.Params.display_name
     Company = $module.Params.company
     EmailAddress = $module.Params.email
     StreetAddress = $module.Params.street
@@ -529,6 +531,7 @@ If ($user_obj) {
     $module.Result.name = $user_obj.Name
     $module.Result.firstname = $user_obj.GivenName
     $module.Result.surname = $user_obj.Surname
+    $module.Result.display_name = $user_obj.DisplayName
     $module.Result.enabled = $user_obj.Enabled
     $module.Result.company = $user_obj.Company
     $module.Result.street = $user_obj.StreetAddress

--- a/plugins/modules/win_domain_user.py
+++ b/plugins/modules/win_domain_user.py
@@ -140,6 +140,7 @@ options:
     description:
       - Configures the user's display name.
     type: str
+    version_added: 1.12.0
   company:
     description:
       - Configures the user's company name.

--- a/plugins/modules/win_domain_user.py
+++ b/plugins/modules/win_domain_user.py
@@ -136,6 +136,10 @@ options:
       - Configures the user's last name (surname).
     type: str
     aliases: [ lastname ]
+  display_name:
+    description:
+      - Configures the user's display name.
+    type: str
   company:
     description:
       - Configures the user's company name.
@@ -251,6 +255,7 @@ EXAMPLES = r'''
     name: bob
     firstname: Bob
     surname: Smith
+    display_name: Mr. Bob Smith
     company: BobCo
     password: B0bP4ssw0rd
     state: present
@@ -359,6 +364,11 @@ description:
     returned: always
     type: str
     sample: Server Administrator
+display_name:
+    description: The user display name
+    returned: always
+    type: str
+    sample: Nick Doe
 distinguished_name:
     description: DN of the user account
     returned: always

--- a/tests/integration/targets/win_domain_user/tasks/test2.yml
+++ b/tests/integration/targets/win_domain_user/tasks/test2.yml
@@ -5,6 +5,7 @@
     upn: hana@ansible.test
     firstname: Hana
     surname: Lytx
+    display_name: Hana Lytx
     company: HelpMeExitVi Inc.
     password: 123
     state: present
@@ -28,6 +29,7 @@
     upn: hana@ansible.test
     firstname: Hana
     surname: Lytx
+    display_name: Hana Lytx
     company: HelpMeExitVi Inc.
     password: h@nAlyTx18!X
     state: present
@@ -50,6 +52,7 @@
     name: katie
     firstname: Katie
     surname: Kickscancer
+    display_name: Katie Kickscancer
     password: SyNs@tI0N
     update_password: on_create
     state: present
@@ -66,6 +69,7 @@
     name: katie
     firstname: Katie
     surname: Kickscancer
+    display_name: Katie Kickscancer
     password: SyNs@tI0N
     update_password: on_create
     state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #477 by adding the `display_name` field to `win_domain_user`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
