### PR TITLE
Improve performance of win_psmodule and win_psmodule_info modules

### DIFF
--- a/changelogs/fragments/win_psmodule_info_include_properties.yml
+++ b/changelogs/fragments/win_psmodule_info_include_properties.yml
@@ -1,21 +1,21 @@
 ---
 minor_changes:
   - >-
-    community.windows.win_psmodule_info - 
-    Added ``include_properties`` parameter to allow fine-grained control over which module properties are returned, 
-    improving performance when only specific properties are needed 
+    community.windows.win_psmodule_info -
+    Added ``include_properties`` parameter to allow fine-grained control over which module properties are returned,
+    improving performance when only specific properties are needed
     (https://github.com/ansible-collections/community.windows/pull/688).
   - >-
-    community.windows.win_psmodule_info - 
-    Added ``skip_module_repository_info`` parameter to skips querying PowerShellGet for repository-related metadata 
+    community.windows.win_psmodule_info -
+    Added ``skip_module_repository_info`` parameter to skips querying PowerShellGet for repository-related metadata
     (https://github.com/ansible-collections/community.windows/pull/688).
   - >-
-    community.windows.win_psmodule_info - 
-    Automatically skips expensive PowerShellGet repository lookups when ``include_properties`` is specified without repository-related properties 
+    community.windows.win_psmodule_info -
+    Automatically skips expensive PowerShellGet repository lookups when ``include_properties`` is specified without repository-related properties
     (https://github.com/ansible-collections/community.windows/pull/688).
 
 bugfixes:
   - >-
-    community.windows.win_psmodule_info - 
-    Fixed typo in documentation changing ``procoessor_architecture`` to ``processor_architecture`` 
+    community.windows.win_psmodule_info -
+    Fixed typo in documentation changing ``procoessor_architecture`` to ``processor_architecture``
     (https://github.com/ansible-collections/community.windows/pull/688).

--- a/changelogs/fragments/win_psmodule_info_include_properties.yml
+++ b/changelogs/fragments/win_psmodule_info_include_properties.yml
@@ -1,8 +1,21 @@
 ---
 minor_changes:
-  - flatiron.windows.win_psmodule_info - Added ``include_properties`` parameter to allow fine-grained control over which module properties are returned, improving performance when only specific properties are needed (https://github.com/ansible-collections/community.windows/pull/688).
-  - flatiron.windows.win_psmodule_info - Added ``skip_module_repository_info`` parameter to skips querying PowerShellGet for repository-related metadata (https://github.com/ansible-collections/community.windows/pull/688).
-  - flatiron.windows.win_psmodule_info - Automatically skips expensive PowerShellGet repository lookups when ``include_properties`` is specified without repository-related properties (https://github.com/ansible-collections/community.windows/pull/688).
+  - >-
+    community.windows.win_psmodule_info - 
+    Added ``include_properties`` parameter to allow fine-grained control over which module properties are returned, 
+    improving performance when only specific properties are needed 
+    (https://github.com/ansible-collections/community.windows/pull/688).
+  - >-
+    community.windows.win_psmodule_info - 
+    Added ``skip_module_repository_info`` parameter to skips querying PowerShellGet for repository-related metadata 
+    (https://github.com/ansible-collections/community.windows/pull/688).
+  - >-
+    community.windows.win_psmodule_info - 
+    Automatically skips expensive PowerShellGet repository lookups when ``include_properties`` is specified without repository-related properties 
+    (https://github.com/ansible-collections/community.windows/pull/688).
 
 bugfixes:
-  - flatiron.windows.win_psmodule_info - Fixed typo in documentation changing ``procoessor_architecture`` to ``processor_architecture`` (https://github.com/ansible-collections/community.windows/pull/688).
+  - >-
+    community.windows.win_psmodule_info - 
+    Fixed typo in documentation changing ``procoessor_architecture`` to ``processor_architecture`` 
+    (https://github.com/ansible-collections/community.windows/pull/688).

--- a/changelogs/fragments/win_psmodule_info_include_properties.yml
+++ b/changelogs/fragments/win_psmodule_info_include_properties.yml
@@ -1,8 +1,8 @@
 ---
 minor_changes:
-  - flatiron.windows.win_psmodule_info - Added C(include_properties) parameter to allow fine-grained control over which module properties are returned, improving performance when only specific properties are needed.
-  - flatiron.windows.win_psmodule_info - Added C(skip_module_repository_info) parameter to skips querying PowerShellGet for repository-related metadata.
-  - flatiron.windows.win_psmodule_info - Automatically skips expensive PowerShellGet repository lookups when C(include_properties) is specified without repository-related properties.
+  - flatiron.windows.win_psmodule_info - Added ``include_properties`` parameter to allow fine-grained control over which module properties are returned, improving performance when only specific properties are needed (https://github.com/ansible-collections/community.windows/pull/688).
+  - flatiron.windows.win_psmodule_info - Added ``skip_module_repository_info`` parameter to skips querying PowerShellGet for repository-related metadata (https://github.com/ansible-collections/community.windows/pull/688).
+  - flatiron.windows.win_psmodule_info - Automatically skips expensive PowerShellGet repository lookups when ``include_properties`` is specified without repository-related properties (https://github.com/ansible-collections/community.windows/pull/688).
 
 bugfixes:
-  - flatiron.windows.win_psmodule_info - Fixed typo in documentation changing C(procoessor_architecture) to C(processor_architecture) (MR-URL).
+  - flatiron.windows.win_psmodule_info - Fixed typo in documentation changing ``procoessor_architecture`` to ``processor_architecture`` (https://github.com/ansible-collections/community.windows/pull/688).

--- a/changelogs/fragments/win_psmodule_info_include_properties.yml
+++ b/changelogs/fragments/win_psmodule_info_include_properties.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - flatiron.windows.win_psmodule_info - Added C(include_properties) parameter to allow fine-grained control over which module properties are returned, improving performance when only specific properties are needed.
+  - flatiron.windows.win_psmodule_info - Added C(skip_module_repository_info) parameter to skips querying PowerShellGet for repository-related metadata.
+  - flatiron.windows.win_psmodule_info - Automatically skips expensive PowerShellGet repository lookups when C(include_properties) is specified without repository-related properties.
+
+bugfixes:
+  - flatiron.windows.win_psmodule_info - Fixed typo in documentation changing C(procoessor_architecture) to C(processor_architecture) (MR-URL).

--- a/changelogs/fragments/win_psmodule_perf.yml
+++ b/changelogs/fragments/win_psmodule_perf.yml
@@ -1,3 +1,7 @@
 ---
-minor_changes:
-  - flatiron.windows.win_psmodule - Now retrieves module installation status of requested module instead of all modules, which was expensive for hosts with many modules installed (https://github.com/ansible-collections/community.windows/pull/688).
+bugfixes:
+  - >-
+    community.windows.win_psmodule - 
+    Now retrieves module installation status of requested module instead of all modules, 
+    which was expensive for hosts with many modules installed 
+    (https://github.com/ansible-collections/community.windows/pull/688).

--- a/changelogs/fragments/win_psmodule_perf.yml
+++ b/changelogs/fragments/win_psmodule_perf.yml
@@ -1,7 +1,7 @@
 ---
 bugfixes:
   - >-
-    community.windows.win_psmodule - 
-    Now retrieves module installation status of requested module instead of all modules, 
-    which was expensive for hosts with many modules installed 
+    community.windows.win_psmodule -
+    Now retrieves module installation status of requested module instead of all modules,
+    which was expensive for hosts with many modules installed
     (https://github.com/ansible-collections/community.windows/pull/688).

--- a/changelogs/fragments/win_psmodule_perf.yml
+++ b/changelogs/fragments/win_psmodule_perf.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - flatiron.windows.win_psmodule - Now retrieves module installation status of requested module instead of all modules, which was expensive for hosts with many modules installed.
+  - flatiron.windows.win_psmodule - Now retrieves module installation status of requested module instead of all modules, which was expensive for hosts with many modules installed (https://github.com/ansible-collections/community.windows/pull/688).

--- a/changelogs/fragments/win_psmodule_perf.yml
+++ b/changelogs/fragments/win_psmodule_perf.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - flatiron.windows.win_psmodule - Now retrieves module installation status of requested module instead of all modules, which was expensive for hosts with many modules installed.

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -147,7 +147,8 @@ Function Get-PsModule {
         Version = ""
     }
 
-    $ExistingModules = Get-Module -ListAvailable -Name $Name
+    # Use Where-Object with '-eq' to handle wildcard names
+    $ExistingModules = Get-Module -ListAvailable -Name $Name | Where-Object { $_.name -eq $Name }
     $ExistingModulesCount = $($ExistingModules | Measure-Object).Count
 
     if ( $ExistingModulesCount -gt 0 ) {
@@ -293,7 +294,8 @@ Function Remove-PsModule {
         [Bool]$CheckMode
     )
     # If module is present, uninstalls it.
-    if (Get-Module -ListAvailable -Name $Name) {
+    # Use Where-Object with '-eq' to handle wildcard names
+    if (Get-Module -ListAvailable -Name $Name | Where-Object { $_.name -eq $Name }) {
         try {
             $ht = @{
                 Name = $Name

--- a/plugins/modules/win_psmodule.ps1
+++ b/plugins/modules/win_psmodule.ps1
@@ -147,7 +147,7 @@ Function Get-PsModule {
         Version = ""
     }
 
-    $ExistingModules = Get-Module -ListAvailable | Where-Object { ($_.name -eq $Name) }
+    $ExistingModules = Get-Module -ListAvailable -Name $Name
     $ExistingModulesCount = $($ExistingModules | Measure-Object).Count
 
     if ( $ExistingModulesCount -gt 0 ) {
@@ -293,7 +293,7 @@ Function Remove-PsModule {
         [Bool]$CheckMode
     )
     # If module is present, uninstalls it.
-    if (Get-Module -ListAvailable | Where-Object { $_.name -eq $Name }) {
+    if (Get-Module -ListAvailable -Name $Name) {
         try {
             $ht = @{
                 Name = $Name

--- a/plugins/modules/win_psmodule_info.ps1
+++ b/plugins/modules/win_psmodule_info.ps1
@@ -36,7 +36,7 @@ $RepositoryManagedProperties = @(
     'IconUri'
     'ReleaseNotes'
     'ExportedDscResources' # ExportedDscResources is not returned here, this is a hack for Windows 2012/R2 to ensure the field is present
-    'Prefix'                # Prefix is not actually returned here, this is a hack for Windows 2012 just to ensure the field is present
+    'Prefix'               # Prefix is not actually returned here, this is a hack for Windows 2012 just to ensure the field is present
 )
 
 # We need to remove this type data so that arrays don't get serialized weirdly.

--- a/plugins/modules/win_psmodule_info.ps1
+++ b/plugins/modules/win_psmodule_info.ps1
@@ -21,22 +21,22 @@ $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 # Define the list of properties that are managed by PowerShellGet repository lookups
 # This is used both by Add-ModuleRepositoryInfo and for optimization checks
 $RepositoryManagedProperties = @(
-    'PublishedDate',
-    'InstalledDate',
-    'UpdatedDate',
-    'Dependencies',
-    'Repository',
-    'PackageManagementProvider',
-    'InstalledLocation',
-    'RepositorySourceLocation',
-    'Tags',
-    'CompatiblePSEditions',
-    'LicenseUri',
-    'ProjectUri',
-    'IconUri',
-    'ReleaseNotes',
-    'ExportedDscResources',
-    'Prefix'
+    'PublishedDate'
+    'InstalledDate'
+    'UpdatedDate'
+    'Dependencies'
+    'Repository'
+    'PackageManagementProvider'
+    'InstalledLocation'
+    'RepositorySourceLocation'
+    'Tags'
+    'CompatiblePSEditions'
+    'LicenseUri'
+    'ProjectUri'
+    'IconUri'
+    'ReleaseNotes'
+    'ExportedDscResources' # ExportedDscResources is not returned here, this is a hack for Windows 2012/R2 to ensure the field is present
+    'Prefix'                # Prefix is not actually returned here, this is a hack for Windows 2012 just to ensure the field is present
 )
 
 # We need to remove this type data so that arrays don't get serialized weirdly.

--- a/plugins/modules/win_psmodule_info.ps1
+++ b/plugins/modules/win_psmodule_info.ps1
@@ -11,10 +11,33 @@ $spec = @{
     options = @{
         name = @{ type = 'str' ; default = '*' }
         repository = @{ type = 'str' }
+        include_properties = @{ type = 'list' ; elements = 'str' }
+        skip_module_repository_info = @{ type = 'bool' ; default = $false }
     }
     supports_check_mode = $true
 }
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+# Define the list of properties that are managed by PowerShellGet repository lookups
+# This is used both by Add-ModuleRepositoryInfo and for optimization checks
+$RepositoryManagedProperties = @(
+    'PublishedDate',
+    'InstalledDate',
+    'UpdatedDate',
+    'Dependencies',
+    'Repository',
+    'PackageManagementProvider',
+    'InstalledLocation',
+    'RepositorySourceLocation',
+    'Tags',
+    'CompatiblePSEditions',
+    'LicenseUri',
+    'ProjectUri',
+    'IconUri',
+    'ReleaseNotes',
+    'ExportedDscResources',
+    'Prefix'
+)
 
 # We need to remove this type data so that arrays don't get serialized weirdly.
 # In some cases, an array gets serialized as an object with a Count and Value property where the value is the actual array.
@@ -214,6 +237,39 @@ function ConvertTo-SerializableModuleInfo {
     }
 }
 
+function Select-ModuleProperties {
+    <#
+        .SYNOPSIS
+        Filters a module dictionary to include only specified properties.
+
+        .DESCRIPTION
+        Takes a module information dictionary (already converted to snake_case) and returns
+        only the properties specified in the PropertyList parameter.
+
+        Properties that don't exist in the module dictionary are silently skipped.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Collections.Specialized.OrderedDictionary]
+        $InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]
+        $PropertyList
+    )
+
+    Process {
+        $result = [Ordered]@{}
+        foreach ($prop in $PropertyList) {
+            if ($InputObject.Contains($prop)) {
+                $result[$prop] = $InputObject[$prop]
+            }
+        }
+        $result
+    }
+}
+
 function Add-ModuleRepositoryInfo {
     <#
         .SYNOPSIS
@@ -236,24 +292,8 @@ function Add-ModuleRepositoryInfo {
     )
 
     Begin {
-        $wantedProperties = @(
-            'PublishedDate',
-            'InstalledDate',
-            'UpdatedDate',
-            'Dependencies',
-            'Repository',
-            'PackageManagementProvider',
-            'InstalledLocation',
-            'RepositorySourceLocation',
-            'Tags',
-            'CompatiblePSEditions',
-            'LicenseUri',
-            'ProjectUri',
-            'IconUri',
-            'ReleaseNotes',
-            'ExportedDscResources', # ExportedDscResources is not returned here, this is a hack for Windows 2012/R2 to ensure the field is present
-            'Prefix'                # Prefix is not actually returned here, this is a hack for Windows 2012 just to ensure the field is present
-        )
+        # Use the variable defined at the script level
+        $wantedProperties = $RepositoryManagedProperties
 
         # Get all the installed modules at once. This prevents us from having to make an expensive individual call for every
         # local module, the vast majority of which didn't come from PowerShellGet.
@@ -297,11 +337,48 @@ function Add-ModuleRepositoryInfo {
     }
 }
 
+$modules = Get-Module -ListAvailable -Name $module.Params.name
+
+# Optimization: Skip expensive PowerShellGet lookups if include_properties is specified
+# and doesn't contain any repository-related properties (converted to snake_case)
+$skipRepositoryLookup = $false
+if ($module.Params.include_properties) {
+    $repositoryPropertiesSnakeCase = $RepositoryManagedProperties | ForEach-Object {
+        Convert-StringToSnakeCase -string $_
+    }
+
+    # Check if any requested property requires repository info
+    $hasRepositoryProperty = $false
+    foreach ($prop in $module.Params.include_properties) {
+        if ($repositoryPropertiesSnakeCase -contains $prop) {
+            $hasRepositoryProperty = $true
+            break
+        }
+    }
+
+    # Only skip if no repository properties were requested
+    if (-not $hasRepositoryProperty) {
+        $skipRepositoryLookup = $true
+    }
+}
+
+if (-not $module.Params.skip_module_repository_info -and -not $skipRepositoryLookup) {
+    $modules = $modules | Add-ModuleRepositoryInfo -RepositoryName $module.Params.repository
+}
+
 $module.Result.modules = @(
-    Get-Module -ListAvailable -Name $module.Params.name |
-        Add-ModuleRepositoryInfo -RepositoryName $module.Params.repository |
+    $modules |
         ConvertTo-SerializableModuleInfo |
-        Convert-ObjectToSnakeCase -NoRecurse
+        Convert-ObjectToSnakeCase -NoRecurse |
+        ForEach-Object {
+            if ($module.Params.include_properties) {
+                Select-ModuleProperties -InputObject $_ -PropertyList $module.Params.include_properties
+            }
+            else {
+                # Default: return all properties
+                $_
+            }
+        }
 )
 
 $module.ExitJson()

--- a/plugins/modules/win_psmodule_info.ps1
+++ b/plugins/modules/win_psmodule_info.ps1
@@ -237,7 +237,7 @@ function ConvertTo-SerializableModuleInfo {
     }
 }
 
-function Select-ModuleProperties {
+function Select-ModuleProperty {
     <#
         .SYNOPSIS
         Filters a module dictionary to include only specified properties.
@@ -372,7 +372,7 @@ $module.Result.modules = @(
         Convert-ObjectToSnakeCase -NoRecurse |
         ForEach-Object {
             if ($module.Params.include_properties) {
-                Select-ModuleProperties -InputObject $_ -PropertyList $module.Params.include_properties
+                Select-ModuleProperty -InputObject $_ -PropertyList $module.Params.include_properties
             }
             else {
                 # Default: return all properties

--- a/plugins/modules/win_psmodule_info.py
+++ b/plugins/modules/win_psmodule_info.py
@@ -26,6 +26,25 @@ options:
       - Only modules installed from a registered repository will be returned.
       - If the repository was re-registered after module installation with a new C(SourceLocation), this will not match.
     type: str
+  include_properties:
+    description:
+      - List of property names to include in the output.
+      - Property names should be in snake_case format (e.g., C(module_base), C(exported_functions)).
+      - If omitted, all available properties are returned.
+      - When specified, only the requested properties will be included in the output.
+      - To get minimal output similar to the old C(simplified=true), use C([name, version, author, module_base]).
+      - See the RETURN section for a complete list of available properties.
+      - Repository-related properties (repository, repository_source_location, installed_date, published_date, etc.) require PowerShellGet lookups and may be slower.
+    type: list
+    elements: str
+  skip_module_repository_info:
+    description:
+      - When C(true), skips querying PowerShellGet for repository-related metadata.
+      - This significantly improves performance but repository properties will be C(null).
+      - Repository properties include C(repository), C(repository_source_location), C(installed_date), C(published_date), C(updated_date), C(package_management_provider), C(installed_location), C(tags), C(compatible_ps_editions), C(license_uri), C(project_uri), C(icon_uri), C(release_notes), and C(dependencies).
+      - When C(include_properties) is specified without any repository properties, this is automatically set to C(true) for optimization.
+    type: bool
+    default: false
 requirements:
   - C(PowerShellGet) module
 seealso:
@@ -46,6 +65,20 @@ EXAMPLES = r'''
 - name: Get info about networking modules
   community.windows.win_psmodule_info:
     name: Net*
+
+- name: Get minimal info about all modules (name, version, author, module_base only)
+  community.windows.win_psmodule_info:
+    include_properties:
+      - name
+      - version
+      - author
+      - module_base
+  register: simple_modules
+
+- name: Get all module info but skip expensive repository lookups for better performance
+  community.windows.win_psmodule_info:
+    skip_module_repository_info: true
+  register: modules_fast
 
 - name: Get info about all modules installed from the PSGallery repository
   community.windows.win_psmodule_info:
@@ -78,6 +111,8 @@ RETURN = r'''
 modules:
   description:
     - A list of modules (or an empty list is there are none).
+    - When I(include_properties) is specified, only contains the requested properties.
+    - When I(include_properties) is not specified (default), contains all available module properties listed below.
   returned: always
   type: list
   elements: dict
@@ -194,7 +229,7 @@ modules:
         - The module's type. See U(https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.moduletype)
       type: str
       sample: Script
-    procoessor_architecture:
+    processor_architecture:
       description:
         - The module's processor architecture. See U(https://docs.microsoft.com/en-us/dotnet/api/system.reflection.processorarchitecture)
       type: str

--- a/plugins/modules/win_psmodule_info.py
+++ b/plugins/modules/win_psmodule_info.py
@@ -34,14 +34,17 @@ options:
       - When specified, only the requested properties will be included in the output.
       - To get minimal output similar to the old C(simplified=true), use C([name, version, author, module_base]).
       - See the RETURN section for a complete list of available properties.
-      - Repository-related properties (repository, repository_source_location, installed_date, published_date, etc.) require PowerShellGet lookups and may be slower.
+      - Repository-related properties (repository, repository_source_location, installed_date, published_date, etc.)
+        require PowerShellGet lookups and may be slower.
     type: list
     elements: str
   skip_module_repository_info:
     description:
       - When C(true), skips querying PowerShellGet for repository-related metadata.
       - This significantly improves performance but repository properties will be C(null).
-      - Repository properties include C(repository), C(repository_source_location), C(installed_date), C(published_date), C(updated_date), C(package_management_provider), C(installed_location), C(tags), C(compatible_ps_editions), C(license_uri), C(project_uri), C(icon_uri), C(release_notes), and C(dependencies).
+      - Repository properties include C(repository), C(repository_source_location), C(installed_date), C(published_date),
+        C(updated_date), C(package_management_provider), C(installed_location), C(tags), C(compatible_ps_editions),
+        C(license_uri), C(project_uri), C(icon_uri), C(release_notes), and C(dependencies).
       - When C(include_properties) is specified without any repository properties, this is automatically set to C(true) for optimization.
     type: bool
     default: false

--- a/tests/integration/targets/win_psmodule_info/defaults/main.yml
+++ b/tests/integration/targets/win_psmodule_info/defaults/main.yml
@@ -16,8 +16,8 @@ builtin_modules:
 
 sample_modules: "{{ builtin_modules + modules_to_install }}"
 
-expected_fields:
-  - prefix
+# Fields returned by Get-Module 
+base_expected_fields:
   - private_data
   - scripts
   - author
@@ -26,33 +26,21 @@ expected_fields:
   # Not present in Pwsh 7+
   # - exported_workflows
   - nested_modules
-  - exported_dsc_resources
-  - updated_date
   - root_module
   - power_shell_host_name
   - module_base
   - path
   - exported_format_files
-  - dependencies
-  - release_notes
-  - installed_date
   - exported_variables
-  - published_date
   - required_assemblies
   - version
-  - icon_uri
-  - project_uri
   - dot_net_framework_version
   - processor_architecture
-  - license_uri
   - required_modules
   - module_type
-  - compatible_ps_editions
   - company_name
   - copyright
-  - tags
   - access_mode
-  - package_management_provider
   - exported_aliases
   - power_shell_host_version
   - clr_version
@@ -65,7 +53,25 @@ expected_fields:
   - repository_source_location
   - exported_cmdlets
   - exported_commands
-  - repository
-  - installed_location
   - name
   - log_pipeline_execution_details
+
+# Fields populated by Get-InstalledModule 
+repository_expected_fields:
+  - updated_date
+  - dependencies
+  - installed_date
+  - published_date
+  - package_management_provider
+  - repository
+  - installed_location
+  - tags
+  - compatible_ps_editions
+  - license_uri
+  - icon_uri
+  - project_uri
+  - release_notes
+  - exported_dsc_resources
+  - prefix
+
+expected_fields: "{{ base_expected_fields + repository_expected_fields }}"

--- a/tests/integration/targets/win_psmodule_info/tasks/tests.yml
+++ b/tests/integration/targets/win_psmodule_info/tasks/tests.yml
@@ -83,3 +83,38 @@
 
   # block
   check_mode: "{{ run_check_mode }}"
+
+- name: Get specific info on a named module
+  vars:
+    expected_modules:
+      - "{{ builtin_modules[0] }}"
+    expected_fields:
+      - name
+      - version
+  block:
+    - name: Get single module {{ suffix }}
+      community.windows.win_psmodule_info:
+        name: "{{ expected_modules[0] }}"
+        include_properties: "{{ expected_fields }}"
+      register: module_info
+
+    - include_tasks: common.yml
+
+  # block
+  check_mode: "{{ run_check_mode }}"
+
+- name: Get info on a named module without module repository info
+  vars:
+    expected_modules:
+      - "{{ builtin_modules[0] }}"
+  block:
+    - name: Get single module {{ suffix }}
+      community.windows.win_psmodule_info:
+        name: "{{ expected_modules[0] }}"
+        skip_module_repository_info: true
+      register: module_info
+
+    - include_tasks: common.yml
+
+  # block
+  check_mode: "{{ run_check_mode }}"

--- a/tests/integration/targets/win_psmodule_info/tasks/tests.yml
+++ b/tests/integration/targets/win_psmodule_info/tasks/tests.yml
@@ -107,6 +107,7 @@
   vars:
     expected_modules:
       - "{{ builtin_modules[0] }}"
+    expected_fields: "{{ base_expected_fields }}"
   block:
     - name: Get single module {{ suffix }}
       community.windows.win_psmodule_info:


### PR DESCRIPTION
**SUMMARY**
- Add `skip_module_repository_info` and `include_properties` support to win_psmodule_info for faster, more customizable module metadata retrieval.
- Optimize `win_psmodule` by querying `Get-Module -ListAvailable -Name $Name` instead of enumerating all modules, reducing overhead on systems with many installed modules.


**COMPONENT NAME**
`win_psmodule_info`
`win_psmodule`

**ADDITIONAL INFORMATION**

Fixes https://github.com/ansible-collections/community.windows/issues/649

For remote Windows hosts that have many PS modules installed (like `AWS.Tools` ), `win_psmodule` would take ~20 seconds to  evaluate all of the modules on the host when we only needed to retrieve the one being installed.

```
# Current module (~23 seconds
[2026-06-12 15:09:05] TASK [collection.example.rdp : Install Powershell Module - xRemoteDesktopAdmin] ***
[2026-06-12 15:09:28] ok: [windows-server-2022-full-base]

# New module (~4 seconds)
[2026-06-12 15:03:07] TASK [collection.example.rdp : Install Powershell Module - xRemoteDesktopAdmin] ***
[2026-06-12 15:03:11] ok: [windows-server-2022-full-base]
```

Additionally, for Windows hosts with many PS module installed, the `win_psmodule_info` would return way too much data, especially when modules like AWS.Tools have hundreds of exported modules and aliases. Sending this data over WinRM was expensive when a user may only be interested in a few properties. This is even more important when running Ansible with `ansible-runner` which will json-ify the entire output of the task and fill the terminal/log with lots of unnecessary data.