### PR TITLE
Fix A record example to prevent unintended nested DNS zone creation

### DIFF
--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -112,7 +112,7 @@ EXAMPLES = r'''
 
 - name: Create database server record
   community.windows.win_dns_record:
-    name: "cgyl1404p.amer.example.com"
+    name: "cgyl1404p"
     type: "A"
     value: "10.1.1.1"
     zone: "amer.example.com"


### PR DESCRIPTION
##### SUMMARY
Creating an "A" record with a FQDN in the "name:" module argument creates a nested DNS zone, which is not expected behavior, and can break AD DNS replication. Updates first example to remove the FQDN.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_dns_record.py

##### ADDITIONAL INFORMATION
In the first example, we use FQDN in the "name" module argument:

````
- name: Create database server record
  community.windows.win_dns_record:
    name: "cgyl1404p.amer.example.com"
    type: "A"
    value: "10.1.1.1"
    zone: "amer.example.com"
````

This creates a "nested" DNS zone (amer.example.com.amer.example.com), which is not intended behavior and can break AD DNS replication. 

The "name:" module argument should not use FQDN, which is properly shown in the later example for "Create Multiple A record values for www", as well as other examples using the "A" record type module argument.



