### PR TITLE
Use SHA1-DES pfx for tests on older win hosts

### DIFF
--- a/tests/integration/targets/win_psmodule/files/setup_certs.sh
+++ b/tests/integration/targets/win_psmodule/files/setup_certs.sh
@@ -16,4 +16,8 @@ openssl req -new -key sign.key -out sign.csr -subj "/CN=Ansible Sign" -config op
 openssl x509 -req -in sign.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out sign.pem -days 365 -extfile openssl.conf -extensions req_sign -passin pass:password
 
 # Create pfx that includes signing cert and cert with the pass 'password'
-openssl pkcs12 -export -out sign.pfx -inkey sign.key -in sign.pem -passin pass:password -passout pass:password
+pfx_args=()
+if [ "${1}" == "-use-legacy" ]; then
+    pfx_args=("-certpbe" "PBE-SHA1-3DES" "-keypbe" "PBE-SHA1-3DES" "-macalg" "SHA1")
+fi
+openssl pkcs12 -export -out sign.pfx -inkey sign.key -in sign.pem -passin pass:password -passout pass:password "${pfx_args[@]}"

--- a/tests/integration/targets/win_psmodule/tasks/setup.yml
+++ b/tests/integration/targets/win_psmodule/tasks/setup.yml
@@ -66,8 +66,16 @@
   delegate_to: localhost
   register: output_dir_abs
 
+- name: check if we can use the default AES encryption
+  ansible.windows.win_powershell:
+    script: |
+      $osVersion = [Version](Get-Item -LiteralPath "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
+      $osVersion -ge [Version]"10.0.17763"
+  changed_when: false
+  register: aes256_support
+
 - name: create certificates for code signing
-  script: setup_certs.sh
+  script: setup_certs.sh {{ '' if aes256_support.output[0] else '-use-legacy' }}
   args:
     chdir: '{{ output_dir_abs.stdout }}'
   delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
Use the older 3DES SHA1 encryption when creating a pfx in the tests for Server 2016. This is needed as OpenSSL defaults to AES256 which is only supported from Server 2019 or newer.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI tests