### PR TITLE
Remove some code that is incompatible with dotnet 5+

### DIFF
--- a/changelogs/fragments/dotnet-preparation.yml
+++ b/changelogs/fragments/dotnet-preparation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Remove some code which is no longer valid for dotnet 5+

--- a/plugins/modules/win_auto_logon.ps1
+++ b/plugins/modules/win_auto_logon.ps1
@@ -53,7 +53,6 @@ if ($state -eq 'absent') {
 Add-CSharpType -AnsibleModule $module -References @'
 using Microsoft.Win32.SafeHandles;
 using System;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -154,8 +153,6 @@ namespace Ansible.WinAutoLogon
     {
         internal SafeLsaMemory() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-
         protected override bool ReleaseHandle()
         {
             return NativeMethods.LsaFreeMemory(handle) == 0;
@@ -171,8 +168,6 @@ namespace Ansible.WinAutoLogon
             base.SetHandle(ptr);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-
         protected override bool ReleaseHandle()
         {
             if (handle != IntPtr.Zero)
@@ -184,8 +179,6 @@ namespace Ansible.WinAutoLogon
     public class SafeLsaHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal SafeLsaHandle() : base(true) { }
-
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
 
         protected override bool ReleaseHandle()
         {

--- a/plugins/modules/win_credential.ps1
+++ b/plugins/modules/win_credential.ps1
@@ -60,7 +60,6 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -223,7 +222,6 @@ namespace Ansible.CredentialManager
     {
         public SafeCredentialBuffer() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             NativeMethods.CredFree(handle);
@@ -242,7 +240,6 @@ namespace Ansible.CredentialManager
         {
             base.SetHandle(handle);
         }
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/plugins/modules/win_inet_proxy.ps1
+++ b/plugins/modules/win_inet_proxy.ps1
@@ -68,7 +68,6 @@ $win_inet_invoke = @'
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 
 namespace Ansible.WinINetProxy
@@ -197,7 +196,6 @@ namespace Ansible.WinINetProxy
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/plugins/modules/win_mapped_drive.ps1
+++ b/plugins/modules/win_mapped_drive.ps1
@@ -41,7 +41,6 @@ Add-CSharpType -AnsibleModule $module -References @'
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 
 namespace Ansible.MappedDrive
@@ -160,7 +159,6 @@ namespace Ansible.MappedDrive
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/tests/integration/targets/setup_win_device/library/win_device.ps1
+++ b/tests/integration/targets/setup_win_device/library/win_device.ps1
@@ -30,7 +30,6 @@ Add-CSharpType -References @'
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.ComponentModel;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -246,7 +245,6 @@ namespace Ansible.Device
     {
         public SafeDeviceInfoSet() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return NativeMethods.SetupDiDestroyDeviceInfoList(handle);
@@ -271,7 +269,6 @@ namespace Ansible.Device
             base.SetHandle(Marshal.StringToHGlobalUni(sz));
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/tests/integration/targets/win_auto_logon/library/test_autologon_info.ps1
+++ b/tests/integration/targets/win_auto_logon/library/test_autologon_info.ps1
@@ -8,7 +8,6 @@ $module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
 Add-CSharpType -AnsibleModule $module -References @'
 using Microsoft.Win32.SafeHandles;
 using System;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -103,8 +102,6 @@ namespace Ansible.TestAutoLogonInfo
     {
         internal SafeLsaMemory() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-
         protected override bool ReleaseHandle()
         {
             return NativeMethods.LsaFreeMemory(handle) == 0;
@@ -120,8 +117,6 @@ namespace Ansible.TestAutoLogonInfo
             base.SetHandle(ptr);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-
         protected override bool ReleaseHandle()
         {
             if (handle != IntPtr.Zero)
@@ -133,8 +128,6 @@ namespace Ansible.TestAutoLogonInfo
     public class SafeLsaHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal SafeLsaHandle() : base(true) { }
-
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
 
         protected override bool ReleaseHandle()
         {

--- a/tests/integration/targets/win_credential/library/test_cred_facts.ps1
+++ b/tests/integration/targets/win_credential/library/test_cred_facts.ps1
@@ -24,7 +24,6 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -187,7 +186,6 @@ namespace Ansible.CredentialManager
     {
         public SafeCredentialBuffer() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             NativeMethods.CredFree(handle);
@@ -206,7 +204,6 @@ namespace Ansible.CredentialManager
         {
             base.SetHandle(handle);
         }
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/tests/integration/targets/win_inet_proxy/library/win_inet_proxy_info.ps1
+++ b/tests/integration/targets/win_inet_proxy/library/win_inet_proxy_info.ps1
@@ -22,7 +22,6 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 
 namespace Ansible.WinINetProxyInfo
@@ -138,7 +137,6 @@ namespace Ansible.WinINetProxyInfo
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);


### PR DESCRIPTION
##### SUMMARY
The `ReliabilityContract` is obsolete and doesn't do anything. It will also fail to compile in newer versions of dotnet.

Related: https://github.com/ansible-collections/ansible.windows/issues/537

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.windows