### PR TITLE
Fix up ansible-lint version

### DIFF
--- a/tests/utils/shippable/lint.sh
+++ b/tests/utils/shippable/lint.sh
@@ -2,9 +2,14 @@
 
 set -o pipefail -eux
 
-# This is aligned with the galaxy-importer used by AH
-# https://github.com/ansible/galaxy-importer/blob/d4b5e6d12088ba452f129f4824bd049be5543358/setup.cfg#L22C4-L22C33
+# This is aligned with the galaxy-importer used by AH.
+# Need to pin to the released tag at.
+# https://github.com/ansible/galaxy_ng/blob/master/requirements/requirements.common.txt
+#
+# The galaxy_ng_commit from can be used to find the specific commit to check.
+# https://galaxy.ansible.com/api/
 python -m pip install \
-    'ansible-lint>=6.2.2,<=6.22.1'
+    'ansible-lint==24.7.0' \
+    'ansible-compat==24.10.0'
 
 ansible-lint


### PR DESCRIPTION
##### SUMMARY
Bumps `ansible-lint` to the version used by galaxy importer in production. Also pins `ansible-compat` due to an incompatibility with the latest release. This will be removed in the future once that bug is fixed.

##### ISSUE TYPE
- Bugfix Pull Request