### PR TITLE
Update ansible-lint to current Galaxy version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -512,3 +512,6 @@ changelogs/.plugin-cache.yaml
 
 # ansible-test ignores
 tests/integration/inventory*
+
+# Ansible dev tools
+.ansible/

--- a/tests/utils/shippable/lint.sh
+++ b/tests/utils/shippable/lint.sh
@@ -3,11 +3,12 @@
 set -o pipefail -eux
 
 # This is aligned with the galaxy-importer used by AH.
-# Need to pin to the released tag at.
-# https://github.com/ansible/galaxy_ng/blob/master/requirements/requirements.common.txt
-#
-# The galaxy_ng_commit from can be used to find the specific commit to check.
+# Check what galaxy_importer_version is used in the galaxy project at
 # https://galaxy.ansible.com/api/
+
+# Then check the ansible-lint upper bound at
+# https://github.com/ansible/galaxy-importer/blob/v${VERSION}/setup.cfg
+
 python -m pip install \
     'ansible-lint==24.12.2' \
     'ansible-compat==24.10.0'

--- a/tests/utils/shippable/lint.sh
+++ b/tests/utils/shippable/lint.sh
@@ -10,7 +10,6 @@ set -o pipefail -eux
 # https://github.com/ansible/galaxy-importer/blob/v${VERSION}/setup.cfg
 
 python -m pip install \
-    'ansible-lint==24.12.2' \
-    'ansible-compat==24.10.0'
+    'ansible-lint==25.1.2'
 
 ansible-lint


### PR DESCRIPTION
##### SUMMARY

Update the ansible-lint version to the current one used in Galaxy/AH.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request