### PR TITLE
Fix mismatch of return structure in win_file_version module documentation

### DIFF
--- a/plugins/modules/win_file_version.py
+++ b/plugins/modules/win_file_version.py
@@ -36,38 +36,43 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-path:
-  description: file path
-  returned: always
-  type: str
-
-file_version:
-  description: File version number..
-  returned: no error
-  type: str
-
-product_version:
-  description: The version of the product this file is distributed with.
-  returned: no error
-  type: str
-
-file_major_part:
-  description: the major part of the version number.
-  returned: no error
-  type: str
-
-file_minor_part:
-  description: the minor part of the version number of the file.
-  returned: no error
-  type: str
-
-file_build_part:
-  description: build number of the file.
-  returned: no error
-  type: str
-
-file_private_part:
-  description: file private part number.
-  returned: no error
-  type: str
+changed:
+    description: Whether anything was changed
+    returned: always
+    type: bool
+    sample: true
+win_file_version:
+    description: dictionary containing all the version data
+    returned: success
+    type: complex
+    contains:
+        file_build_part:
+          description: build number of the file.
+          returned: no error
+          type: str
+        file_major_part:
+          description: the major part of the version number.
+          returned: no error
+          type: str
+        file_minor_part:
+          description: the minor part of the version number of the file.
+          returned: no error
+          type: str
+        file_private_part:
+          description: file private part number.
+          returned: no error
+          type: str
+        file_version:
+          description: File version number..
+          returned: no error
+          type: str
+        path:
+          description: file path
+          returned: always
+          type: str
+        product_version:
+          description: The version of the product this file is distributed with.
+          returned: no error
+          type: str
+          sample: "0.34.0+6fb2e41a0452b5e976c84c17722b6f8d91972cfd"
 '''


### PR DESCRIPTION
Wrapped return values in a complex dictionary so format in docs matches the real result. Changed the order to match the order in output.
Added a sample for one of the parameters

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #605 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_file_version
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The only thing that was changed is the documentation file to match the style of [win_stat module](https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_stat_module.html).