### PR TITLE
win_unzip: use native tar.exe where available

### DIFF
--- a/changelogs/fragments/win_unzip-tar-exe.yml
+++ b/changelogs/fragments/win_unzip-tar-exe.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - >-
+    win_unzip - Use ``tar.exe`` from ``%SystemRoot%\System32`` on Windows 10 build 17063 and later
+    and Windows Server 2019 and later to extract tar-based archives (``.tar``, ``.tar.gz``/``.tgz``,
+    ``.tar.bz2``/``.tbz2``, ``.tar.xz``/``.txz``) without requiring PSCX. On older systems where
+    ``tar.exe`` is not available, PSCX remains the fallback. PSCX is still required for passwords,
+    recursive extraction, and non-tar formats other than ``.zip``.

--- a/changelogs/fragments/win_unzip-tar-exe.yml
+++ b/changelogs/fragments/win_unzip-tar-exe.yml
@@ -5,3 +5,8 @@ minor_changes:
     ``.tar.bz2``/``.tbz2``, ``.tar.xz``/``.txz``) without requiring PSCX. On older systems where
     ``tar.exe`` is not available, PSCX remains the fallback. PSCX is still required for passwords,
     recursive extraction, and non-tar formats other than ``.zip``.
+bugfixes:
+  - >-
+    win_unzip - Use ``-LiteralPath`` when calling PSCX ``Expand-Archive`` so paths containing
+    PowerShell wildcard characters (e.g. ``[``, ``]``) are not glob-expanded and silently
+    resolved to an empty array.

--- a/plugins/modules/win_unzip.ps1
+++ b/plugins/modules/win_unzip.ps1
@@ -203,7 +203,8 @@ If ($use_pscx) {
     $list = Get-Module -ListAvailable
 
     If (-Not ($list -match "PSCX")) {
-        Fail-Json -obj $result -message "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for this archive type, recursive extraction, or password-protected archives."
+        Fail-Json -obj $result -message ("PowerShellCommunityExtensions PowerShell Module (PSCX) is required " +
+            "for this archive type, recursive extraction, or password-protected archives.")
     }
     Else {
         $result.pscx_status = "present"

--- a/plugins/modules/win_unzip.ps1
+++ b/plugins/modules/win_unzip.ps1
@@ -95,25 +95,21 @@ Function Get-SystemTarExePath {
 }
 
 Function Expand-WithTar($src, $dest, $tar_exe) {
-    # Lower $ErrorActionPreference so that stderr from tar.exe does not become a
-    # terminating PowerShell error under the module-level "Stop" preference.
-    $prev_eap = $ErrorActionPreference
+    # Function-scoped: prevents stderr from tar.exe becoming a terminating
+    # PowerShell error under the module-level "Stop" preference.
     $ErrorActionPreference = "Continue"
+    $rc = 0
     $tar_output = $null
-    $failed = $false
     try {
         $tar_output = & $tar_exe -xf $src -C $dest 2>&1
-        $failed = $LASTEXITCODE -ne 0
+        $rc = $LASTEXITCODE
     }
     catch {
-        $failed = $true
+        $rc = -1
         $tar_output = $_.Exception.Message
     }
-    finally {
-        $ErrorActionPreference = $prev_eap
-    }
-    if ($failed) {
-        Fail-Json -obj $result -message "Error extracting '$src' to '$dest' using tar.exe: $tar_output"
+    if ($rc) {
+        Fail-Json -obj $result -message "Error extracting '$src' to '$dest' using tar.exe (rc=$rc): $tar_output"
     }
     $result.changed = $true
 }

--- a/plugins/modules/win_unzip.ps1
+++ b/plugins/modules/win_unzip.ps1
@@ -84,6 +84,40 @@ Function Expand-ZipLegacy($src, $dest) {
     $result.changed = $true
 }
 
+Function Get-SystemTarExePath {
+    # Only use the tar.exe that ships with Windows 10 / Server 2019+; do not
+    # search PATH to avoid picking up an unknown third-party binary.
+    $system_tar = [System.IO.Path]::Combine($env:SystemRoot, 'System32', 'tar.exe')
+    if (Test-Path -LiteralPath $system_tar) {
+        return $system_tar
+    }
+    return $null
+}
+
+Function Expand-WithTar($src, $dest, $tar_exe) {
+    # Lower $ErrorActionPreference so that stderr from tar.exe does not become a
+    # terminating PowerShell error under the module-level "Stop" preference.
+    $prev_eap = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $tar_output = $null
+    $failed = $false
+    try {
+        $tar_output = & $tar_exe -xf $src -C $dest 2>&1
+        $failed = $LASTEXITCODE -ne 0
+    }
+    catch {
+        $failed = $true
+        $tar_output = $_.Exception.Message
+    }
+    finally {
+        $ErrorActionPreference = $prev_eap
+    }
+    if ($failed) {
+        Fail-Json -obj $result -message "Error extracting '$src' to '$dest' using tar.exe: $tar_output"
+    }
+    $result.changed = $true
+}
+
 If ($creates -and (Test-Path -LiteralPath $creates)) {
     $result.skipped = $true
     $result.msg = "The file or directory '$creates' already exists."
@@ -104,6 +138,14 @@ If (-Not (Test-Path -LiteralPath $dest -PathType Container)) {
         Fail-Json -obj $result -message "Error creating '$dest' directory! Msg: $($_.Exception.Message)"
     }
 }
+
+# tar.exe (ships with Windows 10 build 17063+ / Server 2019+) handles tar-based
+# formats natively. It does not support passwords, recursive nested extraction,
+# standalone .gz/.bz2, or .msu - those still require PSCX.
+$filename_lower = [System.IO.Path]::GetFileName($src).ToLower()
+$is_tar_compatible = $filename_lower -match '\.(tar|tar\.gz|tgz|tar\.bz2|tbz2|tar\.xz|txz)$'
+
+$use_pscx = $false
 
 If ($ext -eq ".zip" -And $recurse -eq $false -And -Not $password) {
     # TODO: PS v5 supports zip extraction, use that if available
@@ -135,12 +177,33 @@ If ($ext -eq ".zip" -And $recurse -eq $false -And -Not $password) {
         }
     }
 }
+ElseIf ($is_tar_compatible -And -Not $password -And -Not $recurse) {
+    $tar_exe = Get-SystemTarExePath
+    If ($tar_exe) {
+        If ($check_mode) {
+            # In check mode the dest directory may not exist yet (New-Item ran with -WhatIf)
+            # and there is nothing to execute anyway; just report changed.
+            $result.changed = $true
+        }
+        Else {
+            Expand-WithTar -src $src -dest $dest -tar_exe $tar_exe
+        }
+    }
+    Else {
+        # System tar.exe not available (Windows older than 10 build 17063 / Server 2019); fall back to PSCX
+        $use_pscx = $true
+    }
+}
 Else {
+    $use_pscx = $true
+}
+
+If ($use_pscx) {
     # Check if PSCX is installed
     $list = Get-Module -ListAvailable
 
     If (-Not ($list -match "PSCX")) {
-        Fail-Json -obj $result -message "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for non-'.zip' compressed archive types."
+        Fail-Json -obj $result -message "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for this archive type, recursive extraction, or password-protected archives."
     }
     Else {
         $result.pscx_status = "present"
@@ -161,7 +224,9 @@ Else {
         $expand_params.Password = ConvertTo-SecureString -String $password -AsPlainText -Force
     }
     Try {
-        Expand-Archive -Path $src @expand_params
+        # Use -LiteralPath to prevent PowerShell wildcard-expanding brackets and other
+        # special characters that may appear in the path (e.g. [$!@^&test(;)]).
+        Expand-Archive -LiteralPath $src @expand_params
     }
     Catch {
         Fail-Json -obj $result -message "Error expanding '$src' to '$dest'! Msg: $($_.Exception.Message)"
@@ -170,7 +235,7 @@ Else {
     If ($recurse) {
         Get-ChildItem -LiteralPath $dest -recurse | Where-Object { $pcx_extensions -contains $_.extension } | ForEach-Object {
             Try {
-                Expand-Archive -Path $_.FullName -Force @expand_params
+                Expand-Archive -LiteralPath $_.FullName -Force @expand_params
             }
             Catch {
                 Fail-Json -obj $result -message "Error recursively expanding '$src' to '$dest'! Msg: $($_.Exception.Message)"

--- a/plugins/modules/win_unzip.py
+++ b/plugins/modules/win_unzip.py
@@ -10,11 +10,18 @@ module: win_unzip
 short_description: Unzips compressed files and archives on the Windows node
 description:
 - Unzips compressed files and archives.
-- Supports .zip files natively.
-- Supports other formats supported by the Powershell Community Extensions (PSCX) module (basically everything 7zip supports).
+- Supports .zip files natively via the .NET BCL.
+- Supports tar-based formats (C(.tar), C(.tar.gz)/C(.tgz), C(.tar.bz2)/C(.tbz2), C(.tar.xz)/C(.txz))
+  via C(tar.exe) present in C(%SystemRoot%\System32) on Windows 10 build 17063 and later
+  and Windows Server 2019 and later, with no additional software required.
+- Supports other formats (C(.gz), C(.bz2), C(.msu) and others) via the PowerShell Community
+  Extensions (PSCX) module. PSCX is also required when using the O(recurse) or O(password) options.
 - For non-Windows targets, use the M(ansible.builtin.unarchive) module instead.
 requirements:
-- PSCX
+- C(tar.exe) at C(%SystemRoot%\System32) for tar-based formats without O(recurse) or O(password)
+  (ships with Windows 10 build 17063+ and Windows Server 2019+).
+- PSCX for formats other than C(.zip) and tar-based, or when using O(recurse) or O(password).
+  Also used as a fallback on older systems where C(tar.exe) is not present.
 options:
   src:
     description:
@@ -48,9 +55,13 @@ options:
       - Passing a value to a password parameter requires the PSCX module to be installed.
 notes:
 - This module is not really idempotent, it will extract the archive every time, and report a change.
-- For extracting any compression types other than .zip, the PowerShellCommunityExtensions (PSCX) Module is required.  This module (in conjunction with PSCX)
-  has the ability to recursively unzip files within the src zip file provided and also functionality for many other compression types. If the destination
-  directory does not exist, it will be created before unzipping the file.  Specifying rm parameter will force removal of the src file after extraction.
+- For tar-based formats (C(.tar), C(.tar.gz), C(.tgz), C(.tar.bz2), C(.tbz2), C(.tar.xz), C(.txz))
+  the module uses C(%SystemRoot%\System32\tar.exe) when available, requiring no extra software.
+  On older systems where C(tar.exe) is not present, the module falls back to PSCX.
+- For all other compression types, or when O(recurse) or O(password) are used, the
+  PowerShellCommunityExtensions (PSCX) module is required. If the destination directory does not
+  exist, it will be created before unzipping the file. Specifying rm parameter will force removal
+  of the src file after extraction.
 seealso:
 - module: ansible.builtin.unarchive
 author:
@@ -72,6 +83,12 @@ EXAMPLES = r'''
     src: C:\Logs\application-error-logs.gz
     dest: C:\ExtractedLogs\application-error-logs
 
+- name: Extract a tar.gz archive (uses tar.exe on Windows 10/Server 2019+, no extra software needed)
+  community.windows.win_unzip:
+    src: C:\Downloads\package.tar.gz
+    dest: C:\Extracted\package
+    delete_archive: true
+
 # Unzip .zip file, recursively decompresses the contained .gz files and removes all unneeded compressed files after completion.
 - name: Recursively decompress GZ files in ApplicationLogs.zip
   community.windows.win_unzip:
@@ -80,6 +97,7 @@ EXAMPLES = r'''
     recurse: true
     delete_archive: true
 
+# PSCX is required for: non-tar formats other than .zip, recurse, and password-protected archives.
 - name: Install PSCX
   community.windows.win_psmodule:
     name: Pscx

--- a/plugins/modules/win_unzip.py
+++ b/plugins/modules/win_unzip.py
@@ -19,10 +19,9 @@ description:
   and for tar-based formats prior to C(community.windows 3.2.0).
 - For non-Windows targets, use the M(ansible.builtin.unarchive) module instead.
 requirements:
-- C(tar.exe) at C(%SystemRoot%\System32) for tar-based formats without O(recurse) or O(password)
-  (ships with Windows 10 build 17063+ and Windows Server 2019+).
 - PSCX for formats other than C(.zip) and tar-based, or when using O(recurse) or O(password).
-  Also used as a fallback on older systems where C(tar.exe) is not present.
+  Also required for tar-based formats prior to C(community.windows 3.2.0), or on older OS versions
+  which did not ship C(tar.exe).
 options:
   src:
     description:

--- a/plugins/modules/win_unzip.py
+++ b/plugins/modules/win_unzip.py
@@ -12,10 +12,11 @@ description:
 - Unzips compressed files and archives.
 - Supports .zip files natively via the .NET BCL.
 - Supports tar-based formats (C(.tar), C(.tar.gz)/C(.tgz), C(.tar.bz2)/C(.tbz2), C(.tar.xz)/C(.txz))
-  via C(tar.exe) present in C(%SystemRoot%\System32) on Windows 10 build 17063 and later
-  and Windows Server 2019 and later, with no additional software required.
+  via C(tar.exe) as of C(community.windows 3.2.0). C(tar.exe) ships with Windows 10 build 17063 and
+  later and Windows Server 2019 and later, with no additional software required.
 - Supports other formats (C(.gz), C(.bz2), C(.msu) and others) via the PowerShell Community
-  Extensions (PSCX) module. PSCX is also required when using the O(recurse) or O(password) options.
+  Extensions (PSCX) module. PSCX is also required when using the O(recurse) or O(password) options,
+  and for tar-based formats prior to C(community.windows 3.2.0).
 - For non-Windows targets, use the M(ansible.builtin.unarchive) module instead.
 requirements:
 - C(tar.exe) at C(%SystemRoot%\System32) for tar-based formats without O(recurse) or O(password)

--- a/tests/integration/targets/win_unzip/files/create_tar.py
+++ b/tests/integration/targets/win_unzip/files/create_tar.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import io
+import sys
+import tarfile
+
+
+def main():
+    content = b'hello from tar'
+
+    with tarfile.open(sys.argv[1], 'w:gz') as tar:
+        info = tarfile.TarInfo(name='hello.txt')
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/win_unzip/tasks/main.yml
+++ b/tests/integration/targets/win_unzip/tasks/main.yml
@@ -169,3 +169,123 @@
       - escape.results | map(attribute='failed') | unique | list == [True]
       - files.matched == 1
       - files.files[0]['filename'] == 'rabbit.txt'
+
+# Regression test: zip with recurse still routes through PSCX, not tar.exe.
+# Also exercises the -LiteralPath fix on the Unicode+special-char path.
+# Skipped when PSCX is not installed (e.g. in bare CI environments).
+- name: check if PSCX is installed
+  ansible.windows.win_shell: |
+    if (Get-Module -ListAvailable -Name Pscx) { 'present' } else { 'absent' }
+  register: pscx_check
+  changed_when: false
+
+- name: unarchive zip with recurse (PSCX path)
+  win_unzip:
+    src: '{{ win_unzip_dir }}\hat1.zip'
+    dest: '{{ win_unzip_dir }}\output_pscx'
+    recurse: true
+  register: unzip_pscx
+  when: pscx_check.stdout | trim == 'present'
+
+- name: get result of unarchive zip with recurse
+  ansible.windows.win_stat:
+    path: '{{ win_unzip_dir }}\output_pscx\rabbit.txt'
+  register: unzip_pscx_actual
+  when: pscx_check.stdout | trim == 'present'
+
+- name: assert zip with recurse used PSCX
+  assert:
+    that:
+    - unzip_pscx is changed
+    - unzip_pscx.pscx_status == 'present'
+    - unzip_pscx_actual.stat.exists
+  when: pscx_check.stdout | trim == 'present'
+
+# Tests for tar.exe extraction path (Windows 10 build 17063+ / Server 2019+)
+# Use remote_tmp_dir (plain ASCII path) so tar.exe can pass the path to the
+# external process without hitting the PSNativeCommandArgumentPassing encoding
+# bug that affects non-ASCII / special-character paths.
+- name: create local tar.gz file
+  script: create_tar.py {{ output_dir + '/win_unzip.tar.gz' | quote }}
+  delegate_to: localhost
+
+- name: copy tar.gz to Windows host
+  ansible.windows.win_copy:
+    src: '{{ output_dir }}/win_unzip.tar.gz'
+    dest: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+
+- name: unarchive tar.gz (check)
+  win_unzip:
+    src: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+    dest: '{{ remote_tmp_dir }}\output_tar'
+  register: unzip_tar_check
+  check_mode: yes
+
+- name: get result of unarchive tar.gz (check)
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}\output_tar\hello.txt'
+  register: unzip_tar_actual_check
+
+- name: assert result of unarchive tar.gz (check)
+  assert:
+    that:
+    - unzip_tar_check is changed
+    - not unzip_tar_check.removed
+    - not unzip_tar_actual_check.stat.exists
+
+- name: unarchive tar.gz
+  win_unzip:
+    src: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+    dest: '{{ remote_tmp_dir }}\output_tar'
+  register: unzip_tar
+
+- name: get result of unarchive tar.gz
+  ansible.windows.slurp:
+    path: '{{ remote_tmp_dir }}\output_tar\hello.txt'
+  register: unzip_tar_actual
+
+- name: assert result of unarchive tar.gz
+  assert:
+    that:
+    - unzip_tar is changed
+    - not unzip_tar.removed
+    - unzip_tar_actual.content | b64decode == 'hello from tar'
+
+- name: unarchive tar.gz with delete (check)
+  win_unzip:
+    src: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+    dest: '{{ remote_tmp_dir }}\output_tar'
+    delete_archive: yes
+  register: unzip_tar_delete_check
+  check_mode: yes
+
+- name: get result of unarchive tar.gz with delete (check)
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+  register: unzip_tar_delete_actual_check
+
+- name: assert unarchive tar.gz with delete (check)
+  assert:
+    that:
+    - unzip_tar_delete_check is changed
+    - unzip_tar_delete_check.removed
+    - unzip_tar_delete_actual_check.stat.exists
+
+- name: unarchive tar.gz with delete
+  win_unzip:
+    src: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+    dest: '{{ remote_tmp_dir }}\output_tar'
+    delete_archive: yes
+  register: unzip_tar_delete
+
+- name: get result of unarchive tar.gz with delete
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}\win_unzip.tar.gz'
+  register: unzip_tar_delete_actual
+
+- name: assert unarchive tar.gz with delete
+  assert:
+    that:
+    - unzip_tar_delete is changed
+    - unzip_tar_delete.removed
+    - not unzip_tar_delete_actual.stat.exists


### PR DESCRIPTION
Hoping to avoid the PSCX dependency for Server 2019+ where native tar.exe extraction meets our needs. These changes are LLM-generated. I have reviewed and guided them, but lack much experience with Ansible.  

- Uses `%SystemRoot%\System32\tar.exe` (ships with Windows 10 build 17063+ and Server 2019+) to extract tar-based archives (`.tar`,`.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`) without requiring PSCX. 
- Falls back to PSCX on older systems where `tar.exe` is not present. 
- Fixes a pre-existing bug where `Expand-Archive -Path` wildcard-expanded paths containing square brackets and other special characters; changed to `-LiteralPath` in both call sites.  

Integration tests extended with 

- tar.gz check mode, extraction (content verified), delete-in-check-mode, and delete-actual 
- PSCX regression test, skipped when PSCX is not installed

Tested locally against Windows Server 2019 with & without PSCX installed. The tar tests run independently of PSCX.

Changelog  `changelogs/fragments/win_unzip-tar-exe.yml` included.