### PR TITLE
docs(win_iis_webapppool.ps1): update to include example on how to set…

### DIFF
--- a/plugins/modules/win_iis_webapppool.py
+++ b/plugins/modules/win_iis_webapppool.py
@@ -94,6 +94,14 @@ EXAMPLES = r'''
       managedRuntimeVersion: v4.0
       autoStart: no
 
+- name: Creates an application pool with "No Managed Code" for .Net compatibility
+  community.windows.win_iis_webapppool:
+    name: AnotherAppPool
+    state: started
+    attributes:
+      managedRuntimeVersion: ''
+      autoStart: false
+
 # In the below example we are setting attributes in child element processModel
 # https://www.iis.net/configreference/system.applicationhost/applicationpools/add/processmodel
 - name: Manage child element and set identity of application pool


### PR DESCRIPTION
##### SUMMARY
Update win_iis_webapppool.ps1 documentation to add an  example on how to set No Managed Code for .Net compatibility

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_iis_webapppool

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
