### PR TITLE
Filter out disks without a number to avoid errors later on

### DIFF
--- a/plugins/modules/win_disk_facts.ps1
+++ b/plugins/modules/win_disk_facts.ps1
@@ -41,7 +41,7 @@ $module.Result.ansible_facts = @{ ansible_disks = @() }
 
 # Search disks
 try {
-    $disks = Get-Disk
+    $disks = Get-Disk | Where-Object { $_.Number -ne $null }
 }
 catch {
     $module.FailJson("Failed to search the disks on the target: $($_.Exception.Message)", $_)


### PR DESCRIPTION
##### SUMMARY
A fix to a situation where the Get-Disk command returns disks without numbers

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_disk_facts.ps1

##### ADDITIONAL INFORMATION
The win_disk_facts.ps1 enumerates disks using output from the Get-Disk command. While enumerating, the script tries to use the Number of the disk. When using Windows Server Failover Clustering (WSFC), the list may contain disks without a number from other nodes in the cluster. These disks are not visible in the traditional Windows Disk Management nor in File Explorer, but they are listed in the Get-Disk output. This PR adds a filter to the Get-Disk to filter out the disks without a number - otherwise such disks cause the script to fail, and in my opinion, these disks from other nodes should not be included in the output.

This is the error that occurs when a disk without a number is being processed:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: at <ScriptBlock>, <No file>: line 215
fatal: [hostname1]: FAILED! => {"changed": false, "msg": "Unhandled exception while executing module: Cannot validate argument on parameter 'DiskNumber'. The argument is null. Provide a valid value for the argument, and then try running the command again."}
```
