### PR TITLE
Fix up script name used for reporting coverage

### DIFF
--- a/.azure-pipelines/templates/coverage.yml
+++ b/.azure-pipelines/templates/coverage.yml
@@ -23,7 +23,7 @@ jobs:
       - bash: .azure-pipelines/scripts/report-coverage.sh
         displayName: Generate Coverage Report
         condition: gt(variables.coverageFileCount, 0)
-      - bash: .azure-pipelines/scripts/publish-codecov.sh "$(outputPath)"
+      - bash: .azure-pipelines/scripts/publish-codecov.py "$(outputPath)"
         displayName: Publish to codecov.io
         condition: gt(variables.coverageFileCount, 0)
         continueOnError: true


### PR DESCRIPTION
##### SUMMARY
A previous PR updated the script from the `.sh` to `.py` version used in the latest collection template but this reference was missed.

##### ISSUE TYPE
- Bugfix Pull Request