### PR TITLE
Remove extra quotes from $rabbitmq_plugins_cmd to avoid errors

### DIFF
--- a/changelogs/fragments/635-fix-rabbitmq-plugins-quote.yml
+++ b/changelogs/fragments/635-fix-rabbitmq-plugins-quote.yml
@@ -1,2 +1,3 @@
 bugfixes:
-  - win_rabbitmq_plugin - removed redundant quotes that caused failures when specifying ``rabbitmq_bin_path`` (https://github.com/ansible-collections/community.windows/issues/635).
+  - win_rabbitmq_plugin - removed redundant quotes that caused failures when specifying ``rabbitmq_bin_path``
+    (https://github.com/ansible-collections/community.windows/issues/635).

--- a/changelogs/fragments/635-fix-rabbitmq-plugins-quote.yml
+++ b/changelogs/fragments/635-fix-rabbitmq-plugins-quote.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fix incorrect quoting in ``win_rabbitmq_plugin`` module that caused failures when specifying ``rabbitmq_bin_path``. The ``rabbitmq-plugins`` command now executes properly without redundant quotes.
+  - win_rabbitmq_plugin - removed redundant quotes that caused failures when specifying ``rabbitmq_bin_path`` (https://github.com/ansible-collections/community.windows/issues/635).

--- a/changelogs/fragments/635-fix-rabbitmq-plugins-quote.yml
+++ b/changelogs/fragments/635-fix-rabbitmq-plugins-quote.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix incorrect quoting in ``win_rabbitmq_plugin`` module that caused failures when specifying ``rabbitmq_bin_path``. The ``rabbitmq-plugins`` command now executes properly without redundant quotes.

--- a/plugins/modules/win_rabbitmq_plugin.ps1
+++ b/plugins/modules/win_rabbitmq_plugin.ps1
@@ -101,7 +101,7 @@ else {
 }
 
 if ($rabbitmq_bin_path) {
-    $rabbitmq_plugins_cmd = "'$(Join-Path -Path $rabbitmq_bin_path -ChildPath "rabbitmq-plugins")'"
+    $rabbitmq_plugins_cmd = "$(Join-Path -Path $rabbitmq_bin_path -ChildPath "rabbitmq-plugins")"
 }
 else {
     $rabbitmq_plugins_cmd = "rabbitmq-plugins"


### PR DESCRIPTION
Fixes: #635 

##### SUMMARY
The single quotes break the execution, so I simply remove it.

##### ISSUE TYPE 
- Bugfix Pull Request 

##### COMPONENT NAME
win_rabbitmq_plugin

##### ADDITIONAL INFORMATION

Check issue #635 for further details
 
