### PR TITLE
win_xml: add prefix parameter

### DIFF
--- a/changelogs/fragments/670-win-xml-set-default-prefix.yml
+++ b/changelogs/fragments/670-win-xml-set-default-prefix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - win_xml - allow users to define the prefix of the default namespace (https://github.com/ansible-collections/community.windows/issues/670).

--- a/plugins/modules/win_xml.py
+++ b/plugins/modules/win_xml.py
@@ -65,6 +65,11 @@ options:
         type: bool
         default: false
         version_added: "3.2.0"
+    prefix:
+        description:
+        - The prefix you are using in the I(xpath).
+        type: str
+        version_added: "3.2.0"
 author:
     - Richard Levenberg (@richardcs)
     - Jon Hawkesworth (@jhawkesworth)
@@ -118,6 +123,15 @@ EXAMPLES = r'''
     attribute: lang
     fragment: nl
     type: attribute
+
+- name: add an attribute on a file with default namespace
+  win_xml:
+    path: C:\Data\html_table.xml"
+    xpath: /x:table/x:tr
+    prefix: x
+    fragment: fruits
+    type: attribute
+    attribute: category
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/win_xml/files/html_table.xml
+++ b/tests/integration/targets/win_xml/files/html_table.xml
@@ -1,0 +1,10 @@
+<table xmlns="http://www.w3.org/TR/html4/">
+  <tr id="0">
+    <td>Apples</td>
+    <td>Bananas</td>
+  </tr>
+  <tr id="1">
+    <td>Phone</td>
+    <td>Computer</td>
+  </tr>
+</table>

--- a/tests/integration/targets/win_xml/tasks/default_namespace.yml
+++ b/tests/integration/targets/win_xml/tasks/default_namespace.yml
@@ -1,0 +1,48 @@
+- name: copy a test .xml file
+  ansible.windows.win_copy:
+    src: html_table.xml
+    dest: "{{ remote_tmp_dir }}\\html_table.xml"
+
+- name: add an attribute using query only
+  win_xml:
+    path: "{{ remote_tmp_dir }}\\html_table.xml"
+    xpath: "//*[local-name() = 'table' and namespace-uri() = 'http://www.w3.org/TR/html4/']//*[local-name() = 'tr' and namespace-uri() = 'http://www.w3.org/TR/html4/'][@id='0']"
+    fragment: fruits
+    type: attribute
+    attribute: category
+  register: attribute_add_result
+
+- name: check attribute add result
+  assert:
+    that:
+    - attribute_add_result is changed
+
+- name: add an attribute using query and defining namespace
+  win_xml:
+    path: "{{ remote_tmp_dir }}\\html_table.xml"
+    xpath: /x:table/x:tr[@id='1']
+    prefix: x
+    fragment: tech
+    type: attribute
+    attribute: category
+  register: attribute_add_prefix_result
+
+- name: check element add result
+  assert:
+    that:
+    - attribute_add_prefix_result is changed
+
+- name: remove an attribute using query and defining namespace
+  win_xml:
+    path: "{{ remote_tmp_dir }}\\html_table.xml"
+    xpath: /x:table/x:tr[@id='1']
+    prefix: x
+    state: absent
+    type: attribute
+    attribute: category
+  register: attribute_rm_prefix_result
+
+- name: check element add result
+  assert:
+    that:
+    - attribute_rm_prefix_result is changed

--- a/tests/integration/targets/win_xml/tasks/main.yml
+++ b/tests/integration/targets/win_xml/tasks/main.yml
@@ -419,3 +419,5 @@
       - multi_attr_again.msg == 'not changed'
 
 - include_tasks: config_with_tab.yml
+
+- include_tasks: default_namespace.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a parameter to win_xml to define the prefix of a default namespace. Futhermore, the modification of attributes has changed from .saveAttribute() to Attributes.Append(). This stops the module from writing a temporary namespace to the nodes that are changed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #670
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
changelogs/fragments/win_xml-read.yml
plugins/modules/win_xml.ps1
plugins/modules/win_xml.py
tests/integration/targets/win_xml/tasks/default_namespace.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
XML:
You have the following xml.
```xml
<table xmlns="http://www.w3.org/TR/html4/">
  <tr>
    <td>Apples</td>
    <td>Bananas</td>
  </tr>
</table>
```
To edit a XML file with a default namespace (no prefix), you had to use the following Xpath structure
```yaml
xpath: "//*[local-name() = 'table' and namespace-uri() = 'http://www.w3.org/TR/html4/']//*[local-name() = 'tr' and namespace-uri() = 'http://www.w3.org/TR/html4/']"
```
Furthermore, the namespace (with a random prefix) was added to the edited nodes.
```yaml
- name: Add an attribute
  community.windows.win_xml:
    path: "{{ xml_filepath }}"
    xpath: "//*[local-name() = 'table' and namespace-uri() = 'http://www.w3.org/TR/html4']//*[local-name() = 'tr' and namespace-uri() = 'http://www.w3.org/TR/html4']"
    type: attribute
    attribute: category
    fragment: fruits
```
```xml
<table xmlns="http://www.w3.org/TR/html4/">
  <tr d2p1:category="fruits" xmlns:d2p1="http://www.w3.org/TR/html4/">
    <td>Apples</td>
    <td>Bananas</td>
  </tr>
</table>
```
Now, you can run the following play:
```yaml
- name: Add an attribute
  community.windows.win_xml:
    path: "{{ xml_filepath }}"
    xpath: /x:table/x:tr
    prefix: x
    type: attribute
    attribute: category
    fragment: fruits
```
or this play (to keep existant code working):
```yaml
- name: Add an attribute
  community.windows.win_xml:
    path: "{{ xml_filepath }}"
    xpath: "//*[local-name() = 'table' and namespace-uri() = 'http://www.w3.org/TR/html4']//*[local-name() = 'tr' and namespace-uri() = 'http://www.w3.org/TR/html4']"
    type: attribute
    attribute: category
    fragment: fruits
```
And have the following output:
```xml
<table xmlns="http://www.w3.org/TR/html4/">
  <tr category="fruits">
    <td>Apples</td>
    <td>Bananas</td>
  </tr>
</table>
```
