### PR TITLE
Fix requires_ansible version

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.15'
+requires_ansible: '>=2.15.0'
 plugin_routing:
   modules:
     win_domain_computer:


### PR DESCRIPTION
##### SUMMARY
The `requires_ansible` entry should have the build version and not just major.minor.

##### ISSUE TYPE
- Bugfix Pull Request