### PR TITLE
Change tests to use include or import_tasks

### DIFF
--- a/tests/integration/targets/win_data_deduplication/tasks/main.yml
+++ b/tests/integration/targets/win_data_deduplication/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: pre_test.yml
+- import_tasks: pre_test.yml

--- a/tests/integration/targets/win_data_deduplication/tasks/pre_test.yml
+++ b/tests/integration/targets/win_data_deduplication/tasks/pre_test.yml
@@ -34,7 +34,7 @@
 
 - name: Run tests
   block:
-    - include: tests.yml
+    - import_tasks: tests.yml
   always:
     - name: Detach disk
       ansible.windows.win_command: diskpart.exe /s {{ remote_tmp_dir }}\partition_deletion_script.txt

--- a/tests/integration/targets/win_disk_facts/tasks/main.yml
+++ b/tests/integration/targets/win_disk_facts/tasks/main.yml
@@ -10,4 +10,4 @@
   block:
 
   - name: Test in normal mode
-    include: tests.yml
+    import_tasks: tests.yml

--- a/tests/integration/targets/win_dns_record/tasks/main.yml
+++ b/tests/integration/targets/win_dns_record/tasks/main.yml
@@ -8,5 +8,5 @@
   register: os_supported
 
 - name: run tests on supported hosts
-  include: tests.yml
+  import_tasks: tests.yml
   when: os_supported.stdout | trim | bool

--- a/tests/integration/targets/win_format/tasks/main.yml
+++ b/tests/integration/targets/win_format/tasks/main.yml
@@ -3,5 +3,5 @@
   ansible.windows.win_shell: if (Get-Command -Name Format-Volume -ErrorAction SilentlyContinue) { $true } else { $false }
   register: module_present
 
-- include: pre_test.yml
+- include_tasks: pre_test.yml
   when: module_present.stdout | trim | bool

--- a/tests/integration/targets/win_format/tasks/pre_test.yml
+++ b/tests/integration/targets/win_format/tasks/pre_test.yml
@@ -15,7 +15,7 @@
 
 - name: Run tests
   block:
-    - include: tests.yml
+    - import_tasks: tests.yml
   always:
     - name: Detach disk
       ansible.windows.win_command: diskpart.exe /s {{ remote_tmp_dir }}\partition_deletion_script.txt

--- a/tests/integration/targets/win_initialize_disk/tasks/main.yml
+++ b/tests/integration/targets/win_initialize_disk/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Run tests
   block:
-    - include: tests.yml
+    - import_tasks: tests.yml
   always:
     - name: Detach disk
       ansible.windows.win_command: diskpart.exe /s C:\win_initialize_disk_tests\vhdx_deletion_script.txt

--- a/tests/integration/targets/win_partition/tasks/main.yml
+++ b/tests/integration/targets/win_partition/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Run tests
   block:
-    - include: tests.yml
+    - import_tasks: tests.yml
   always:
     - name: Detach disk
       ansible.windows.win_command: diskpart.exe /s "{{ remote_tmp_dir }}\vhdx_deletion_script.txt"

--- a/tests/integration/targets/win_route/tasks/main.yml
+++ b/tests/integration/targets/win_route/tasks/main.yml
@@ -22,8 +22,6 @@
   ansible.windows.win_shell: '[Environment]::OSVersion.Version -ge [Version]"6.3"'
   register: os
 
-- name: Perform with os Windows 2012R2 or newer
+- name: run all tasks
+  include_tasks: tests.yml
   when: os.stdout_lines[0] == "True"
-  block:
-    - name: run all tasks
-      include: tests.yml


### PR DESCRIPTION
##### SUMMARY
The `include` task has been deprecated and was removed in Ansible devel. Change the tests to use either `include_tasks` or `import_tasks`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.windows