### PR TITLE
Use correct P/Invoke signature in WNetAddConnection2.

### DIFF
--- a/changelogs/fragments/578-win_mapped_drive.yml
+++ b/changelogs/fragments/578-win_mapped_drive.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - win_mapped_drive - Use correct P/Invoke signature to fix mapped network drives on 32 Bit OS.

--- a/plugins/modules/win_mapped_drive.ps1
+++ b/plugins/modules/win_mapped_drive.ps1
@@ -116,7 +116,7 @@ namespace Ansible.MappedDrive
 
         [DllImport("Mpr.dll", CharSet = CharSet.Unicode)]
         public static extern UInt32 WNetAddConnection2W(
-            NativeHelpers.NETRESOURCEW lpNetResource,
+            ref NativeHelpers.NETRESOURCEW lpNetResource,
             [MarshalAs(UnmanagedType.LPWStr)] string lpPassword,
             [MarshalAs(UnmanagedType.LPWStr)] string lpUserName,
             NativeHelpers.AddFlags dwFlags);
@@ -224,7 +224,7 @@ namespace Ansible.MappedDrive
             // the implicit credential cache used in Windows
             using (Impersonation imp = new Impersonation(iToken))
             {
-                UInt32 res = NativeMethods.WNetAddConnection2W(resource, password, username, dwFlags);
+                UInt32 res = NativeMethods.WNetAddConnection2W(ref resource, password, username, dwFlags);
                 if (res != ERROR_SUCCESS)
                     throw new Win32Exception((int)res, String.Format("Failed to map {0} to '{1}' with WNetAddConnection2W()", drive, path));
             }


### PR DESCRIPTION
##### SUMMARY
This commit implements the correct reference-based signature for [WNetAddConnection2](https://learn.microsoft.com/de-de/windows/win32/api/winnetwk/nf-winnetwk-wnetaddconnection2a). On 32-bit systems, the previous implementation led to a significant issue when mapping network drives, causing memory layout corruption and resulting in the function failing with error 487. This commit resolves that issue and corrects the behavior.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
It's about `win_mapped_drive` that fails on any 32 bit platform because of using the wrong method signature. Check P/Invoke for [reference](https://www.pinvoke.net/default.aspx/mpr.wnetaddconnection2).

##### ADDITIONAL INFORMATION
Example log output of failure:

```
Exception calling "Invoke" with "2" argument(s): "Failed to map Z: to '\\TESTBOX1\Share' with WNetAddConnection2W() (Attempt to access invalid address, Win32ErrorCode 487)"
At line:422 char:17
+ ...             $add_method.Invoke($null, [Object[]]@($letter_root, $path ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : Win32Exception

ScriptStackTrace:
at <ScriptBlock>, <No file>: line 422
fatal: [TW10B-903-1]: FAILED! => {
    "changed": false,
    "msg": "Unhandled exception while executing module: Exception calling \"Invoke\" with \"2\" argument(s): \"Failed to map Z: to '\\\\TESTBOX1\\Share' with WNetAddConnection2W() (Attempt to access invalid address, Win32ErrorCode 487)\""
}
```

```
verbatim: n/a
```
