### PR TITLE
win_xml: Prevent issue when no childnode is defined

### DIFF
--- a/changelogs/fragments/482-win_xml-no-childnode.yml
+++ b/changelogs/fragments/482-win_xml-no-childnode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_xml - Fixes the issue when no childnode is defined and will allow adding a new element to an empty element.

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -191,7 +191,15 @@ if ($type -eq "element") {
             if ($node.get_NodeType() -eq "Document") {
                 $node = $node.get_DocumentElement()
             }
-            $elements = $node.get_ChildNodes()
+            
+            if ($node.ChildNodes.Count -eq 0) {
+                $elements = @()
+                $elements += $node
+            }
+            else {
+                $elements = $node.get_ChildNodes()
+            }
+
             [bool]$present = $false
             [bool]$changed = $false
             if ($elements.get_Count()) {

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -191,7 +191,7 @@ if ($type -eq "element") {
             if ($node.get_NodeType() -eq "Document") {
                 $node = $node.get_DocumentElement()
             }
-            
+
             if ($node.ChildNodes.Count -eq 0) {
                 $elements = @()
                 $elements += $node

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -193,8 +193,7 @@ if ($type -eq "element") {
             }
 
             if ($node.ChildNodes.Count -eq 0) {
-                $elements = @()
-                $elements += $node
+                $elements = @($node)
             }
             else {
                 $elements = $node.get_ChildNodes()

--- a/tests/integration/targets/win_xml/files/config.xml
+++ b/tests/integration/targets/win_xml/files/config.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
   <string key="foo">bar</string>
+  <setting></setting>
 </config>

--- a/tests/integration/targets/win_xml/tasks/main.yml
+++ b/tests/integration/targets/win_xml/tasks/main.yml
@@ -100,6 +100,32 @@
     that:
     - not element_add_attribute_result_second is changed
 
+- name: try to add a new element in empty element
+  win_xml:
+    path: "{{ remote_tmp_dir }}\\config.xml"
+    xpath: '/config/setting'
+    fragment: "<property />"
+    type: element
+  register: element_add_empty_element
+
+- name: check element add in empty element result
+  assert:
+    that:
+    - element_add_empty_element is changed
+
+- name: try to add a new element in empty element again
+  win_xml:
+    path: "{{ remote_tmp_dir }}\\config.xml"
+    xpath: '/config/setting'
+    fragment: "<property />"
+    type: element
+  register: element_add_empty_element_second
+
+- name: check element add in empty element result
+  assert:
+    that:
+    - not element_add_empty_element_second is changed
+
 # This testing is for https://github.com/ansible/ansible/issues/48471
 # The issue was that an .xml with no encoding declaration, but a UTF8 BOM
 # with some UTF-8 characters was being written out with garbage characters.


### PR DESCRIPTION
##### SUMMARY
It is not possible to add a new element to an empty element. To prevent this I have added logic to add an element when the node does not contain any childnodes. Please take a look at the additional information for more details and examples.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_xml

##### ADDITIONAL INFORMATION
My goal was to add a simple httpRedirect configuration in an existing web.config of an IIS server. In my example, I only had an empty configuration as by base XML.

Playbook:
```YAML
- name: Create httpRedirect
  win_xml:
    path: C:\inetpub\wwwroot\web.config
    xpath: "/configuration/system.webServer"
    fragment: "<httpRedirect />"
```
Base XML:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <system.webServer>
  </system.webServer>
</configuration>
```

In this example, no changes are made. When adjusting the XML by adding a text element:

Base XML:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <system.webServer>
    example
  </system.webServer>
</configuration>
```

Result XML:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <system.webServer>
    example
  <httpRedirect /></system.webServer>
</configuration>
```

Behavior when using the pull request adjustment:

Base XML:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <system.webServer>
  </system.webServer>
</configuration>
```

Result:
```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <system.webServer>
    <httpRedirect />
  </system.webServer>
</configuration>
```

Tested this in two separate environments on both Windows Server 2019 and Windows Server 2022 with the ansible versions: 
2.10.17 & 2.13.7