### PR TITLE
Add win_log_properties module to configure eventlog

### DIFF
--- a/plugins/modules/win_log_properties.ps1
+++ b/plugins/modules/win_log_properties.ps1
@@ -35,9 +35,6 @@ catch {
     $module.FailJson("Object Name does not exists", $_)
 }
 
-$module.Diff.before = @{ }
-$module.Diff.after = @{ }
-
 $module.Diff.before = @{ enabled = $log.Enabled; retention = $log.Retention; auto_backup = $log.AutoBackup; size = $log.MaxLogSize; }
 
 

--- a/plugins/modules/win_log_properties.ps1
+++ b/plugins/modules/win_log_properties.ps1
@@ -1,0 +1,76 @@
+#!powershell
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{ type = 'str'; required = $true }
+        enabled = @{ type = 'bool' }
+        size = @{ type = 'int' }
+        mode = @{ type = 'str'; choices = @( 'overwrite', 'archive', 'no_overwrite' ) }
+
+    }
+    required_one_of = @(
+        , @('enabled', 'size', 'mode')
+    )
+
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module.Result.changed = $false
+
+$enabled = $module.Params.enabled
+$size = $module.Params.size
+$mode = $module.Params.mode
+
+
+try {
+    $log = Get-LogProperties -Name $module.Params.name
+}
+catch {
+    $module.FailJson("Object Name does not exists", $_)
+}
+
+$module.Diff.before = @{ }
+$module.Diff.after = @{ }
+
+$module.Diff.before = @{ enabled = $log.Enabled; retention = $log.Retention; auto_backup = $log.AutoBackup; size = $log.MaxLogSize; }
+
+
+if ($null -ne $enabled -and $log.Enabled -ne $enabled) {
+    $log.Enabled = $enabled
+    $module.Result.changed = $true
+}
+
+if ($size -and $log.MaxLogSize -ne $size) {
+    if ($size -ge 1052672) {
+        $log.MaxLogSize = $size
+        $module.Result.changed = $true
+    }
+    else {
+        $module.FailJson("Size must be larger than 1052672")
+    }
+}
+
+if ($null -ne $mode) {
+    $retention = $mode -eq 'archive' -or $mode -eq 'no_overwrite'
+    $auto_backup = $mode -eq 'archive'
+
+    if ($log.Retention -ne $retention -or $log.AutoBackup -ne $auto_backup) {
+        $log.Retention = $retention
+        $log.AutoBackup = $auto_backup
+        $module.Result.changed = $true
+    }
+}
+
+if ($module.Result.changed -and -Not($module.CheckMode)) {
+    Set-LogProperties -LogDetails $log
+}
+
+$module.Diff.after = @{ enabled = $log.Enabled; retention = $log.Retention; auto_backup = $log.AutoBackup; size = $log.MaxLogSize; }
+
+$module.ExitJson()

--- a/plugins/modules/win_log_properties.py
+++ b/plugins/modules/win_log_properties.py
@@ -39,6 +39,17 @@ author:
 """
 
 EXAMPLES = r"""
+- name: Enable PrintService Admin log, set size and archive full logs
+  win_log_properties:
+    name: Microsoft-Windows-PrintService/Admin
+    enabled: true
+    size: 10485760
+    mode: archive
+
+- name: Enable PrintService Operational log
+  win_log_properties:
+    name: Microsoft-Windows-PrintService/Operational
+    enabled: true
 """
 
 RETURN = r"""

--- a/plugins/modules/win_log_properties.py
+++ b/plugins/modules/win_log_properties.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: win_log_properties
+short_description: Set the properties for an eventlog
+description:
+  - Set the properties for an eventlog, it is possible to configure if the log should be enabled,
+  - the maximum log size and how the log should handle reaching the maximum size.
+options:
+  name:
+    description:
+      - The name of the eventlog to configure
+    type: str
+    required: true
+  enabled:
+    description:
+      - Should the eventlog be enabled
+    type: bool
+  size:
+    description:
+      - Sets the max log size, must be larger than 1052672
+    type: int
+  mode:
+    description:
+      - Sets how eventlog handles log when it reaches size. This matches the setting in the eventlog
+      - properties window and it affect two values, auto_backup and retention.
+      - C(overwrite) overwrites oldest logs
+      - C(archive) rotates logs and backups old logs
+      - C(no_overwrite) logging stops when log is full
+    type: str
+    choices: [ overwrite, archive, no_overwrite ]
+author:
+  - Mikael Olofsson (@quiphius)
+"""
+
+EXAMPLES = r"""
+"""
+
+RETURN = r"""
+"""


### PR DESCRIPTION
##### SUMMARY
A new module to set the properties for an eventlog, it is possible to configure if the log should be enabled, the maximum log size and how the log should handle reaching the maximum size.

The name is chosen to match the PowerShell cmdlets used.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_log_properties

##### ADDITIONAL INFORMATION
