### PR TITLE
Add force option to win psrepository copy

### DIFF
--- a/plugins/modules/win_psrepository_copy.py
+++ b/plugins/modules/win_psrepository_copy.py
@@ -55,6 +55,11 @@ options:
       - systemprofile
       - LocalService
       - NetworkService
+  force:
+    description:
+      - If C(True), this deletes repositories that are not present in the source.
+    type: bool
+    default: False
 notes:
   - Does not require the C(PowerShellGet) module or any other external dependencies.
   - User profiles are loaded from the registry. If a given path does not exist (like if the profile directory was deleted), it is silently skipped.


### PR DESCRIPTION
##### SUMMARY
Adds a `force` option to the **win_psrepository_copy** module.
The current module only had the option to append. This addition also lets you 'set' the repository list identically tot the source

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_psrepository_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
