### PR TITLE
Migrate from deprecated text module_utils import

### DIFF
--- a/changelogs/fragments/text-coverters.yml
+++ b/changelogs/fragments/text-coverters.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    laps_password - Migrate away from deprecated ``to_text`` methods to the new public API.
+  - >-
+    psexec - Migrate away from deprecated ``to_text`` methods to the new public API.

--- a/plugins/lookup/laps_password.py
+++ b/plugins/lookup/laps_password.py
@@ -194,7 +194,7 @@ import os
 import traceback
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import missing_required_lib
 from ansible.plugins.lookup import LookupBase
 

--- a/plugins/modules/psexec.py
+++ b/plugins/modules/psexec.py
@@ -320,7 +320,7 @@ rc:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 PYPSEXEC_IMP_ERR = None
 try:
@@ -436,7 +436,7 @@ def main():
     if (connection_username is None or connection_password is None) and \
             not HAS_KERBEROS:
         module.fail_json(msg=missing_required_lib("gssapi"),
-                         execption=KERBEROS_IMP_ERR)
+                         exception=KERBEROS_IMP_ERR)
 
     win_client = client.Client(server=hostname, username=connection_username,
                                password=connection_password, port=port,


### PR DESCRIPTION
##### SUMMARY
Use the public API and not the deprecated old import for the `to_text` methods.

##### ISSUE TYPE
- Bugfix Pull Request