### PR TITLE
Update win_xml.ps1

### DIFF
--- a/changelogs/fragments/520-fixed-empty-element-bug.yaml
+++ b/changelogs/fragments/520-fixed-empty-element-bug.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_xml - Fix issue where it was not possible to add a new element in empty element.

--- a/changelogs/fragments/520-fixed-empty-element-bug.yaml
+++ b/changelogs/fragments/520-fixed-empty-element-bug.yaml
@@ -1,2 +1,2 @@
-bugfixes:
-  - win_xml - Fix issue where it was not possible to add a new element in empty element.
+minor_changes:
+  - win_xml - Revert fix from pull request 482 and move element presence check outside of element matching code.

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -191,14 +191,7 @@ if ($type -eq "element") {
             if ($node.get_NodeType() -eq "Document") {
                 $node = $node.get_DocumentElement()
             }
-
-            if ($node.ChildNodes.Count -eq 0) {
-                $elements = @($node)
-            }
-            else {
-                $elements = $node.get_ChildNodes()
-            }
-
+            $elements = $node.get_ChildNodes()
             [bool]$present = $false
             [bool]$changed = $false
             if ($elements.get_Count()) {

--- a/plugins/modules/win_xml.ps1
+++ b/plugins/modules/win_xml.ps1
@@ -218,11 +218,11 @@ if ($type -eq "element") {
                         }
                     }
                 }
-                if (-Not $present -and ($state -eq "present")) {
-                    [void]$node.AppendChild($candidate)
-                    $result.msg = $result.msg + "xml added "
-                    $changed = $true
-                }
+            }
+            if (-Not $present -and ($state -eq "present")) {
+                [void]$node.AppendChild($candidate)
+                $result.msg = $result.msg + "xml added "
+                $changed = $true
             }
         }
     }


### PR DESCRIPTION
##### SUMMARY
Fixed bug: module would not add new child nodes to empty parent nodes

Moved code that will modify the xml node outside the check to find an existing node

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: win_xml