### PR TITLE
win_pssession_configuration: Fix parser error + add diff mode support

### DIFF
--- a/changelogs/fragments/491-win_pssession_configuration.yml
+++ b/changelogs/fragments/491-win_pssession_configuration.yml
@@ -1,4 +1,4 @@
 bugfixes:
-- win_pssession_configuration - Fix parser error (Invalid JSON primitive: icrosoft.WSMan.Management.WSManConfigContainerElement)
+- 'win_pssession_configuration - Fix parser error (Invalid JSON primitive: icrosoft.WSMan.Management.WSManConfigContainerElement)'
 minor_changes:
 - win_pssession_configuration - Add diff mode support

--- a/changelogs/fragments/491-win_pssession_configuration.yml
+++ b/changelogs/fragments/491-win_pssession_configuration.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- win_pssession_configuration - Fix parser error (Invalid JSON primitive: icrosoft.WSMan.Management.WSManConfigContainerElement)
+minor_changes:
+- win_pssession_configuration - Add diff mode support

--- a/plugins/modules/win_pssession_configuration.ps1
+++ b/plugins/modules/win_pssession_configuration.ps1
@@ -515,7 +515,7 @@ try {
     if (-not $module.CheckMode) {
         if ($remove) {
             # Wait-WinRMConnection
-            Unregister-PSSessionConfiguration -Name $opt_session.Name
+            $null = Unregister-PSSessionConfiguration -Name $opt_session.Name
         }
 
         if ($create) {
@@ -528,7 +528,7 @@ try {
         elseif ($session_change) {
             $psso = $opt_session
             # Wait-WinRMConnection
-            Set-PSSessionConfiguration @psso
+            $null = Set-PSSessionConfiguration @psso
         }
     }
 }

--- a/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
+++ b/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
@@ -356,57 +356,60 @@
 
 #######
 
-- name: Create a complex configuration
-  win_pssession_configuration:
-    name: "{{ config_name }}"
-    description: "{{ config_description }}"
-    modules_to_import: Microsoft.PowerShell.Utility
-    visible_aliases: []
-    visible_cmdlets: []
-    visible_external_commands: []
-    visible_functions: []
-    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
-  register: status
+- name: complex configuration for pwsh 5.1+
+  when: when: ansible_powershell_version > 4
+  block:
+  - name: Create a complex configuration
+    win_pssession_configuration:
+      name: "{{ config_name }}"
+      description: "{{ config_description }}"
+      modules_to_import: Microsoft.PowerShell.Utility
+      visible_aliases: []
+      visible_cmdlets: []
+      visible_external_commands: []
+      visible_functions: []
+      security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
+    register: status
 
-- name: Check for changed status
-  assert:
-    that: status is changed
-    quiet: yes
+  - name: Check for changed status
+    assert:
+      that: status is changed
+      quiet: yes
 
-- name: Create a complex configuration again (check)
-  win_pssession_configuration:
-    name: "{{ config_name }}"
-    description: "{{ config_description }}"
-    modules_to_import: Microsoft.PowerShell.Utility
-    visible_aliases: []
-    visible_cmdlets: []
-    visible_external_commands: []
-    visible_functions: []
-    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
-  register: status
-  check_mode: yes
+  - name: Create a complex configuration again (check)
+    win_pssession_configuration:
+      name: "{{ config_name }}"
+      description: "{{ config_description }}"
+      modules_to_import: Microsoft.PowerShell.Utility
+      visible_aliases: []
+      visible_cmdlets: []
+      visible_external_commands: []
+      visible_functions: []
+      security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
+    register: status
+    check_mode: yes
 
-- name: Check for unchanged status
-  assert:
-    that: status is not changed
-    quiet: yes
+  - name: Check for unchanged status
+    assert:
+      that: status is not changed
+      quiet: yes
 
-- name: Create a complex configuration again
-  win_pssession_configuration:
-    name: "{{ config_name }}"
-    description: "{{ config_description }}"
-    modules_to_import: Microsoft.PowerShell.Utility
-    visible_aliases: []
-    visible_cmdlets: []
-    visible_external_commands: []
-    visible_functions: []
-    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
-  register: status
+  - name: Create a complex configuration again
+    win_pssession_configuration:
+      name: "{{ config_name }}"
+      description: "{{ config_description }}"
+      modules_to_import: Microsoft.PowerShell.Utility
+      visible_aliases: []
+      visible_cmdlets: []
+      visible_external_commands: []
+      visible_functions: []
+      security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
+    register: status
 
-- name: Check for unchanged status
-  assert:
-    that: status is not changed
-    quiet: yes
+  - name: Check for unchanged status
+    assert:
+      that: status is not changed
+      quiet: yes
 
 #######
 

--- a/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
+++ b/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
@@ -357,7 +357,7 @@
 #######
 
 - name: complex configuration for pwsh 5.1+
-  when: when: ansible_powershell_version > 4
+  when: ansible_powershell_version > 4
   block:
   - name: Create a complex configuration
     win_pssession_configuration:

--- a/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
+++ b/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
@@ -356,6 +356,60 @@
 
 #######
 
+- name: Create a complex configuration
+  win_pssession_configuration:
+    name: "{{ config_name }}"
+    description: "{{ config_description }}"
+    modules_to_import: Microsoft.PowerShell.Utility
+    visible_aliases: []
+    visible_cmdlets: []
+    visible_external_commands: []
+    visible_functions: []
+    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
+  register: status
+
+- name: Check for changed status
+  assert:
+    that: status is changed
+    quiet: yes
+
+- name: Create a complex configuration again (check)
+  win_pssession_configuration:
+    name: "{{ config_name }}"
+    description: "{{ config_description }}"
+    modules_to_import: Microsoft.PowerShell.Utility
+    visible_aliases: []
+    visible_cmdlets: []
+    visible_external_commands: []
+    visible_functions: []
+    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
+  register: status
+  check_mode: yes
+
+- name: Check for unchanged status
+  assert:
+    that: status is not changed
+    quiet: yes
+
+- name: Create a complex configuration again
+  win_pssession_configuration:
+    name: "{{ config_name }}"
+    description: "{{ config_description }}"
+    modules_to_import: Microsoft.PowerShell.Utility
+    visible_aliases: []
+    visible_cmdlets: []
+    visible_external_commands: []
+    visible_functions: []
+    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
+  register: status
+
+- name: Check for unchanged status
+  assert:
+    that: status is not changed
+    quiet: yes
+
+#######
+
 - name: Test session configuration removal (check)
   win_pssession_configuration:
     name: "{{ config_name }}"


### PR DESCRIPTION
##### SUMMARY
`win_pssession_configuration` throws errors if changes are applies to a PS Session Configuration that contains JEA features.
It's a plugin result parsing error due to some outputs that are not piped into the void (aka `null`), looking like this:

```
failed to parse module output: Invalid JSON primitive: icrosoft.WSMan.Management.WSManConfigContainerElement.
```

Diff mode support was added for this plugin too.
It only works for changes and does not contain any info if the session is not created yet.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_pssession_configuration

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook:
```
- name: "Create a configuration with JEA features"
  win_pssession_configuration:
    name: "{{ config_name }}"
    description: "{{ config_description }}"
    modules_to_import: Microsoft.PowerShell.Utility
    visible_aliases: []
    visible_cmdlets: []
    visible_external_commands: []
    visible_functions: []
    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
  register: status

- name: "Update configuration, use same parameters as above"
  win_pssession_configuration:
    name: "{{ config_name }}"
    description: "{{ config_description }}"
    modules_to_import: Microsoft.PowerShell.Utility
    visible_aliases: []
    visible_cmdlets: []
    visible_external_commands: []
    visible_functions: []
    security_descriptor_sddl: "O:NSG:BAD:P(A;;GA;;;IU)(A;;GA;;;BA)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"
  register: status
```

Output:
```
TASK [Create a configuration with JEA features] *************************************************************************************************************
changed

TASK [Update configuration, use same parameters as above] ***************************************************************************************************
FAILED! => {"msg": "failed to parse module output: Invalid JSON primitive: icrosoft.WSMan.Management.WSManConfigContainerElement."}

WINRM RESULT '<Response code 0, out "{"ansible_async_watc", err "#< CLIXML\r\n<Objs Ver">'
Async Job Status: {'ansible_async_watchdog_pid': 123, 'stdout': '{"changed":true,"invocation":{...}}\r\n\r\nMicrosoft.WSMan.Management.WSManConfigContainerElement\r\n', 'finished': 1, 'stderr': '', 'started': 1, 'failed': True, 'msg': 'failed to parse module output: Invalid JSON primitive: icrosoft.WSMan.Management.WSManConfigContainerElement.', 'changed': False, '_ansible_parsed': True, 'stdout_lines': ['{"changed":true,"invocation":{...}}', '', 'Microsoft.WSMan.Management.WSManConfigContainerElement'], 'stderr_lines': []} 
```
