### PR TITLE
Remove 2016 from CI tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -167,10 +167,8 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}/5.1/1
           targets:
-            - name: Server 2016 WinRM HTTP
-              test: 2016/winrm/http
-            - name: Server 2019 WinRM HTTPS
-              test: 2019/winrm/https
+            - name: Server 2019 WinRM HTTP
+              test: 2019/winrm/http
             - name: Server 2022 WinRM HTTPS
               test: 2022/winrm/https
             - name: Server 2022 PSRP HTTPS
@@ -205,10 +203,8 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}/5.1/2
           targets:
-            - name: Server 2016 WinRM HTTP
-              test: 2016/winrm/http
-            - name: Server 2019 WinRM HTTPS
-              test: 2019/winrm/https
+            - name: Server 2019 WinRM HTTP
+              test: 2019/winrm/http
             - name: Server 2022 WinRM HTTPS
               test: 2022/winrm/https
             - name: Server 2022 PSRP HTTPS
@@ -243,10 +239,8 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}/5.1/3
           targets:
-            - name: Server 2016 WinRM HTTP
-              test: 2016/winrm/http
-            - name: Server 2019 WinRM HTTPS
-              test: 2019/winrm/https
+            - name: Server 2019 WinRM HTTP
+              test: 2019/winrm/http
             - name: Server 2022 WinRM HTTPS
               test: 2022/winrm/https
             - name: Server 2022 PSRP HTTPS
@@ -281,10 +275,8 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}/5.1/4
           targets:
-            - name: Server 2016 WinRM HTTP
-              test: 2016/winrm/http
-            - name: Server 2019 WinRM HTTPS
-              test: 2019/winrm/https
+            - name: Server 2019 WinRM HTTP
+              test: 2019/winrm/http
             - name: Server 2022 WinRM HTTPS
               test: 2022/winrm/https
             - name: Server 2022 PSRP HTTPS
@@ -319,10 +311,8 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}/5.1/5
           targets:
-            - name: Server 2016 WinRM HTTP
-              test: 2016/winrm/http
-            - name: Server 2019 WinRM HTTPS
-              test: 2019/winrm/https
+            - name: Server 2019 WinRM HTTP
+              test: 2019/winrm/http
             - name: Server 2022 WinRM HTTPS
               test: 2022/winrm/https
             - name: Server 2022 PSRP HTTPS


### PR DESCRIPTION
##### SUMMARY
Remove Server 2016 from CI matrix as it has been removed in Ansible devel due to its impending EOL.
