### PR TITLE
Fix win_zip backslash issue

### DIFF
--- a/changelogs/fragments/442-win_zip-backslash.yml
+++ b/changelogs/fragments/442-win_zip-backslash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_zip - fix source appears to use backslashes as path separators issue when extracting Zip archve in non-Windows environment - https://github.com/ansible-collections/community.windows/issues/442

--- a/plugins/modules/win_zip.ps1
+++ b/plugins/modules/win_zip.ps1
@@ -53,7 +53,7 @@ catch {
 Function Compress-Zip($src, $dest) {
     # Disable using backslash for Zip path. This works for .NET 4.6.1 or later
     [System.AppContext]::SetSwitch('Switch.System.IO.Compression.ZipFile.UseBackslash', $false)
-    
+
     If (-not $module.CheckMode) {
         If (Test-Path -LiteralPath $src -PathType Container) {
             [System.IO.Compression.ZipFile]::CreateFromDirectory($src, $dest, $compressionLevel, (-not $srcWildcard), $encoding)

--- a/plugins/modules/win_zip.ps1
+++ b/plugins/modules/win_zip.ps1
@@ -52,7 +52,9 @@ catch {
 
 Function Compress-Zip($src, $dest) {
     # Disable using backslash for Zip path. This works for .NET 4.6.1 or later
-    [System.AppContext]::SetSwitch('Switch.System.IO.Compression.ZipFile.UseBackslash', $false)
+    if ([object].Assembly.GetType("System.AppContext")) {
+        [System.AppContext]::SetSwitch('Switch.System.IO.Compression.ZipFile.UseBackslash', $false)
+    }
 
     If (-not $module.CheckMode) {
         If (Test-Path -LiteralPath $src -PathType Container) {

--- a/plugins/modules/win_zip.ps1
+++ b/plugins/modules/win_zip.ps1
@@ -51,6 +51,9 @@ catch {
 }
 
 Function Compress-Zip($src, $dest) {
+    # Disable using backslash for Zip path. This works for .NET 4.6.1 or later
+    [System.AppContext]::SetSwitch('Switch.System.IO.Compression.ZipFile.UseBackslash', $false)
+    
     If (-not $module.CheckMode) {
         If (Test-Path -LiteralPath $src -PathType Container) {
             [System.IO.Compression.ZipFile]::CreateFromDirectory($src, $dest, $compressionLevel, (-not $srcWildcard), $encoding)

--- a/tests/integration/targets/win_zip/tasks/main.yml
+++ b/tests/integration/targets/win_zip/tasks/main.yml
@@ -116,7 +116,7 @@
     - zip is changed
     - zip_actual.output | length == 1
     # Should contain the original base directory
-    - zip_actual.output[0]['FullName'] == "src\\" + win_zip_name + '.txt'
+    - zip_actual.output[0]['FullName'] == "src/" + win_zip_name + '.txt'
     - zip_actual.output[0]['Length'] == 21
 
 - name: compress a directories contents


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #442 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_zip

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
From .NET 4.6.1, Windows is able to swich path separater from backslash to forwardslash.
https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-ziparchiveentry-fullname-path-separator

So I added ` [System.AppContext]::SetSwitch('Switch.System.IO.Compression.ZipFile.UseBackslash', $false)` to use forwardslash forcibly to avoid warning when extracting in non-windows environment.
