### PR TITLE
win_firewall_rule.py: add reference to IPv6 types and codes

### DIFF
--- a/plugins/modules/win_firewall_rule.py
+++ b/plugins/modules/win_firewall_rule.py
@@ -111,6 +111,7 @@ options:
       - Set the value to just C(*) to apply the rule for all ICMP type codes.
       - See U(https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
         for a list of ICMP types and the codes that apply to them.
+      - ICMP types and codes for IPV6 can be found at U(https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml).
     type: list
     elements: str
 notes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This change adds a URL to IANAs IPv6 types and codes parameters to the comments section of `icmp_type_code`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_firewall_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
