### PR TITLE
Issue #147

### DIFF
--- a/changelogs/fragments/588-nuget-requirement-patch.yaml
+++ b/changelogs/fragments/588-nuget-requirement-patch.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - This issue fixes installation of requirements as it requires a confirmation when installed as a depedency to PowershellGet. Installing it by itself prevents this confirmation dialog and allows required components to be installed (https://github.com/ansible-collections/community.windows/issues/147).

--- a/changelogs/fragments/588-nuget-requirement-patch.yaml
+++ b/changelogs/fragments/588-nuget-requirement-patch.yaml
@@ -1,3 +1,5 @@
 ---
 minor_changes:
-  - This issue fixes installation of requirements as it requires a confirmation when installed as a depedency to PowershellGet. Installing it by itself prevents this confirmation dialog and allows required components to be installed (https://github.com/ansible-collections/community.windows/issues/147).
+  - This issue fixes installation of requirements as it requires a confirmation when installed as a depedency to PowershellGet.
+    Installing it by itself prevents this confirmation dialog and allows required components to be installed
+    (https://github.com/ansible-collections/community.windows/issues/147).

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -101,7 +101,7 @@ Function Install-PrereqModule {
         $job = Start-Job -ScriptBlock {
             $ErrorActionPreference = 'Stop'
 
-            if (-not (Get-PackageProvider -ListAvailable -ErrorAction SilentlyContinue | Where-Object { ($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201") }) ) {
+            if (-not (Get-PackageProvider -ListAvailable | Where-Object { ($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201") }) ) {
                 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
             }
 

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -70,6 +70,9 @@ Function Install-PrereqModule {
         [string]$Repository
     )
 
+    # Install NuGet provider if needed.
+    Install-NugetProvider -CheckMode $CheckMode
+
     # Those are minimum required versions of modules.
     $PrereqModules = @{
         PackageManagement = '1.1.7'
@@ -108,7 +111,6 @@ Function Install-PrereqModule {
                     Name = $info.Name
                     MinimumVersion = $info.Version
                     Force = $true
-                    Confirm = $false
                 }
                 $installCmd = Get-Command -Name Install-Module
                 if ($installCmd.Parameters.ContainsKey('SkipPublisherCheck')) {

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -108,6 +108,7 @@ Function Install-PrereqModule {
                     Name = $info.Name
                     MinimumVersion = $info.Version
                     Force = $true
+                    Confirm = $false
                 }
                 $installCmd = Get-Command -Name Install-Module
                 if ($installCmd.Parameters.ContainsKey('SkipPublisherCheck')) {

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -70,9 +70,6 @@ Function Install-PrereqModule {
         [string]$Repository
     )
 
-    # Install NuGet provider if needed.
-    Install-NugetProvider -CheckMode $CheckMode
-
     # Those are minimum required versions of modules.
     $PrereqModules = @{
         PackageManagement = '1.1.7'
@@ -103,6 +100,10 @@ Function Install-PrereqModule {
         # https://github.com/ansible-collections/community.windows/issues/487
         $job = Start-Job -ScriptBlock {
             $ErrorActionPreference = 'Stop'
+
+            if (-not (Get-PackageProvider -ListAvailable -ErrorAction SilentlyContinue | Where-Object { ($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201") }) ) {
+                Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+            }
 
             $Repository = $using:Repository
 


### PR DESCRIPTION
##### SUMMARY
Attempting to fix Issue #147 as a confirmation is required when it should not.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`win_psmodule`

##### ADDITIONAL INFORMATION

Before:
```
The full traceback is:
Exception calling "ShouldContinue" with "2" argument(s): "A command that prompts the user failed because the host program or the command type does not support user interaction. The host was attempting to request confirmation with the following message: PowerShellGet requires NuGet provider version '2.8.5.201' or newer to interact with NuGet-based repositories. The NuGet provider must be available in 'C:\Program Files\PackageManagement\ProviderAssemblies' or
'C:\Users\user\AppData\Local\PackageManagement\ProviderAssemblies'. You can also install the NuGet provider by running 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force'. Do you want PowerShellGet to install and import the NuGet provider now?"
At line:131 char:13
+             $null = $job | Receive-Job -AutoRemoveJob -Wait -ErrorAct ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Install-NuGetClientBinaries], MethodInvocationException
    + FullyQualifiedErrorId : HostException,Install-NuGetClientBinaries

at Install-NuGetClientBinaries, C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1: line 7392
at Install-Module, C:\Program Files\WindowsPowerShell\Modules\PowerShellGet\1.0.0.1\PSModule.psm1: line 1725
at , : line 26
fatal: [10.0.0.11]: FAILED! => {
    "changed": true,
    "msg": "Problems adding a prerequisite module PackageManagement or PowerShellGet: Exception calling \"ShouldContinue\" with \"2\" argument(s): \"A command that prompts the user failed because the host program or the command type does not support user interaction. The host was attempting to request confirmation with the following message: PowerShellGet requires NuGet provider version '2.8.5.201' or newer to interact with NuGet-based repositories. The NuGet provider must be available in 'C:\\Program Files\\PackageManagement\\ProviderAssemblies' or 'C:\\Users\\user\\AppData\\Local\\PackageManagement\\ProviderAssemblies'. You can also install the NuGet provider by running 'Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force'. Do you want PowerShellGet to install and import the NuGet provider now?\"",
    "nuget_changed": false,
    "output": "",
    "repository_changed": false
}
```
After
```
changed: [10.0.0.11] => {
    "changed": true,
    "nuget_changed": false,
    "output": "Module Microsoft.PowerShell.PSResourceGet installed",
    "repository_changed": false
}
```