### PR TITLE
Fix issue #265. Support for Windows Failover Cluster

### DIFF
--- a/changelogs/fragments/543-support_for_failover_cluster.yaml
+++ b/changelogs/fragments/543-support_for_failover_cluster.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Add support for windows failover cluster disks

--- a/changelogs/fragments/543-support_for_failover_cluster.yaml
+++ b/changelogs/fragments/543-support_for_failover_cluster.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Add support for windows failover cluster disks
+  - win_format, win_partition - Add support for Windows failover cluster disks

--- a/plugins/modules/win_format.ps1
+++ b/plugins/modules/win_format.ps1
@@ -74,7 +74,8 @@ function Get-AnsibleVolume {
 
     if ($null -ne $DriveLetter) {
         try {
-            $volume = Get-Volume -DriveLetter $DriveLetter
+            $partition = Get-Partition -DriveLetter $DriveLetter | Where-Object { $null -ne $_.DiskNumber }
+            $volume = Get-Volume -Partition $partition
         }
         catch {
             $module.FailJson("There was an error retrieving the volume using drive_letter $($DriveLetter): $($_.Exception.Message)", $_)

--- a/plugins/modules/win_format.ps1
+++ b/plugins/modules/win_format.ps1
@@ -74,6 +74,11 @@ function Get-AnsibleVolume {
 
     if ($null -ne $DriveLetter) {
         try {
+            # This needs to be a two step process so that we can support Windows failover cluster disks.
+            # With Windows failover cluster disks every node sees every disk participating in that cluster.
+            # For example a clustered disk in a three node cluster will show up three times.
+            # Fortunatly we can differentiate local from remote disk as only local disk will ever have a disk number.
+            # So with that we just ignore all disk without a number which will result in a local disk being picked.
             $partition = Get-Partition -DriveLetter $DriveLetter | Where-Object { $null -ne $_.DiskNumber }
             $volume = Get-Volume -Partition $partition
         }

--- a/plugins/modules/win_partition.ps1
+++ b/plugins/modules/win_partition.ps1
@@ -100,7 +100,7 @@ if ($null -ne $disk_number -and $null -ne $partition_number) {
 # Check if drive_letter is either auto-assigned or a character from A-Z
 elseif ($drive_letter -and $drive_letter -ne "auto" -and -not ($disk_number -and $partition_number)) {
     if ($drive_letter -match "^[a-zA-Z]$") {
-        $ansible_partition = Get-Partition -DriveLetter $drive_letter -ErrorAction SilentlyContinue
+        $ansible_partition = Get-Partition -DriveLetter $drive_letter -ErrorAction SilentlyContinue | Where-Object { $null -ne $_.DiskNumber }
     }
     else {
         $module.FailJson("Incorrect usage of drive_letter: specify a drive letter from A-Z or use 'auto' to automatically assign a drive letter")

--- a/plugins/modules/win_partition.ps1
+++ b/plugins/modules/win_partition.ps1
@@ -100,6 +100,11 @@ if ($null -ne $disk_number -and $null -ne $partition_number) {
 # Check if drive_letter is either auto-assigned or a character from A-Z
 elseif ($drive_letter -and $drive_letter -ne "auto" -and -not ($disk_number -and $partition_number)) {
     if ($drive_letter -match "^[a-zA-Z]$") {
+        # This step need to be a bit more complex so that we can support Windows failover cluster disks.
+        # With Windows failover cluster disks every node sees every disk participating in that cluster.
+        # For example a clustered disk in a three node cluster will show up three times.
+        # Fortunatly we can differentiate local from remote disk as only local disk will ever have a disk number.
+        # So with that we just ignore all disk without a number which will result in a local disk being picked.
         $ansible_partition = Get-Partition -DriveLetter $drive_letter -ErrorAction SilentlyContinue | Where-Object { $null -ne $_.DiskNumber }
     }
     else {


### PR DESCRIPTION
##### SUMMARY
Fix issue #265. Support for Windows Failover Cluster

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_format.ps1
win_partition.ps1

##### ADDITIONAL INFORMATION
On systems with an active failover cluster Get-Partitions and Get-Volumes show entries from all nodes in that cluster.
To solve the problem the code filters out all partitions and volumes without a disk number.
AFAIK only a local disk will ever have a disk number.
Tested with Windows Server 2022.
