### PR TITLE
win_psrepository_copy - improve changed check

### DIFF
--- a/changelogs/fragments/win_psrepository_copy-comparison.yml
+++ b/changelogs/fragments/win_psrepository_copy-comparison.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_psrepository_copy - Fix idempotence check to not rely on .NET runtime implementation details. This should
+    avoid any false positive changed indicators


### PR DESCRIPTION
##### SUMMARY
Improves the method used by `win_psrepository_copy` to determine if any changes are needed by not relying on the hashtable ordering implementation. This is not strictly defined and newer .NET runtimes have issues with how this gets serialized. Using a SortedDictionary gives us a better guarantee of the serialized output and thus better idempotency check.

##### ISSUE TYPE
- Bugfix Pull Request