### PR TITLE
[Fix] community.windows.win_psmodule_info throws exception when host has no Installed Module

### DIFF
--- a/changelogs/fragments/win_psmodule_info.yml
+++ b/changelogs/fragments/win_psmodule_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - community.windows.win_psmodule_info - exception thrown when host has no Installed Module. Fix now checks that variable $installedModules is not null before calling the .Contains(..) function on it.

--- a/plugins/modules/win_psmodule_info.ps1
+++ b/plugins/modules/win_psmodule_info.ps1
@@ -263,7 +263,7 @@ function Add-ModuleRepositoryInfo {
     Process {
         $moduleName = $InputObject.Name
 
-        $installed = if ($installedModules.Contains($moduleName)) {
+        $installed = if ($installedModules -and $installedModules.Contains($moduleName)) {
             # we know at least one version of this module was installed from PowerShellGet
             # if the version of this local modle matches what we got it in the initial installed module list
             # use it


### PR DESCRIPTION
When a host has no installled Module, the $installedModules is null and $installedModules.Contains() throws an exception

##### SUMMARY
When the host does not have an installed module (in any version of PowerShell), the community.windows.win_psmodule_info throws a:  

```Unhandled exception while executing module: You cannot call a method on a null-valued expression.```

With the -vvv, the details of the exception are:
```
The full traceback is:
You cannot call a method on a null-valued expression.
At line:294 char:5
+     Add-ModuleRepositoryInfo -RepositoryName $module.Params.repositor ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Add-ModuleRepositoryInfo], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull,Add-ModuleRepositoryInfo

ScriptStackTrace:
at Add-ModuleRepositoryInfo<Process>, <No file>: line 261
at <ScriptBlock>, <No file>: line 293

System.Management.Automation.RuntimeException: You cannot call a method on a null-valued expression.
```



##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
module: community.windows.win_psmodule_info
