### PR TITLE
fixing portion where building app pools with the word value fails.

### DIFF
--- a/changelogs/fragments/588-win_iis_webapppool.yaml
+++ b/changelogs/fragments/588-win_iis_webapppool.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - win_iis_webapppool  - this pull request fixes the portion where building an app pool with the word "value" in it fails unexpectedly.
+    https://github.com/ansible-collections/community.windows/issues/410.

--- a/plugins/modules/win_iis_webapppool.ps1
+++ b/plugins/modules/win_iis_webapppool.ps1
@@ -108,7 +108,7 @@ Function Compare-Value($current, $new) {
 
 Function Convert-ToPropertyValue($pool, $attribute_key, $attribute_value) {
     # Will convert the new value to the enum value expected and cast accordingly to the type
-    if ([bool]($attribute_value.PSobject.Properties -match "Value")) {
+    if ([bool]($attribute_value.PSobject.Properties.Name -match "Value")) {
         $attribute_value = $attribute_value.Value
     }
     $attribute_key_split = $attribute_key -split "\."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

For the last two years we've had an issue with this module regard app pool creations failing that specifically contain the word "value" in it. We weren't able to create sites that contained this word. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

**https://github.com/ansible-collections/community.windows/issues/410**

Root cause is that the string "Value" is matched against collection of property objects of the $attribute_value but from the context it can be deduced that "Value" should only be matched against collection of names of those properties. Match should not be partial either, hence the -eq operator.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
-
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.win_iis_webapppool

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
