### PR TITLE
CI fixes for pwsh 7 - ci_complete

### DIFF
--- a/tests/integration/targets/win_nssm/tasks/main.yml
+++ b/tests/integration/targets/win_nssm/tasks/main.yml
@@ -3,6 +3,8 @@
   chocolatey.chocolatey.win_chocolatey:
     name: NSSM
     state: present
+  vars:
+    ansible_pwsh_interpreter: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
 
 - name: restart sshd after env var was updated by chocolatey
   win_service:
@@ -61,4 +63,6 @@
       chocolatey.chocolatey.win_chocolatey:
         name: NSSM
         state: absent
+      vars:
+        ansible_pwsh_interpreter: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
       failed_when: false

--- a/tests/integration/targets/win_rabbitmq_plugin/tasks/tests.yml
+++ b/tests/integration/targets/win_rabbitmq_plugin/tasks/tests.yml
@@ -2,6 +2,8 @@
   chocolatey.chocolatey.win_chocolatey:
     name: rabbitmq
     state: present
+  vars:
+    ansible_pwsh_interpreter: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
 
 - name: Ensure that rabbitmq_management plugin disabled
   win_rabbitmq_plugin:


### PR DESCRIPTION
##### SUMMARY
The `win_chocolatey` module isn't compatible with PowerShell 7 just yet so have it fallback to WinPS during testing.