### PR TITLE
add Zone Scope support to win_dns_record module

### DIFF
--- a/changelogs/fragments/win_dns_record-zone-scope.yml
+++ b/changelogs/fragments/win_dns_record-zone-scope.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_dns_record - Added ``zone_scope`` option to manage a record in a specific zone scope

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -123,7 +123,8 @@ if ($null -ne $records) {
         $record_value = $record.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString()
         if ((-Not $required_values.ContainsKey($record_value)) -Or (-Not $record_aging_old -eq $aging)) {
             $record | Remove-DnsServerResourceRecord -ZoneName $zone -Force -WhatIf:$module.CheckMode @extra_args
-            $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+            $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" `
+                -f ("","/$zone_scope")[$null -ne $zone_scope]
             $module.Result.changed = $true
         }
         else {
@@ -141,10 +142,12 @@ if ($null -ne $records) {
                     Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
 
                     $changes.before += -join @(
-                        "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN " -f ("","/$zone_scope")[$null -ne $zone_scope]
+                        "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN " `
+                            -f ("","/$zone_scope")[$null -ne $zone_scope]
                         "$type $record_value $record_port_old $record_weight_old $record_priority_old`n"
                     )
-                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value $port $weight $priority`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value $port $weight $priority`n" `
+                        -f ("","/$zone_scope")[$null -ne $zone_scope]
                     $module.Result.changed = $true
                 }
             }
@@ -154,8 +157,10 @@ if ($null -ne $records) {
                     $new_record = $record.Clone()
                     $new_record.TimeToLive = $ttl
                     Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
-                    $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
-                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+                    $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" `
+                        -f ("","/$zone_scope")[$null -ne $zone_scope]
+                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value`n" `
+                        -f ("","/$zone_scope")[$null -ne $zone_scope]
                     $module.Result.changed = $true
                 }
             }
@@ -189,7 +194,8 @@ if ($null -ne $values -and $values.Count -gt 0) {
         catch {
             $module.FailJson("Error adding DNS $type resource $name in zone $zone with value $value", $_)
         }
-        $changes.after += "[$zone{0}] $name $($ttl.TotalSeconds) IN $type $value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+        $changes.after += "[$zone{0}] $name $($ttl.TotalSeconds) IN $type $value`n" `
+            -f ("","/$zone_scope")[$null -ne $zone_scope]
     }
     $module.Result.changed = $true
 }
@@ -204,12 +210,14 @@ else {
     $records_end = Get-DnsServerResourceRecord -ZoneName $zone -Name $name -RRType $type -Node -ErrorAction:Ignore @extra_args | Sort-Object
     $module.Diff.before = @(
         $records | ForEach-Object {
-            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" `
+                -f ("","/$zone_scope")[$null -ne $zone_scope]
         }
     ) -join ''
     $module.Diff.after = @(
         $records_end | ForEach-Object {
-            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" `
+                -f ("","/$zone_scope")[$null -ne $zone_scope]
         }
     ) -join ''
 }

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -17,6 +17,7 @@ $spec = @{
         value = @{ type = "list"; elements = "str"; default = @() ; aliases = @( 'values' ) }
         weight = @{ type = "int" }
         zone = @{ type = "str"; required = $true }
+        zone_scope = @{ type = "str" }
         computer_name = @{ type = "str" }
     }
     required_if = @(, @("type", "SRV", @("port", "priority", "weight")))
@@ -34,6 +35,7 @@ $type = $module.Params.type
 $values = $module.Params.value
 $weight = $module.Params.weight
 $zone = $module.Params.zone
+$zone_scope = $module.Params.zone_scope
 $dns_computer_name = $module.Params.computer_name
 
 $extra_args = @{}
@@ -41,6 +43,9 @@ $extra_args_new_records = @{}
 
 if ($null -ne $dns_computer_name) {
     $extra_args.ComputerName = $dns_computer_name
+}
+if ($null -ne $zone_scope) {
+    $extra_args.ZoneScope = $zone_scope
 }
 if ($aging -eq $true) {
     $extra_args_new_records.AgeRecord = $true
@@ -118,7 +123,7 @@ if ($null -ne $records) {
         $record_value = $record.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString()
         if ((-Not $required_values.ContainsKey($record_value)) -Or (-Not $record_aging_old -eq $aging)) {
             $record | Remove-DnsServerResourceRecord -ZoneName $zone -Force -WhatIf:$module.CheckMode @extra_args
-            $changes.before += "[$zone] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n"
+            $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
             $module.Result.changed = $true
         }
         else {
@@ -136,10 +141,10 @@ if ($null -ne $records) {
                     Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
 
                     $changes.before += -join @(
-                        "[$zone] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN "
+                        "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN " -f ("","/$zone_scope")[$null -ne $zone_scope]
                         "$type $record_value $record_port_old $record_weight_old $record_priority_old`n"
                     )
-                    $changes.after += "[$zone] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value $port $weight $priority`n"
+                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value $port $weight $priority`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
                     $module.Result.changed = $true
                 }
             }
@@ -149,8 +154,8 @@ if ($null -ne $records) {
                     $new_record = $record.Clone()
                     $new_record.TimeToLive = $ttl
                     Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
-                    $changes.before += "[$zone] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n"
-                    $changes.after += "[$zone] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value`n"
+                    $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
+                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
                     $module.Result.changed = $true
                 }
             }
@@ -184,7 +189,7 @@ if ($null -ne $values -and $values.Count -gt 0) {
         catch {
             $module.FailJson("Error adding DNS $type resource $name in zone $zone with value $value", $_)
         }
-        $changes.after += "[$zone] $name $($ttl.TotalSeconds) IN $type $value`n"
+        $changes.after += "[$zone{0}] $name $($ttl.TotalSeconds) IN $type $value`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
     }
     $module.Result.changed = $true
 }
@@ -199,12 +204,12 @@ else {
     $records_end = Get-DnsServerResourceRecord -ZoneName $zone -Name $name -RRType $type -Node -ErrorAction:Ignore @extra_args | Sort-Object
     $module.Diff.before = @(
         $records | ForEach-Object {
-            "[$zone] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n"
+            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
         }
     ) -join ''
     $module.Diff.after = @(
         $records_end | ForEach-Object {
-            "[$zone] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n"
+            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" -f ("","/$zone_scope")[$null -ne $zone_scope]
         }
     ) -join ''
 }

--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -124,7 +124,7 @@ if ($null -ne $records) {
         if ((-Not $required_values.ContainsKey($record_value)) -Or (-Not $record_aging_old -eq $aging)) {
             $record | Remove-DnsServerResourceRecord -ZoneName $zone -Force -WhatIf:$module.CheckMode @extra_args
             $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" `
-                -f ("","/$zone_scope")[$null -ne $zone_scope]
+                -f ("", "/$zone_scope")[$null -ne $zone_scope]
             $module.Result.changed = $true
         }
         else {
@@ -143,11 +143,11 @@ if ($null -ne $records) {
 
                     $changes.before += -join @(
                         "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN " `
-                            -f ("","/$zone_scope")[$null -ne $zone_scope]
+                            -f ("", "/$zone_scope")[$null -ne $zone_scope]
                         "$type $record_value $record_port_old $record_weight_old $record_priority_old`n"
                     )
                     $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value $port $weight $priority`n" `
-                        -f ("","/$zone_scope")[$null -ne $zone_scope]
+                        -f ("", "/$zone_scope")[$null -ne $zone_scope]
                     $module.Result.changed = $true
                 }
             }
@@ -158,9 +158,9 @@ if ($null -ne $records) {
                     $new_record.TimeToLive = $ttl
                     Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
                     $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" `
-                        -f ("","/$zone_scope")[$null -ne $zone_scope]
+                        -f ("", "/$zone_scope")[$null -ne $zone_scope]
                     $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value`n" `
-                        -f ("","/$zone_scope")[$null -ne $zone_scope]
+                        -f ("", "/$zone_scope")[$null -ne $zone_scope]
                     $module.Result.changed = $true
                 }
             }
@@ -195,7 +195,7 @@ if ($null -ne $values -and $values.Count -gt 0) {
             $module.FailJson("Error adding DNS $type resource $name in zone $zone with value $value", $_)
         }
         $changes.after += "[$zone{0}] $name $($ttl.TotalSeconds) IN $type $value`n" `
-            -f ("","/$zone_scope")[$null -ne $zone_scope]
+            -f ("", "/$zone_scope")[$null -ne $zone_scope]
     }
     $module.Result.changed = $true
 }
@@ -211,13 +211,13 @@ else {
     $module.Diff.before = @(
         $records | ForEach-Object {
             "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" `
-                -f ("","/$zone_scope")[$null -ne $zone_scope]
+                -f ("", "/$zone_scope")[$null -ne $zone_scope]
         }
     ) -join ''
     $module.Diff.after = @(
         $records_end | ForEach-Object {
             "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" `
-                -f ("","/$zone_scope")[$null -ne $zone_scope]
+                -f ("", "/$zone_scope")[$null -ne $zone_scope]
         }
     ) -join ''
 }

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -97,6 +97,7 @@ options:
     - The zone must already exist.
     required: no
     type: str
+    version_added: 2.0.0
   computer_name:
     description:
       - Specifies a DNS server.

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -91,6 +91,12 @@ options:
     - The zone must already exist.
     required: yes
     type: str
+  zone_scope:
+    description:
+    - The name of the zone scope to manage (eg C(ScopeAZ)).
+    - The zone must already exist.
+    required: no
+    type: str
   computer_name:
     description:
       - Specifies a DNS server.
@@ -193,6 +199,16 @@ EXAMPLES = r'''
     type: "TXT"
     value: "justavalue"
     zone: "example.com"
+
+# Demostrate creating a A record to Zone Scope
+
+- name: Create database server record
+  community.windows.win_dns_record:
+    name: "cgyl1404p.amer.example.com"
+    type: "A"
+    value: "10.1.1.1"
+    zone: "amer.example.com"
+    zone_scope: "external"
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add support for Zone Scopes to win_dns_record module.

There is an option named "-ZoneScope" at XXX-DnsServerResourceRecord cmdlets for managing scopes (DNS views) on AD DNS servers zones. With this PR, we have added support to configure dns records inside Zone scopes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_dns_record

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Using the following tasks you add an A record to Zone's Scope named "external"

```
- name: Create database server record
  community.windows.win_dns_record:
    name: "cgyl1404p.amer.example.com"
    type: "A"
    value: "10.1.1.1"
    zone: "amer.example.com"
    zone_scope: "external"
```

