### PR TITLE
Add file_version_raw result value to win_file_version

### DIFF
--- a/changelogs/fragments/add-file-version-raw-result-to-win_file_version.yaml
+++ b/changelogs/fragments/add-file-version-raw-result-to-win_file_version.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - win_file_version - Add file_version_raw result for cases where file_version might be empty or in not in the right format.

--- a/plugins/modules/win_file_version.ps1
+++ b/plugins/modules/win_file_version.ps1
@@ -48,7 +48,7 @@ Try {
     If ($null -eq $file_private_part) {
         $file_private_part = ''
     }
-	$file_version_raw = $_version_fields.FileVersionRaw
+    $file_version_raw = $_version_fields.FileVersionRaw
     If ($null -eq $file_version_raw) {
         $file_version_raw = ''
     }

--- a/plugins/modules/win_file_version.ps1
+++ b/plugins/modules/win_file_version.ps1
@@ -19,7 +19,7 @@ If (-Not (Test-Path -LiteralPath $path -PathType Leaf)) {
 }
 $ext = [System.IO.Path]::GetExtension($path)
 If ( $ext -notin '.exe', '.dll') {
-    Fail-Json $result "Specified path $path is not a valid file type; Must be DLL or EXE."
+    Fail-Json $result "Specified path $path is not a valid file type; must be DLL or EXE."
 }
 
 Try {

--- a/plugins/modules/win_file_version.ps1
+++ b/plugins/modules/win_file_version.ps1
@@ -19,7 +19,7 @@ If (-Not (Test-Path -LiteralPath $path -PathType Leaf)) {
 }
 $ext = [System.IO.Path]::GetExtension($path)
 If ( $ext -notin '.exe', '.dll') {
-    Fail-Json $result "Specified path $path is not a valid file type; must be DLL or EXE."
+    Fail-Json $result "Specified path $path is not a valid file type; Must be DLL or EXE."
 }
 
 Try {
@@ -48,6 +48,10 @@ Try {
     If ($null -eq $file_private_part) {
         $file_private_part = ''
     }
+	$file_version_raw = $_version_fields.FileVersionRaw
+    If ($null -eq $file_version_raw) {
+        $file_version_raw = ''
+    }
 }
 Catch {
     Fail-Json $result "Error: $_.Exception.Message"
@@ -60,4 +64,5 @@ $result.win_file_version.file_major_part = $file_major_part.toString()
 $result.win_file_version.file_minor_part = $file_minor_part.toString()
 $result.win_file_version.file_build_part = $file_build_part.toString()
 $result.win_file_version.file_private_part = $file_private_part.toString()
+$result.win_file_version.file_version_raw = $file_version_raw.toString()
 Exit-Json $result

--- a/plugins/modules/win_file_version.py
+++ b/plugins/modules/win_file_version.py
@@ -23,6 +23,7 @@ seealso:
 - module: ansible.windows.win_file
 author:
 - Sam Liu (@SamLiu79)
+- Mikhail Samodurov (@EasyMoney322)
 '''
 
 EXAMPLES = r'''
@@ -32,15 +33,10 @@ EXAMPLES = r'''
   register: exe_file_version
 
 - debug:
-    msg: '{{ exe_file_version }}'
+    msg: '{{ exe_file_version }}.win_file_version'
 '''
 
 RETURN = r'''
-changed:
-    description: Whether anything was changed
-    returned: always
-    type: bool
-    sample: true
 win_file_version:
     description: dictionary containing all the version data
     returned: success
@@ -50,22 +46,32 @@ win_file_version:
           description: build number of the file.
           returned: no error
           type: str
+          sample: "0"
         file_major_part:
           description: the major part of the version number.
           returned: no error
           type: str
+          sample: "0"
         file_minor_part:
           description: the minor part of the version number of the file.
           returned: no error
           type: str
+          sample: "34"
         file_private_part:
           description: file private part number.
           returned: no error
           type: str
+          sample: "0"
         file_version:
-          description: File version number..
+          description: File version number.
           returned: no error
           type: str
+          sample: "0.34.0"
+        file_version_raw:
+          description: File version number that may not match the file_version
+          returned: no error
+          type: str
+          sample: "0.34.0"
         path:
           description: file path
           returned: always

--- a/plugins/modules/win_file_version.py
+++ b/plugins/modules/win_file_version.py
@@ -46,7 +46,7 @@ win_file_version:
           description: build number of the file.
           returned: no error
           type: str
-          sample: "0"
+          sample: "2"
         file_major_part:
           description: the major part of the version number.
           returned: no error
@@ -56,7 +56,7 @@ win_file_version:
           description: the minor part of the version number of the file.
           returned: no error
           type: str
-          sample: "34"
+          sample: "30"
         file_private_part:
           description: file private part number.
           returned: no error
@@ -66,12 +66,12 @@ win_file_version:
           description: File version number.
           returned: no error
           type: str
-          sample: "0.34.0"
+          sample: "v0.30.2"
         file_version_raw:
           description: File version number that may not match the file_version
           returned: no error
           type: str
-          sample: "0.34.0"
+          sample: "0.30.2.0"
         path:
           description: file path
           returned: always
@@ -80,5 +80,5 @@ win_file_version:
           description: The version of the product this file is distributed with.
           returned: no error
           type: str
-          sample: "0.34.0+6fb2e41a0452b5e976c84c17722b6f8d91972cfd"
+          sample: "0.30.2+b4a594409fc9e79e7c5161763cf1c4328e9c5a5d"
 '''

--- a/plugins/modules/win_file_version.py
+++ b/plugins/modules/win_file_version.py
@@ -33,7 +33,7 @@ EXAMPLES = r'''
   register: exe_file_version
 
 - debug:
-    msg: '{{ exe_file_version }}.win_file_version'
+    msg: '{{ exe_file_version.win_file_version }}'
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I suggest adding return value `FileVersionRaw`, as it behaves differently from the `FileVersion`.
`FileVersionRaw` output is guaranteed to be a non-empty string that has strict format.
The `FileVersionRaw` might match the version, be older, newer or be set to `0.0.0.0`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_file_version
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
There are various posts that demonstrate difference in these version values.
Some are on [StackOverflow](https://stackoverflow.com/a/66005), some are on [GitHub](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13842). The thing is, these versions may match or differ.

In my case, the `FileVersion` was missing but the `FileVersionRaw` wasn't and the [windows explorer was showing the raw version](https://imgur.com/4HkR8Jf). In some cases it's better to use the raw version, in some cases it's the opposite.

Thus, both `file_version` and `file_version_raw` are needed. 
Below are two examples that demonstrate it:
<!--- Paste verbatim command output below, e.g. before and after your change -->
The task
```
- name: Get acm instance version
  win_file_version:
    path: 'C:\\Program Files//windows_exporter/windows_exporter.exe'
  register: exe_file_version

- debug:
    msg: '{{ exe_file_version }}'
```

Before:
```paste below
ok: [desktop-rpseca1] => {
    "msg": {
        "changed": false,
        "failed": false,
        "win_file_version": {
            "file_build_part": "1",
            "file_major_part": "0",
            "file_minor_part": "25",
            "file_private_part": "0",
            "file_version": "",
            "path": "C:\\\\Program Files//windows_exporter/windows_exporter.exe",
            "product_version": ""
        }
    }
}
```

After:
```paste below
TASK [debug] ****************************************************************************************************************************
task path: /etc/ansible/playbooks/version.yml:6
ok: [desktop-rpseca1] => {
    "msg": {
        "changed": false,
        "failed": false,
        "win_file_version": {
            "file_build_part": "1",
            "file_major_part": "0",
            "file_minor_part": "25",
            "file_private_part": "0",
            "file_version": "",
            "file_version_raw": "0.25.1.0",
            "path": "C:\\\\Program Files//windows_exporter/windows_exporter.exe",
            "product_version": ""
        }
    }
}
```
Notice that `file_version` is still empty.


This may also help for string comparison when the developers change `file_version` so it starts to return a value with 'v' prefix:
```
ok: [desktop-rpseca1] => {
    "msg": {
        "changed": false,
        "failed": false,
        "win_file_version": {
            "file_build_part": "2",
            "file_major_part": "0",
            "file_minor_part": "30",
            "file_private_part": "0",
            "file_version": "v0.30.2",
            "file_version_raw": "0.30.2.0",
            "path": "C:\\\\Program Files//windows_exporter/windows_exporter.exe",
            "product_version": "v0.30.2"
        }
    }
}
```

Since docs had to be updated, I've also removed `changed` return value as it's both [wasn't necessary](https://github.com/ansible-collections/community.windows/pull/606#issuecomment-2637700614) and [hardcoded to return `false` anyway](https://github.com/ansible-collections/community.windows/blob/bc8260613daa71873f5101147eefafc300e72e21/plugins/modules/win_file_version.ps1#L12).