### PR TITLE
Raise minimum supported Ansible version to 2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,20 +120,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_14
-    displayName: Ansible 2.14
-    dependsOn:
-      - Dependencies
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: "{0}"
-          testFormat: "2.14/{0}"
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows_1
     displayName: Windows 1
     dependsOn:
@@ -241,7 +227,6 @@ stages:
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
-      - Ansible_2_14
       - Windows_1
       - Windows_2
       - Windows_3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.14**.
+This collection has been tested against following Ansible versions: **>=2.15**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-version.yml
+++ b/changelogs/fragments/ansible-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Set minimum supported Ansible version to 2.15 to align with the versions still supported by Asnible.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.14'
+requires_ansible: '>=2.15'
 plugin_routing:
   modules:
     win_domain_computer:

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,5 +1,0 @@
-plugins/modules/win_audit_rule.ps1 pslint:PSCustomUseLiteralPath  # Unsure if we can fix this or not so keep ignoring for now
-tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
-tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
-tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings
-tests/integration/targets/win_regmerge/templates/win_line_ending.j2 line-endings


### PR DESCRIPTION
##### SUMMARY
Ansible 2.14 is EOL so the new minimum is 2.15.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.windows