### PR TITLE
Add doc reqs for redirection

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -22,6 +22,7 @@ jobs:
       init-lenient: false
       init-fail-on-error: true
       build-ref: refs/pull/${{ github.event.number }}/merge
+      extra-collections: microsoft.ad microsoft.iis
 
   # The build job runs with the most lenient settings to ensure the best chance of getting
   # a rendered docsite that can be looked at.


### PR DESCRIPTION
##### SUMMARY
The doc validation will fail when we add the `microsoft.iis` references in a subsequent PR. This makes sure the doc validation can find them without actually adding the collection as a runtime requirement.

##### ISSUE TYPE
- Docs Pull Request