### PR TITLE
fix: win_scheduled_task - Error creating task when ansible user is SYSTEM

### DIFF
--- a/changelogs/fragments/scheduled_task-system.yml
+++ b/changelogs/fragments/scheduled_task-system.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_scheduled_task - Fix issue when creating a new scheduled task when using ``become_user: SYSTEM`` -
+    https://github.com/ansible-collections/community.windows/issues/633

--- a/plugins/modules/win_scheduled_task.ps1
+++ b/plugins/modules/win_scheduled_task.ps1
@@ -1103,8 +1103,12 @@ else {
             }
         }
 
+        $tmp_user = $username
+        if ($null -eq $tmp_user) {
+            $tmp_user = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+        }
         try {
-            $task = $task_folder.RegisterTaskDefinition($name, $task_definition, $task_creation_flags, $null, $null, $null)
+            $task = $task_folder.RegisterTaskDefinition($name, $task_definition, $task_creation_flags, $tmp_user, $null, $null)
         }
         catch {
             Fail-Json -obj $result -message "failed to register new task definition: $($_.Exception.Message)"

--- a/tests/integration/targets/win_scheduled_task/tasks/principals.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/principals.yml
@@ -43,6 +43,9 @@
     actions:
     - path: cmd.exe
   register: task_with_password
+  become: true
+  become_user: SYSTEM
+  become_method: runas
 
 - name: get result of task with password principal
   win_scheduled_task_stat:

--- a/tests/integration/targets/win_scheduled_task/tasks/principals.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/principals.yml
@@ -43,9 +43,6 @@
     actions:
     - path: cmd.exe
   register: task_with_password
-  become: true
-  become_user: SYSTEM
-  become_method: runas
 
 - name: get result of task with password principal
   win_scheduled_task_stat:

--- a/tests/integration/targets/win_scheduled_task/tasks/tests.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/tests.yml
@@ -439,12 +439,14 @@
     that:
     - remove_sole_task_again is not changed
 
-- name: with SYSTEM user
+# Task Scheduler seems to have some special requirements when running as SYSTEM
+# https://github.com/ansible-collections/community.windows/issues/633
+- name: with SYSTEM user tests
   become: true
   become_user: SYSTEM
   become_method: runas
   block:
-  - name: create task
+  - name: create task as SYSTEM user
     win_scheduled_task:
       name: "{{test_scheduled_task_name}} with system user"
       path: "{{test_scheduled_task_path}}"
@@ -455,13 +457,13 @@
       description: Original Description
     register: create_task
 
-  - name: get result of create task 
+  - name: get result of create task as SYSTEM user
     win_scheduled_task_stat:
       path: "{{test_scheduled_task_path}}"
       name: "{{test_scheduled_task_name}} with system user"
     register: create_task_result
 
-  - name: Remove task
+  - name: Remove task as SYSTEM user
     win_scheduled_task:
       name: "{{test_scheduled_task_name}} with system user"
       path: "{{test_scheduled_task_path}}"

--- a/tests/integration/targets/win_scheduled_task/tasks/tests.yml
+++ b/tests/integration/targets/win_scheduled_task/tasks/tests.yml
@@ -438,3 +438,31 @@
   assert:
     that:
     - remove_sole_task_again is not changed
+
+- name: with SYSTEM user
+  become: true
+  become_user: SYSTEM
+  become_method: runas
+  block:
+  - name: create task
+    win_scheduled_task:
+      name: "{{test_scheduled_task_name}} with system user"
+      path: "{{test_scheduled_task_path}}"
+      state: present
+      actions:
+      - path: cmd.exe
+        arguments: /c echo hi
+      description: Original Description
+    register: create_task
+
+  - name: get result of create task 
+    win_scheduled_task_stat:
+      path: "{{test_scheduled_task_path}}"
+      name: "{{test_scheduled_task_name}} with system user"
+    register: create_task_result
+
+  - name: Remove task
+    win_scheduled_task:
+      name: "{{test_scheduled_task_name}} with system user"
+      path: "{{test_scheduled_task_path}}"
+      state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The TaskFolder::RegisterTaskDefinition method returns error when called by the SYSTEM account with the user parameter equal to NULL, this PR fixes it by setting the user parameter to the username supplied or otherwise if empty to the current username.

- win_scheduled_task - Error creating scheduled tasks with SYSTEM account. Fixed by setting the user parameter to the username supplied or otherwise if empty to the current username. (https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/taskschd/nf-taskschd-itaskfolder-registertaskdefinition.md)

This fixes #633 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

win_scheduled_taksk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [win_scheduled_task : task with password principal] ***********************
[ERROR]: Task failed: Module failed: failed to register new task definition: (31,4):UserId:
Origin: /home/stanley/.ansible/collections/ansible_collections/community/windows/tests/output/.tmp/integration/win_scheduled_task-iokru30h-ÅÑŚÌβŁÈ/tests/integration/targets/win_scheduled_task/tasks/principals.yml:35:3

33     - task_with_password_result_check.task_exists == False
34
35 - name: task with password principal
     ^ column 3

fatal: [WindowsServer]: FAILED! => {"changed": false, "msg": "failed to register new task definition: (31,4):UserId:"}

```
After
```
TASK [win_scheduled_task : task with password principal] ***********************
changed: [WindowsServer]                                                               

TASK [win_scheduled_task : get result of task with password principal] *********
ok: [WindowsServer]
                                                                                                           
TASK [win_scheduled_task : assert results of task with password principal] *****
ok: [WindowsServer] => {             
    "changed": false,                                     
    "msg": "All assertions passed"
}
```

Reference doc:

https://github.com/MicrosoftDocs/sdk-api/blob/docs/sdk-api-src/content/taskschd/nf-taskschd-itaskfolder-registertaskdefinition.md
https://learn.microsoft.com/en-us/windows/win32/api/taskschd/nf-taskschd-itaskfolder-registertaskdefinition
