### PR TITLE
Expand connection plugins used in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -144,9 +144,11 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}
           targets:
-            - test: 2016
-            - test: 2019
-            - test: 2022
+            - test: 2016/winrm/http
+            - test: 2019/winrm/https
+            - test: 2022/winrm/https
+            - test: 2022/psrp/https
+            - test: 2022/ssh/key
           groups:
             - 1
             - 2

--- a/changelogs/fragments/win_mapped_drive-ssh.yml
+++ b/changelogs/fragments/win_mapped_drive-ssh.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - >-
+    win_mapped_drive - better handle failures when attempting to set mapped drive that already exists but was seen as a local path.

--- a/plugins/modules/win_mapped_drive.ps1
+++ b/plugins/modules/win_mapped_drive.ps1
@@ -390,11 +390,6 @@ try {
         }
     }
     else {
-        $physical_drives = Get-PSDrive -PSProvider "FileSystem"
-        if ($letter -in $physical_drives.Name) {
-            $module.FailJson("failed to create mapped drive $letter, this letter is in use and is pointing to a non UNC path")
-        }
-
         # PowerShell converts a $null value to "" when crossing the .NET marshaler, we need to convert the input
         # to a missing value so it uses the defaults. We also need to Invoke it with MethodInfo.Invoke so the defaults
         # are still used
@@ -418,6 +413,11 @@ try {
             }
         }
         else {
+            $physical_drives = Get-PSDrive -PSProvider "FileSystem"
+            if ($letter -in $physical_drives.Name) {
+                $module.FailJson("failed to create mapped drive $letter, this letter is in use and is pointing to a non UNC path")
+            }
+
             if (-not $module.CheckMode) {
                 $add_method.Invoke($null, [Object[]]@($letter_root, $path, $i_token_ptr, $input_username, $input_password))
             }

--- a/tests/integration/targets/psexec/tasks/main.yml
+++ b/tests/integration/targets/psexec/tasks/main.yml
@@ -18,7 +18,7 @@
   set_fact:
     psexec_hostname: '{{ansible_host}}'
     psexec_username: '{{ansible_user}}'
-    psexec_password: '{{ansible_password}}'
+    psexec_password: '{{ ansible_password | default(ansible_test_connection_password) }}'
     psexec_encrypt: '{{encryption_supported_raw.stdout_lines[0]|bool}}'
 
 - name: create test rule to allow SMB traffic inbound

--- a/tests/integration/targets/win_credential/tasks/main.yml
+++ b/tests/integration/targets/win_credential/tasks/main.yml
@@ -20,7 +20,7 @@
     ansible_become: True
     ansible_become_method: runas
     ansible_become_user: '{{ ansible_user }}'
-    ansible_become_pass: '{{ ansible_password }}'
+    ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
 
 - name: ensure test credentials are removed before testing
   win_credential:

--- a/tests/integration/targets/win_credential/tasks/tests.yml
+++ b/tests/integration/targets/win_credential/tasks/tests.yml
@@ -22,7 +22,7 @@
     ansible_become: True
     ansible_become_method: runas
     ansible_become_user: '{{ ansible_user }}'
-    ansible_become_pass: '{{ ansible_password }}'
+    ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
 
 - name: get result of create domain user credential (check mode)
   test_cred_facts:

--- a/tests/integration/targets/win_iis_webapppool/tasks/tests.yml
+++ b/tests/integration/targets/win_iis_webapppool/tasks/tests.yml
@@ -375,10 +375,10 @@
         startMode: AlwaysRunning
         processModel.identityType: SpecificUser
         processModel.userName: '{{ansible_user}}'
-        processModel.password: '{{ansible_password}}'
+        processModel.password: '{{ ansible_password | default(ansible_test_connection_password) }}'
     register: iis_attributes_new_check
     check_mode: yes
-  
+
   - name: assert change attributes for newer IIS version check
     assert:
       that:
@@ -393,9 +393,9 @@
         startMode: AlwaysRunning
         processModel.identityType: SpecificUser
         processModel.userName: '{{ansible_user}}'
-        processModel.password: '{{ansible_password}}'
+        processModel.password: '{{ ansible_password | default(ansible_test_connection_password) }}'
     register: iis_attributes_new
-  
+
   - name: assert change attributes for newer IIS version
     assert:
       that:
@@ -412,9 +412,9 @@
         startMode: AlwaysRunning
         processModel.identityType: 3
         processModel.userName: '{{ansible_user}}'
-        processModel.password: '{{ansible_password}}'
+        processModel.password: '{{ ansible_password | default(ansible_test_connection_password) }}'
     register: iis_attributes_new_again
-  
+
   - name: assert change attributes for newer IIS version again
     assert:
       that:

--- a/tests/integration/targets/win_mapped_drive/tasks/main.yml
+++ b/tests/integration/targets/win_mapped_drive/tasks/main.yml
@@ -60,7 +60,7 @@
       ansible_become: yes
       ansible_become_method: runas
       ansible_become_user: '{{ ansible_user }}'
-      ansible_become_pass: '{{ ansible_password }}'
+      ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
 
   - name: ensure mapped drive is deleted at the end of the test
     win_mapped_drive:

--- a/tests/integration/targets/win_mapped_drive/tasks/tests.yml
+++ b/tests/integration/targets/win_mapped_drive/tasks/tests.yml
@@ -283,7 +283,7 @@
     ansible_become: yes
     ansible_become_method: runas
     ansible_become_user: '{{ ansible_user }}'
-    ansible_become_pass: '{{ ansible_password }}'
+    ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
 
 - name: map drive with stored cred (check mode)
   win_mapped_drive:

--- a/tests/integration/targets/win_nssm/tasks/main.yml
+++ b/tests/integration/targets/win_nssm/tasks/main.yml
@@ -4,6 +4,14 @@
     name: NSSM
     state: present
 
+- name: restart sshd after env var was updated by chocolatey
+  win_service:
+    name: sshd
+    state: restarted
+  when: ansible_connection == 'ssh'
+
+- meta: reset_connection
+
 - name: ensure testing folder exists
   ansible.windows.win_file:
     path: '{{test_win_nssm_path}}'

--- a/tests/integration/targets/win_pester/tasks/main.yml
+++ b/tests/integration/targets/win_pester/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: download Pester module from S3 bucket
   ansible.windows.win_get_url:
     # this was downloaded straight off the Pester GitHub release page and uploaded to the S3 bucket
-    # https://github.com/pester/Pester/releases 
+    # https://github.com/pester/Pester/releases
     url: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_pester/Pester-4.3.1.zip'
     dest: '{{test_win_pester_path}}\Pester-4.3.1.zip'
   register: download_res
@@ -34,6 +34,8 @@
     elements:
     - '{{test_win_pester_path}}\Modules'
 
+- meta: reset_connection
+
 - name: copy test files
   ansible.windows.win_copy:
     src: files/
@@ -53,6 +55,8 @@
       state: absent
       elements:
       - '{{test_win_pester_path}}\Modules'
+
+  - meta: reset_connection
 
   - name: delete test folder
     ansible.windows.win_file:

--- a/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
+++ b/tests/integration/targets/win_pssession_configuration/tasks/tests.yml
@@ -306,7 +306,7 @@
 - name: "RunAs Tests"
   vars:
     runas_user: "{{ ansible_user }}"
-    runas_pass: "{{ ansible_password }}"
+    runas_pass: "{{ ansible_password | default(ansible_test_connection_password) }}"
   block:
     - name: Change runas credential (check)
       win_pssession_configuration:

--- a/tests/utils/shippable/windows.sh
+++ b/tests/utils/shippable/windows.sh
@@ -6,9 +6,11 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
+connection="${args[2]}"
+connection_setting="${args[3]}"
 
-if [ "${#args[0]}" -gt 2 ]; then
-    target="shippable/windows/group${args[2]}/"
+if [ "${#args[0]}" -gt 4 ]; then
+    target="shippable/windows/group${args[4]}/"
 else
     target="shippable/windows/"
 fi
@@ -18,4 +20,6 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test windows-integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --windows "${version}" --docker default --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"
+    --controller "docker:default" \
+    --target "remote:windows/${version},connection=${connection}+${connection_setting},provider=${provider}" \
+    --remote-terminate always --remote-stage "${stage}"


### PR DESCRIPTION
##### SUMMARY
Expands the testing matrix of the Windows connection plugins used in CI to cover all the supported connections of Windows.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
testing